### PR TITLE
Fix/ios pairing compatibility

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,10 +62,12 @@ orchestrates lifecycle, while `event_dispatcher` owns persistence/notification
 fan-out. `ProfileSupervisor` owns MAP/PBAP open, close, retry, loss, and resume
 transitions; its worker, session, and timer protocols make those races testable
 without BlueZ. Interactive pairing rendering lives separately from the BlueZ
-pairing service, and CLI message commands use the same backend client as
-graphical UIs. Group replies use `SendToThread`, so routing always comes from
-the backend's current conversation projection rather than client-supplied
-recipients.
+pairing service. An interactive client owns a device-scoped agent, promotes it
+over any desktop default for the complete pairing and Classic-to-LE handoff,
+then unregisters it before persistence and daemon startup. CLI message commands
+use the same backend client as graphical UIs. Group replies use `SendToThread`,
+so routing always comes from the backend's current conversation projection
+rather than client-supplied recipients.
 
 ## Lifecycle
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -83,6 +83,36 @@ independent, and three behaviors were observed on iOS 26.5:
   either record. Users must check both entries.
 - Closing and reopening the entry's detail page refreshes iOS's view.
 
+An iOS 18 test did not follow the same post-pair behavior: an outbound LE
+connection hung and ended in `le-connection-abort-by-local`, while MAP/PBAP
+worked when attempted first. BlueZ still reported its LE bearer as paired and
+bonded, so those properties cannot predict whether the phone will answer.
+
+The experimental pairing flow therefore keeps the ANCS solicitation
+advertisement active, activates obexd's local Message Notification Server
+before pairing, and makes MAP/PBAP the first post-pair profile attempt. LE is
+enabled after that attempt completes, whether it succeeds or fails. Before
+each connection request the daemon explicitly selects the corresponding BlueZ
+`PreferredBearer`; otherwise the pairing-time BR/EDR preference prevents the
+later LE request from completing.
+
+On a clean iOS 26 test this ordering opened MAP/PBAP first; the pending LE
+request completed three seconds later, resolved all three ANCS characteristics,
+and presented the system-notification consent prompt. The first Control Point
+request returned `NotPermitted`; the retry five seconds later succeeded after
+the prompt was approved. MAP, PBAP, and authorized ANCS then shared one
+iPhone-side record. Failed or partial pairing attempts can still leave two
+same-named records on the phone, so both must be removed before another clean
+test.
+
+Starting notifications on the ANCS Notification Source and Data Source proves
+only that the GATT subscriptions exist. It does not prove that iOS authorized
+notification contents. During setup BlueFerry therefore sends a minimal
+Control Point request for the Messages app's display name and reports ANCS
+ready only after the corresponding Data Source response arrives. This probe
+contains no notification identifier or notification content. A rejected or
+interrupted probe is retried while MAP/PBAP remains available.
+
 Without the relevant permission, MAP or PBAP can be visible at the SDP level
 but reject an OBEX connection with `Forbidden`/`0x43`; that state resolves
 once the toggle is enabled and is not a reason to re-pair. A MAP `Connection

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ On first launch it opens the iPhone setup page.
    appear on some controllers.
 3. Confirm the same code on both devices when prompted.
 4. On the iPhone, open **Settings → Bluetooth → ⓘ** beside the computer and
-   enable **Show Message Notifications** and **Sync Contacts**.
+   enable **Show Message Notifications** and **Sync Contacts**. You may need
+   to back out and tap **ⓘ** again before these toggles appear.
 5. Wait for Messages and Contacts to show as connected. For the default
    encrypted storage, approve the desktop wallet prompt that opens automatically.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ On first launch it opens the iPhone setup page.
 4. On the iPhone, open **Settings → Bluetooth → ⓘ** beside the computer and
    enable **Show Message Notifications** and **Sync Contacts**. You may need
    to back out and tap **ⓘ** again before these toggles appear.
+   **Allow System Notifications** is also required to identify group text
+   threads; without it, a group text appears as a one-to-one conversation with
+   its sender.
 5. Wait for Messages and Contacts to show as connected. For the default
    encrypted storage, approve the desktop wallet prompt that opens automatically.
 

--- a/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
@@ -40,6 +40,12 @@
   </developer>
 
   <releases>
+    <release version="0.6.2" date="2026-08-10">
+      <description>
+        <p>Improves interactive Bluetooth pairing, diagnostics, and handling
+        when a saved device is forgotten outside BlueFerry.</p>
+      </description>
+    </release>
     <release version="0.6.1" date="2026-08-10">
       <description>
         <p>Adds the Textual terminal client, notification deep links, KDE tray

--- a/data/io.weirdware.BlueFerry.Qt.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Qt.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.6.2" date="2026-08-10"><description><p>Improves interactive Bluetooth pairing, diagnostics, and forgotten-device handling.</p></description></release>
     <release version="0.6.1" date="2026-08-10"><description><p>Adds KDE tray integration and notification deep links.</p></description></release>
     <release version="0.6.0" date="2026-08-08"><description><p>First Qt/KDE client.</p></description></release>
   </releases>

--- a/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.6.2" date="2026-08-10"><description><p>Improves interactive Bluetooth pairing, diagnostics, and forgotten-device handling.</p></description></release>
     <release version="0.6.1" date="2026-08-10"><description><p>Adds notification deep links and backend upgrade handling.</p></description></release>
     <release version="0.6.0" date="2026-08-08"><description><p>First standalone Quickshell client.</p></description></release>
   </releases>

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -151,9 +151,13 @@ ShellRoot {
   function pendingIphoneSetupText() {
     var tasks = pendingIphoneSetupTasks().join("\n• ")
     var instructions = "After approving “Allow System Notifications,” you may need to return to the Bluetooth device list and reopen this computer before the other settings appear."
-    if (root.configured) return instructions + "\n• " + tasks
-    return "On the iPhone open Settings → Bluetooth, tap ⓘ next to this computer, then finish the settings below. " + instructions + "\n• "
-      + tasks
+    var text = root.configured
+      ? instructions + "\n• " + tasks
+      : "On the iPhone open Settings → Bluetooth, tap ⓘ next to this computer, then finish the settings below. " + instructions + "\n• " + tasks
+    var verified = backendStatus.verified_iphone_setup || []
+    if (notificationsSupported && verified.indexOf("notification-access") < 0)
+      text += "\n\nWithout System Notification access, group texts appear as individual conversations with their sender."
+    return text
   }
 
   function updateOnboarding() {
@@ -1078,7 +1082,7 @@ ShellRoot {
             text: root.onboardingStage === "ready"
               ? "Bluetooth services and iPhone permissions have been verified."
               : root.onboardingStage === "ready-without-ancs"
-                ? "Messages and contacts have been verified; per-app notifications are unavailable."
+                ? "Messages and contacts have been verified. System notifications are unavailable, so group texts may appear as individual conversations."
                 : root.onboardingStage === "iphone-settings"
                     ? root.mapConnectionRefused()
                       ? "Cannot retrieve or send messages - are you connected to another computer? We will reconnect once your phone is free"
@@ -1092,7 +1096,7 @@ ShellRoot {
             visible: !root.configured && !root.targetSaved
           }
           FerryLabel {
-            text: "Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds."
+            text: "Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."
             wrapMode: Text.Wrap
             Layout.fillWidth: true
             visible: !root.configured && !root.targetSaved

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   blueferry-qt
   blueferry-quickshell
 )
-pkgver=0.6.1
+pkgver=0.6.2
 pkgrel=1
 pkgdesc='BlueFerry Bluetooth bridge from iPhone to Linux'
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueferry"
-version = "0.6.1"
+version = "0.6.2"
 description = "BlueFerry brings iPhone messages, notifications, and contacts to Linux"
 authors = [
   {name = "Erik Bourget", email = "erik@ebourget.net"},

--- a/src/blueferry/__init__.py
+++ b/src/blueferry/__init__.py
@@ -1,3 +1,3 @@
 """BlueFerry — Bluetooth bridge from a paired iPhone to Linux desktop."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -66,6 +66,7 @@ log = logging.getLogger(__name__)
 REQUEST_TIMEOUT_SECONDS = 15
 DBUS_CALL_TIMEOUT_SECONDS = 10
 SUBSCRIBE_RETRY_SECONDS = 2
+AUTHORIZATION_RETRY_SECONDS = 5
 
 
 @dataclass(slots=True)
@@ -76,6 +77,7 @@ class _PendingRequest:
     notification: Notification | None = None
     app_probe: bool = False
     expected_app_id: str | None = None
+    authorization_probe: bool = False
 
 
 _APP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
@@ -118,6 +120,7 @@ class AncsClient:
         self._ds_path: str | None = None
         self._cp_path: str | None = None
         self._notify_started = False
+        self._authorized = False
 
         # In-flight per-notification attribute requests + app-name cache
         self._app_name_cache: OrderedDict[str, str] = OrderedDict()
@@ -135,6 +138,7 @@ class AncsClient:
         self._manager_signal_matches: list = []
         self._characteristic_signal_matches: list = []
         self._subscribe_retry_id: int | None = None
+        self._authorization_retry_id: int | None = None
         self._started = False
 
     # ---- lifecycle ------------------------------------------------------
@@ -172,12 +176,16 @@ class AncsClient:
 
     @property
     def connected(self) -> bool:
-        return self._notify_started
+        # StartNotify only proves that BlueZ subscribed to the GATT
+        # characteristics. iOS notification access is usable only after an
+        # authorized Control Point round trip succeeds.
+        return self._notify_started and self._authorized
 
     def stop(self) -> None:
         log.info("ANCS client stopping")
-        was_connected = self._notify_started
+        was_connected = self.connected
         self._cancel_subscribe_retry()
+        self._cancel_authorization_retry()
         self._clear_characteristic_subscription()
         for m in self._manager_signal_matches:
             try:
@@ -217,9 +225,10 @@ class AncsClient:
         path_s = str(path)
         for attr in ("_ns_path", "_ds_path", "_cp_path"):
             if getattr(self, attr) == path_s:
-                was_connected = self._notify_started
+                was_connected = self.connected
                 setattr(self, attr, None)
                 self._cancel_subscribe_retry()
+                self._cancel_authorization_retry()
                 self._clear_characteristic_subscription()
                 log.warning("ANCS char gone: %s", path_s)
                 if was_connected and self.on_status is not None:
@@ -228,6 +237,7 @@ class AncsClient:
 
     def _clear_characteristic_subscription(self) -> None:
         """Remove receivers and notification ownership before rediscovery."""
+        self._cancel_authorization_retry()
         for match in self._characteristic_signal_matches:
             try:
                 match.remove()
@@ -245,6 +255,7 @@ class AncsClient:
                     except dbus.exceptions.DBusException:
                         pass
         self._notify_started = False
+        self._authorized = False
         self._reset_requests()
 
     def _try_subscribe(self) -> None:
@@ -301,9 +312,10 @@ class AncsClient:
         self._cancel_subscribe_retry()
         self._characteristic_signal_matches = matches
         self._notify_started = True
-        log.info("ANCS subscription active for %s", self.device_path)
-        if self.on_status is not None:
-            self.on_status()
+        log.info(
+            "ANCS characteristic subscriptions active; requesting notification access"
+        )
+        self._queue_authorization_probe()
 
     def _schedule_subscribe_retry(self) -> None:
         if (
@@ -331,6 +343,62 @@ class AncsClient:
         except Exception:
             log.debug("could not remove ANCS subscription retry", exc_info=True)
         self._subscribe_retry_id = None
+
+    def _queue_authorization_probe(self) -> None:
+        if not self._notify_started or self._authorized:
+            return
+        request = _PendingRequest(
+            key="authorization",
+            packet=build_get_app_attributes(MESSAGES_APP_ID),
+            assembler=DataSourceAssembler(
+                CommandID.GetAppAttributes,
+                [0],
+                app_id=MESSAGES_APP_ID,
+            ),
+            authorization_probe=True,
+        )
+        if self._request_queue.enqueue(request.key, request):
+            self._pump_requests()
+
+    def _schedule_authorization_retry(self) -> None:
+        if (
+            not self._started
+            or not self._notify_started
+            or self._authorized
+            or self._authorization_retry_id is not None
+        ):
+            return
+        self._authorization_retry_id = self._schedule(
+            AUTHORIZATION_RETRY_SECONDS,
+            self._retry_authorization,
+        )
+        log.info(
+            "ANCS notification access is not authorized yet; retrying in %ds",
+            AUTHORIZATION_RETRY_SECONDS,
+        )
+
+    def _retry_authorization(self) -> bool:
+        self._authorization_retry_id = None
+        self._queue_authorization_probe()
+        return False
+
+    def _cancel_authorization_retry(self) -> None:
+        if self._authorization_retry_id is None:
+            return
+        try:
+            self._cancel(self._authorization_retry_id)
+        except Exception:
+            log.debug("could not remove ANCS authorization retry", exc_info=True)
+        self._authorization_retry_id = None
+
+    def _mark_authorized(self) -> None:
+        if self._authorized:
+            return
+        self._authorized = True
+        self._cancel_authorization_retry()
+        log.info("ANCS notification access authorized for %s", self.device_path)
+        if self.on_status is not None:
+            self.on_status()
 
     # ---- Notification Source: new/modified/removed events --------------
 
@@ -412,7 +480,9 @@ class AncsClient:
                 timeout=DBUS_CALL_TIMEOUT_SECONDS,
             )
         except dbus.exceptions.DBusException as error:
-            log.warning("ANCS CP WriteValue failed: %s", error.get_dbus_name())
+            name = error.get_dbus_name() or type(error).__name__
+            detail = error.get_dbus_message() or str(error)
+            log.warning("ANCS CP WriteValue failed: %s: %s", name, detail)
             self._abandon_request(request)
             self._active_request = None
             self._pump_requests()
@@ -451,6 +521,9 @@ class AncsClient:
         if request is None:
             return
         self._request_queue.finish(request.key)
+        if request.authorization_probe:
+            self._schedule_authorization_retry()
+            return
         app_id = request.assembler.app_id
         if request.notification is not None or not app_id:
             return
@@ -541,6 +614,8 @@ class AncsClient:
                 self._abandon_request(request)
                 self._pump_requests()
                 return
+            if request.authorization_probe:
+                self._mark_authorized()
             self._handle_app_attrs(app_attrs)
         self._pump_requests()
 

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -109,6 +109,7 @@ class BearerSupervisor:
         if not self._running:
             return False
 
+        log.debug("probing iPhone BR/EDR and LE bearer state")
         bredr = self._read("bredr")
         le = self._read("le")
         self._update_state("bredr", bredr)
@@ -176,6 +177,9 @@ class BearerSupervisor:
     def _update_state(self, kind: str, value: bool | None) -> None:
         previous = self._states[kind]
         self._states[kind] = value
+        if previous != value:
+            label = "unknown" if value is None else ("connected" if value else "disconnected")
+            log.debug("iPhone %s bearer state: %s", kind.upper(), label)
         if value is True:
             self._last_errors.pop(kind, None)
             self._failures[kind] = 0

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -28,6 +28,7 @@ _INTERFACES = {
 
 ReadConnected = Callable[[str], bool | None]
 Connect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
+Prefer = Callable[[str], None]
 Schedule = Callable[[int, Callable[[], bool]], int]
 Cancel = Callable[[int], object]
 Clock = Callable[[], float]
@@ -45,9 +46,11 @@ class BearerSupervisor:
         self,
         device_path: str,
         *,
+        le_enabled: bool = True,
         on_status: Callable[[], None] | None = None,
         read_connected: ReadConnected | None = None,
         connect: Connect | None = None,
+        prefer: Prefer | None = None,
         schedule: Schedule = GLib.timeout_add_seconds,
         cancel: Cancel = GLib.source_remove,
         clock: Clock = time.monotonic,
@@ -56,9 +59,13 @@ class BearerSupervisor:
         self._on_status = on_status
         self._read_connected = read_connected or self._read_bluez_connected
         self._connect = connect or self._connect_bluez
+        self._prefer = prefer or (
+            self._prefer_bluez if connect is None else lambda _kind: None
+        )
         self._schedule = schedule
         self._cancel = cancel
         self._clock = clock
+        self._le_enabled = le_enabled
         self._timer_id: int | None = None
         self._le_settle_id: int | None = None
         self._running = False
@@ -82,6 +89,20 @@ class BearerSupervisor:
         self._running = True
         self._tick()
         self._timer_id = self._schedule(POLL_SECONDS, self._tick)
+
+    def enable_le(self) -> None:
+        """Allow the LE bearer after the first Classic profile attempt.
+
+        Pairing-time callers can hold LE back long enough for MAP/PBAP to be
+        the first post-pair profile transaction.  Calling this more than once
+        is harmless.
+        """
+        if self._le_enabled:
+            return
+        self._le_enabled = True
+        log.info("MAP/PBAP attempt completed; enabling iPhone LE bearer")
+        if self._running:
+            self._tick()
 
     def poke(self) -> None:
         """Run a health check now, for example after system resume."""
@@ -122,7 +143,7 @@ class BearerSupervisor:
             self._cancel_le_settle()
         if bredr is False:
             self._request_connect("bredr")
-        elif bredr is True and le is False:
+        elif bredr is True and le is False and self._le_enabled:
             self._schedule_le_connect()
         elif le is True:
             self._cancel_le_settle()
@@ -148,7 +169,7 @@ class BearerSupervisor:
         le = self._read("le")
         self._update_state("bredr", bredr)
         self._update_state("le", le)
-        if bredr is True and le is False:
+        if bredr is True and le is False and self._le_enabled:
             self._request_connect("le")
         elif bredr is False:
             self._request_connect("bredr")
@@ -195,6 +216,10 @@ class BearerSupervisor:
         self._connecting.add(kind)
         log.info("connecting iPhone %s bearer", kind.upper())
         try:
+            # Pairing pins the device to BR/EDR so iOS sees MAP/PBAP first.
+            # Switch that preference explicitly for the deferred LE handoff;
+            # restore it just as explicitly before a later Classic reconnect.
+            self._prefer(kind)
             self._connect(
                 kind,
                 lambda: self._connect_succeeded(kind),
@@ -266,3 +291,28 @@ class BearerSupervisor:
             error_handler=on_error,
             timeout=45.0,
         )
+
+    def _prefer_bluez(self, kind: str) -> None:
+        properties = dbus.Interface(
+            get_system_bus().get_object("org.bluez", self.device_path),
+            "org.freedesktop.DBus.Properties",
+        )
+        try:
+            properties.Set(
+                "org.bluez.Device1",
+                "PreferredBearer",
+                dbus.String(kind),
+                timeout=5.0,
+            )
+            log.debug("set iPhone PreferredBearer=%s", kind)
+        except dbus.exceptions.DBusException as error:
+            if error.get_dbus_name() in {
+                "org.freedesktop.DBus.Error.UnknownInterface",
+                "org.freedesktop.DBus.Error.UnknownMethod",
+                "org.freedesktop.DBus.Error.UnknownProperty",
+            }:
+                # Older BlueZ releases can still accept inbound ANCS without
+                # exposing their experimental bearer-selection API.
+                log.debug("PreferredBearer is unavailable on this BlueZ build")
+                return
+            raise

--- a/src/blueferry/bluez_setup.py
+++ b/src/blueferry/bluez_setup.py
@@ -250,6 +250,7 @@ def unregister_advert(adapter: str | None = None) -> None:
         ad_mgr = bluez(f"/org/bluez/{adapter}",
                        "org.bluez.LEAdvertisingManager1")
         ad_mgr.UnregisterAdvertisement(_AncsAdvert.PATH)
+        log.info("BLE advert unregistered: %s", _AncsAdvert.PATH)
     except dbus.exceptions.DBusException as e:
         log.debug("UnregisterAdvertisement: %s", e.get_dbus_name())
     finally:

--- a/src/blueferry/cli.py
+++ b/src/blueferry/cli.py
@@ -32,7 +32,7 @@ def _find_obexd() -> str | None:
 
 
 @app.command()
-def run(verbose: bool = typer.Option(False, "-v", "--verbose")):
+def run(verbose: bool = typer.Option(False, "-v", "--verbose", "--debug")):
     """Start the BlueFerry daemon (runs until Ctrl+C / SIGTERM)."""
     _setup_logging(verbose)
     # Import inside command to avoid loading dbus stack just to print --help
@@ -124,9 +124,17 @@ def pair_setup(
     no_verify: bool = typer.Option(
         False, "--no-verify", help="Don't wait for profile verification at the end"
     ),
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        help="Print detailed Bluetooth pairing and connection activity",
+    ),
 ):
     """First-run wizard: pick a paired iPhone, write the local config,
     walk through the iPhone-side toggle steps."""
+    if debug:
+        _setup_logging(True)
+
     from blueferry.pairing_cli import run_wizard
 
     raise typer.Exit(code=run_wizard(verify_after=not no_verify))
@@ -217,6 +225,7 @@ def pairing_activate_bluez() -> None:
 def pairing_complete(
     mac: str,
     interactive_agent: bool = typer.Option(False, "--interactive-agent", hidden=True),
+    debug: bool = typer.Option(False, "--debug"),
 ) -> None:
     """Pair and perform all Linux-side setup for graphical clients."""
     import json
@@ -224,6 +233,9 @@ def pairing_complete(
 
     from blueferry.errors import PairingError
     from blueferry.setup_client import SetupClient
+
+    if debug:
+        _setup_logging(True)
 
     def emit(event: dict) -> None:
         print(json.dumps(event), flush=True)

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -419,7 +419,18 @@ class Daemon:
     def _check_target_config(self) -> bool:
         mac, adapter = config.current_target()
         if mac == config.IPHONE_MAC and adapter == config.ADAPTER:
-            return True
+            bonded = bond_status(mac, adapter)
+            if bonded is not False:
+                return True
+            # The daemon may already have initialized its supervisors when a
+            # user removes the bond through a desktop Bluetooth client. Stop
+            # the current process so those supervisors cannot keep issuing
+            # Connect/CreateSession calls for an explicitly forgotten phone.
+            # ``None`` is deliberately ignored above because it represents an
+            # unavailable adapter or transient BlueZ inspection failure.
+            log.info("saved iPhone bond was removed; stopping daemon")
+            main_loop.quit()
+            return False
         if not mac:
             log.info("saved iPhone target was cleared; stopping daemon")
         else:

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -86,7 +86,14 @@ class Daemon:
             f"/org/bluez/{config.ADAPTER}/"
             f"dev_{config.IPHONE_MAC.replace(':', '_')}"
         )
-        self.bearers = BearerSupervisor(device_path, on_status=self._emit_status)
+        # Keep LE out of the initial post-pair window.  The first OBEX
+        # attempt below either establishes ordinary Classic MAP/PBAP or gives
+        # iOS a chance to reject it before ANCS is allowed to connect.
+        self.bearers = BearerSupervisor(
+            device_path,
+            le_enabled=False,
+            on_status=self._emit_status,
+        )
         self._contacts_refresh_id: int | None = None
         self._bus_name = None
         self._dbus_service: MessagesService | None = None
@@ -109,6 +116,7 @@ class Daemon:
             on_ready=self._post_sessions_setup,
             on_lost=self._profiles_lost,
             on_status=self._emit_status,
+            on_first_attempt_complete=self.bearers.enable_le,
         )
 
     def _emit_status(self) -> None:
@@ -232,9 +240,8 @@ class Daemon:
             )
 
         # A bond records trust but does not guarantee a live connection.
-        # Connect classic Bluetooth first for MAP/PBAP, then LE for ANCS.
-        # Keeping this in the daemon avoids relying on a desktop Bluetooth
-        # applet to connect a newly paired phone as a side effect.
+        # The bearer supervisor establishes BR/EDR but deliberately holds LE
+        # until ProfileSupervisor completes its first MAP/PBAP attempt.
         self.bearers.start()
 
         # ANCS — per-app notifications via BLE GATT. Independent of MAP/PBAP.

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Callable
+from contextlib import ExitStack
 from pathlib import Path
 
 import dbus
@@ -18,6 +20,8 @@ from blueferry.commands import run_command
 from blueferry.errors import CommandError, PairingError
 from blueferry.private_files import atomic_write_private_text
 from blueferry.setup_verification import clear_setup_verification
+
+log = logging.getLogger(__name__)
 
 LOCAL_ENV_PATH = config.LOCAL_ENV_PATH
 CLASSIC_SETTLE_SECONDS = 3.0
@@ -210,6 +214,7 @@ def _device(mac: str) -> PairedDevice:
 
 def _wait_for_paired_device(mac: str, *, timeout: float = 120) -> PairedDevice:
     """Wait for a local or iPhone-initiated pairing transaction to settle."""
+    log.debug("waiting up to %.0fs for the %s pairing record to settle", timeout, mac)
     deadline = time.monotonic() + timeout
     device = _device(mac)
     while not device.paired and time.monotonic() < deadline:
@@ -220,6 +225,7 @@ def _wait_for_paired_device(mac: str, *, timeout: float = 120) -> PairedDevice:
             "Bluetooth pairing did not finish. Keep the iPhone unlocked with "
             "Bluetooth settings open, then retry."
         )
+    log.debug("pairing record settled for %s", device.device_path)
     return device
 
 
@@ -255,6 +261,12 @@ def _wait_for_classic_settled(
     context = GLib.MainContext.default()
     deadline = time.monotonic() + timeout
     connected_since: float | None = None
+    previous_connected: bool | None = None
+    log.debug(
+        "probing Classic connection state for up to %.0fs (%.1fs stable required)",
+        timeout,
+        settle_seconds,
+    )
     while True:
         while context.pending():
             context.iteration(False)
@@ -265,10 +277,17 @@ def _wait_for_classic_settled(
             )
         except dbus.exceptions.DBusException:
             connected = False
+        if connected != previous_connected:
+            log.debug(
+                "Classic connection state: %s",
+                "connected" if connected else "disconnected",
+            )
+            previous_connected = connected
         if connected:
             if connected_since is None:
                 connected_since = now
             if now - connected_since >= settle_seconds:
+                log.info("Classic connection is settled")
                 return
         else:
             connected_since = None
@@ -287,6 +306,7 @@ def _connect_classic(
     settle: bool = True,
 ) -> None:
     """Connect the Classic bearer without blocking agent dispatch."""
+    log.info("sending Device1.Connect for Classic bearer: %s", device_path)
     interface = dbus.Interface(
         get_system_bus().get_object("org.bluez", device_path),
         "org.bluez.Device1",
@@ -306,6 +326,10 @@ def _connect_classic(
         raise PairingError(
             error.get_dbus_message() or error.get_dbus_name() or str(error)
         ) from error
+    if error is None:
+        log.debug("Device1.Connect completed successfully")
+    else:
+        log.debug("Device1.Connect reports %s", error.get_dbus_name())
     if settle:
         _wait_for_classic_settled(device_path, timeout=timeout)
 
@@ -313,12 +337,29 @@ def _connect_classic(
 def _connect_ancs(device: PairedDevice, *, timeout: float = 30.0) -> str:
     """Connect the bonded LE bearer exposed by bluetoothd's experimental API."""
     manager = _object_manager()
+    previous_state: tuple[bool, bool, bool] | None = None
 
     def bearer_present() -> bool:
+        nonlocal previous_state
         objects = manager.GetManagedObjects()
         interfaces = objects.get(dbus.ObjectPath(device.device_path), {})
-        return "org.bluez.Bearer.LE1" in interfaces
+        bearer = interfaces.get("org.bluez.Bearer.LE1")
+        if bearer is None:
+            return False
+        state = (
+            bool(bearer.get("Paired", False)),
+            bool(bearer.get("Bonded", False)),
+            bool(bearer.get("Connected", False)),
+        )
+        if state != previous_state:
+            log.debug(
+                "LE bearer probe: paired=%s bonded=%s connected=%s",
+                *state,
+            )
+            previous_state = state
+        return True
 
+    log.debug("probing for Bearer.LE1 on %s", device.device_path)
     if not _dispatching_wait(time.monotonic() + timeout, bearer_present):
         raise PairingError(
             "The iPhone has not established the low-energy half of this "
@@ -328,6 +369,7 @@ def _connect_ancs(device: PairedDevice, *, timeout: float = 30.0) -> str:
     obj = get_system_bus().get_object("org.bluez", device.device_path)
     props = dbus.Interface(obj, "org.freedesktop.DBus.Properties")
     try:
+        log.debug("setting Device1.PreferredBearer=le")
         props.Set("org.bluez.Device1", "PreferredBearer", dbus.String("le"))
     except dbus.exceptions.DBusException as error:
         name = error.get_dbus_name() or ""
@@ -342,7 +384,9 @@ def _connect_ancs(device: PairedDevice, *, timeout: float = 30.0) -> str:
         ) from error
     for attempt in range(2):
         try:
+            log.info("sending Bearer.LE1.Connect (attempt %d/2)", attempt + 1)
             dbus.Interface(obj, "org.bluez.Bearer.LE1").Connect(timeout=45.0)
+            log.info("LE bearer connected")
             return "connected"
         except dbus.exceptions.DBusException as error:
             name = error.get_dbus_name() or ""
@@ -351,6 +395,10 @@ def _connect_ancs(device: PairedDevice, *, timeout: float = 30.0) -> str:
                 "org.bluez.Error.AlreadyConnected",
                 "org.bluez.Error.InProgress",
             } or detail.casefold() == "operation already in progress":
+                log.info(
+                    "LE bearer connection is already active (%s)",
+                    name or detail,
+                )
                 return "already connected"
             if name in {
                 "org.freedesktop.DBus.Error.UnknownInterface",
@@ -359,7 +407,13 @@ def _connect_ancs(device: PairedDevice, *, timeout: float = 30.0) -> str:
             }:
                 # Marker-only bearer API: the advert invites the bonded iPhone
                 # to establish LE inbound instead.
+                log.debug("Bearer.LE1.Connect is unavailable: %s", name)
                 return "waiting for iPhone to connect"
+            log.debug(
+                "Bearer.LE1.Connect failed: %s: %s",
+                name or "unknown error",
+                detail or "(no detail)",
+            )
             failure = f"{name} {detail}".casefold()
             if attempt == 0 and "le-connection-abort-by-local" in failure:
                 # Desktop managers often connect the newly paired Classic
@@ -402,6 +456,14 @@ def complete_pairing(
     from blueferry import bluez_setup
 
     device = _device(mac)
+    log.info(
+        "starting setup for %s (%s): paired=%s trusted=%s connected=%s",
+        device.name,
+        device.mac,
+        device.paired,
+        device.trusted,
+        device.connected,
+    )
     adapter = device.adapter_path.rsplit("/", 1)[-1]
     compatibility = bluetooth_compatibility(adapter)
     if not compatibility["hardware_supported"]:
@@ -423,6 +485,7 @@ def complete_pairing(
             "blueferry-backend is installed and run doctor."
         )
 
+    pairing_agents = ExitStack()
     try:
         if not device.paired:
             try:
@@ -430,45 +493,33 @@ def complete_pairing(
                     # Headless fallback: a Linux-initiated transaction pairs
                     # the Classic bearer. Controllers whose Classic pairing
                     # derives LE keys (CTKD) get the dual bond this way too.
+                    log.info("sending Device1.Pair using the headless pairing path")
                     dbus.Interface(
                         get_system_bus().get_object("org.bluez", device.device_path),
                         "org.bluez.Device1",
                     ).Pair(timeout=120.0)
                 else:
-                    from blueferry.pairing_agent import (
-                        RegisteredPairingAgent,
-                        desktop_pairing_manager_present,
-                    )
+                    from blueferry.pairing_agent import RegisteredPairingAgent
 
-                    if desktop_pairing_manager_present():
-                        # KDE BlueDevil, GNOME Shell, and Blueman own both the
-                        # confirmation UI and the surrounding post-pair
-                        # connection lifecycle. Preserve the desktop-proven
-                        # Device1.Pair flow instead of racing that manager
-                        # with BlueFerry's Connect-driven transaction.
-                        dbus.Interface(
-                            get_system_bus().get_object(
-                                "org.bluez", device.device_path
-                            ),
-                            "org.bluez.Device1",
-                        ).Pair(timeout=120.0)
-                    else:
-                        # Connecting the unpaired ACL makes iOS initiate the
-                        # pairing itself, and the authentication initiator is
-                        # the side that derives the cross-transport LE keys.
-                        # Use this fallback when no interactive desktop agent
-                        # owns the full pairing lifecycle.
-                        with RegisteredPairingAgent(
+                    # Connecting the unpaired ACL makes iOS initiate pairing,
+                    # and the authentication initiator is the side that derives
+                    # the cross-transport LE keys. The client has explicit
+                    # confirmation UI, so its device-scoped agent temporarily
+                    # becomes BlueZ default for this transaction even when a
+                    # desktop agent is already registered.
+                    registered = pairing_agents.enter_context(
+                        RegisteredPairingAgent(
                             device.device_path,
                             confirmation,
                             display,
-                        ) as registered:
-                            _connect_classic(
-                                device.device_path,
-                                timeout=60.0,
-                                settle=False,
-                            )
-                            registered.wait_for_pair(timeout=120.0)
+                        )
+                    )
+                    _connect_classic(
+                        device.device_path,
+                        timeout=60.0,
+                        settle=False,
+                    )
+                    registered.wait_for_pair(timeout=120.0)
             except dbus.exceptions.DBusException as error:
                 name = error.get_dbus_name() or ""
                 if name in {
@@ -487,12 +538,14 @@ def complete_pairing(
                         detail = f"Bluetooth confirmation did not complete: {detail}"
                     raise PairingError(detail) from error
             device = _wait_for_paired_device(mac)
+        log.debug("setting Device1.Trusted=true for %s", device.device_path)
         trust_device(device.mac, device.adapter_path)
 
         _connect_classic(device.device_path)
         # Two-phase LE setup, matching the proven desktop sequence: only
         # after the Classic bearer is connected does the ANCS solicitation
         # advert appear, inviting the bonded iPhone to establish LE.
+        log.debug("registering ANCS solicitation advertisement on %s", adapter)
         if not bluez_setup.register_advert(adapter, settle_for_pairing=True):
             raise PairingError("The ANCS advertisement did not activate")
         try:
@@ -506,14 +559,20 @@ def complete_pairing(
             raise PairingError("ANCS/LE connection did not complete; the iPhone was not saved")
     finally:
         # The temporary setup process owns this advertisement. Remove it
-        # before starting the daemon so ownership transfers without a gap or
-        # an AlreadyExists false-positive.
-        bluez_setup.unregister_advert(adapter)
+        # before releasing our device-scoped default agent. Restoring a
+        # desktop agent as soon as Device1.Paired flips can let its post-pair
+        # work race BlueFerry's Classic-to-LE handoff.
+        try:
+            log.debug("removing ANCS solicitation advertisement from %s", adapter)
+            bluez_setup.unregister_advert(adapter)
+        finally:
+            pairing_agents.close()
 
     # The selected MAC is a capability-bearing target, not merely discovery
     # data. Persist it only after ANCS proves that the LE half of this exact
     # bond works; until then the daemon must have no MAP target to connect to.
     write_local_env(device.mac, device.adapter_path.rsplit("/", 1)[-1])
+    log.debug("saved paired target %s; restarting user service", device.mac)
     _restart_user_service()
     device = _device(mac)
     return {
@@ -527,11 +586,9 @@ def complete_pairing(
         "ancs_ready": ancs_ready,
         "iphone_steps": [
             "Open Settings → Bluetooth and tap ⓘ next to this computer",
-            "If the toggles below are missing, go back and reopen this "
-            "screen — iOS adds them with a delay, sometimes after minutes",
             "If this computer is listed twice, check both entries",
-            "Enable Show Message Notifications",
-            "Enable Sync Contacts",
+            "Toggle on Show Message Notifications and Sync Contacts",
+            "You may need to back out and tap ⓘ again to make these toggles appear",
         ],
     }
 
@@ -542,9 +599,11 @@ def forget_device(mac: str) -> None:
     if not config.is_valid_mac(normalized):
         raise PairingError("invalid Bluetooth device address")
     device = _find_device(normalized)
+    log.info("stopping the user service before forgetting target %s", normalized)
     _stop_user_service()
     if device is not None:
         try:
+            log.info("sending Adapter1.RemoveDevice for %s", device.device_path)
             dbus.Interface(
                 get_system_bus().get_object("org.bluez", device.adapter_path),
                 "org.bluez.Adapter1",
@@ -554,7 +613,10 @@ def forget_device(mac: str) -> None:
                 raise PairingError(
                     error.get_dbus_message() or error.get_dbus_name() or str(error)
                 ) from error
+    else:
+        log.debug("no BlueZ device record remains for %s", normalized)
     clear_local_target()
+    log.info("cleared configured BlueFerry target %s", normalized)
 
 
 def clear_local_target() -> Path:

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -15,7 +15,7 @@ from gi.repository import GLib
 from blueferry import bluetooth_capabilities as capabilities
 from blueferry import config
 from blueferry.bluetooth_devices import PairedDevice
-from blueferry.bus import get_system_bus
+from blueferry.bus import get_session_bus, get_system_bus
 from blueferry.commands import run_command
 from blueferry.errors import CommandError, PairingError
 from blueferry.private_files import atomic_write_private_text
@@ -334,6 +334,76 @@ def _connect_classic(
         _wait_for_classic_settled(device_path, timeout=timeout)
 
 
+def _prefer_bredr(device_path: str) -> None:
+    """Force the post-pair Device1.Connect transaction onto BR/EDR."""
+    log.info(
+        "setting Device1.PreferredBearer=bredr before post-pair connection"
+    )
+    obj = get_system_bus().get_object("org.bluez", device_path)
+    props = dbus.Interface(obj, "org.freedesktop.DBus.Properties")
+    try:
+        props.Set(
+            "org.bluez.Device1",
+            "PreferredBearer",
+            dbus.String("bredr"),
+        )
+    except dbus.exceptions.DBusException as error:
+        name = error.get_dbus_name() or ""
+        detail = error.get_dbus_message() or name or str(error)
+        raise PairingError(
+            f"Could not select the BR/EDR bearer for the post-pair "
+            f"connection: {detail}"
+        ) from error
+
+
+def _activate_obex_mns() -> None:
+    """Activate obexd so its local MAP notification service is advertised.
+
+    BlueZ's obexd publishes the Message Notification Server SDP record when
+    it starts.  Activating it before pairing gives iOS the same stable MAP
+    capability presentation used by automotive accessories instead of
+    waiting for BlueFerry's daemon to start after pairing.
+    """
+    log.info("activating BlueZ OBEX/MNS service before pairing")
+    try:
+        peer = dbus.Interface(
+            get_session_bus().get_object("org.bluez.obex", "/org/bluez/obex"),
+            "org.freedesktop.DBus.Peer",
+        )
+        peer.Ping(timeout=10.0)
+    except dbus.exceptions.DBusException as error:
+        detail = error.get_dbus_message() or error.get_dbus_name() or str(error)
+        raise PairingError(
+            f"Could not activate BlueZ's MAP notification service: {detail}"
+        ) from error
+    log.info("BlueZ OBEX/MNS service is available during pairing")
+
+
+def _wait_for_daemon_transports(*, timeout: float = 45.0) -> tuple[bool, bool, bool]:
+    """Observe the daemon while the pairing advert and agent remain active."""
+    from blueferry.client import BackendClient, BackendError
+
+    deadline = time.monotonic() + timeout
+    previous: tuple[bool, bool, bool] | None = None
+    while time.monotonic() < deadline:
+        try:
+            status = BackendClient().status()
+        except BackendError:
+            time.sleep(0.5)
+            continue
+        current = (status.map, status.pbap, status.ancs)
+        if current != previous:
+            log.debug(
+                "daemon transport state: MAP=%s PBAP=%s ANCS=%s",
+                *current,
+            )
+            previous = current
+        if status.ancs:
+            return current
+        time.sleep(0.5)
+    return previous or (False, False, False)
+
+
 def _connect_ancs(device: PairedDevice, *, timeout: float = 30.0) -> str:
     """Connect the bonded LE bearer exposed by bluetoothd's experimental API."""
     manager = _object_manager()
@@ -484,6 +554,7 @@ def complete_pairing(
             "Could not prepare the Bluetooth adapter; check that "
             "blueferry-backend is installed and run doctor."
         )
+    _activate_obex_mns()
 
     pairing_agents = ExitStack()
     try:
@@ -541,22 +612,34 @@ def complete_pairing(
         log.debug("setting Device1.Trusted=true for %s", device.device_path)
         trust_device(device.mac, device.adapter_path)
 
-        _connect_classic(device.device_path)
-        # Two-phase LE setup, matching the proven desktop sequence: only
-        # after the Classic bearer is connected does the ANCS solicitation
-        # advert appear, inviting the bonded iPhone to establish LE.
+        _prefer_bredr(device.device_path)
+        # The pairing transaction already established the Classic ACL.  A
+        # second generic Device1.Connect can wander into LE and hangs on the
+        # observed iOS 18 path, so only require that existing ACL to settle.
+        _wait_for_classic_settled(device.device_path)
+
+        # Keep ANCS solicitation active because iOS 26 testing found that it
+        # surfaced the MAP/PBAP permission toggles.  It is a pairing signal,
+        # not a prerequisite connection: the daemon below attempts MAP/PBAP
+        # before it is allowed to connect the LE bearer.
         log.debug("registering ANCS solicitation advertisement on %s", adapter)
         if not bluez_setup.register_advert(adapter, settle_for_pairing=True):
             raise PairingError("The ANCS advertisement did not activate")
-        try:
-            ancs = _connect_ancs(_device(mac))
-        except PairingError as error:
-            raise PairingError(
-                f"ANCS/LE connection did not complete; the iPhone was not saved: {error}"
-            ) from error
-        ancs_ready = ancs in {"connected", "already connected"}
-        if not ancs_ready:
-            raise PairingError("ANCS/LE connection did not complete; the iPhone was not saved")
+
+        # Start the long-lived owner while both the advert and temporary
+        # pairing agent are still present.  Its first operation is a Classic
+        # MAP/PBAP open; only when that attempt completes does it enable LE.
+        write_local_env(device.mac, device.adapter_path.rsplit("/", 1)[-1])
+        log.debug("saved paired target %s; restarting user service", device.mac)
+        _restart_user_service()
+        map_ready, pbap_ready, ancs_ready = _wait_for_daemon_transports()
+        ancs = "connected" if ancs_ready else "daemon connecting"
+        log.info(
+            "pairing-window result: MAP=%s PBAP=%s ANCS=%s",
+            map_ready,
+            pbap_ready,
+            ancs_ready,
+        )
     finally:
         # The temporary setup process owns this advertisement. Remove it
         # before releasing our device-scoped default agent. Restoring a
@@ -568,12 +651,6 @@ def complete_pairing(
         finally:
             pairing_agents.close()
 
-    # The selected MAC is a capability-bearing target, not merely discovery
-    # data. Persist it only after ANCS proves that the LE half of this exact
-    # bond works; until then the daemon must have no MAP target to connect to.
-    write_local_env(device.mac, device.adapter_path.rsplit("/", 1)[-1])
-    log.debug("saved paired target %s; restarting user service", device.mac)
-    _restart_user_service()
     device = _device(mac)
     return {
         "ok": True,
@@ -581,8 +658,6 @@ def complete_pairing(
         "config": str(LOCAL_ENV_PATH),
         "service": "package-enabled and restarted",
         "ancs": ancs,
-        # Reaching this result means ANCS/LE was established before the target
-        # was persisted and the daemon was started.
         "ancs_ready": ancs_ready,
         "iphone_steps": [
             "Open Settings → Bluetooth and tap ⓘ next to this computer",

--- a/src/blueferry/pairing_agent.py
+++ b/src/blueferry/pairing_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from collections.abc import Callable
@@ -14,54 +15,13 @@ from gi.repository import GLib
 from blueferry.bus import get_system_bus
 from blueferry.errors import PairingError
 
+log = logging.getLogger(__name__)
+
 AGENT_INTERFACE = "org.bluez.Agent1"
 AGENT_PATH = "/io/weirdware/BlueFerry/PairingAgent"
 
 ConfirmationCallback = Callable[[int | None], bool]
 DisplayCallback = Callable[[int], None]
-
-_DESKTOP_AGENT_BUS_NAMES = {
-    "org.blueman.Applet",
-    "org.cinnamon",
-    "org.Cinnamon",
-    "org.gnome.Shell",
-}
-_KDE_AGENT_MODULES = {
-    "org.kde.kded5": "org.kde.kded5",
-    "org.kde.kded6": "org.kde.kded6",
-}
-
-
-def desktop_pairing_manager_present(bus=None) -> bool:
-    """Return whether a common interactive desktop pairing agent is active.
-
-    BlueZ does not expose its registered/default agent list. Recognize the
-    session services that own pairing UI on the desktops BlueFerry supports;
-    deliberately ignore generic headless agents such as ``bt-agent`` because
-    they may advertise NoInputNoOutput and cannot show numeric comparison.
-    """
-    try:
-        session = bus or dbus.SessionBus()
-        names = {str(name) for name in session.list_names()}
-    except dbus.exceptions.DBusException:
-        return False
-    if names & _DESKTOP_AGENT_BUS_NAMES:
-        return True
-    for name, interface_name in _KDE_AGENT_MODULES.items():
-        if name not in names:
-            continue
-        try:
-            interface = dbus.Interface(
-                session.get_object(name, "/kded"),
-                interface_name,
-            )
-            modules = interface.loadedModules(timeout=2.0)
-        except dbus.exceptions.DBusException:
-            continue
-        if "bluedevil" in {str(module).casefold() for module in modules}:
-            return True
-    return False
-
 
 class _Rejected(dbus.exceptions.DBusException):
     _dbus_error_name = "org.bluez.Error.Rejected"
@@ -84,6 +44,10 @@ class PairingAgent(dbus.service.Object):
 
     def _require_expected(self, device: dbus.ObjectPath) -> None:
         if str(device) != self._expected_device:
+            log.warning(
+                "rejecting pairing-agent request for unexpected device %s",
+                device,
+            )
             raise _Rejected("BlueFerry did not request pairing with this device")
 
     def _confirm_deferred(
@@ -100,10 +64,13 @@ class PairingAgent(dbus.service.Object):
         def confirm() -> None:
             try:
                 if self._confirmation(passkey):
+                    log.debug("pairing-agent confirmation accepted")
                     return_cb()
                 else:
+                    log.debug("pairing-agent confirmation rejected")
                     error_cb(_Rejected(rejection))
             except Exception as error:  # callback/UI failures reject securely
+                log.debug("pairing-agent confirmation callback failed", exc_info=True)
                 error_cb(error)
 
         threading.Thread(
@@ -114,7 +81,7 @@ class PairingAgent(dbus.service.Object):
 
     @dbus.service.method(AGENT_INTERFACE, in_signature="", out_signature="")
     def Release(self) -> None:
-        pass
+        log.debug("BlueZ released the BlueFerry pairing agent")
 
     @dbus.service.method(AGENT_INTERFACE, in_signature="o", out_signature="s")
     def RequestPinCode(self, device: dbus.ObjectPath) -> str:
@@ -155,6 +122,7 @@ class PairingAgent(dbus.service.Object):
         error_cb: Callable[[Exception], None],
     ) -> None:
         self._require_expected(device)
+        log.debug("BlueZ requested numeric confirmation for %s", device)
         self._confirm_deferred(
             int(passkey),
             "Pairing code was not confirmed",
@@ -175,6 +143,7 @@ class PairingAgent(dbus.service.Object):
         error_cb: Callable[[Exception], None],
     ) -> None:
         self._require_expected(device)
+        log.debug("BlueZ requested pairing authorization for %s", device)
         self._confirm_deferred(
             None,
             "Pairing was not authorized",
@@ -185,14 +154,15 @@ class PairingAgent(dbus.service.Object):
     @dbus.service.method(AGENT_INTERFACE, in_signature="os", out_signature="")
     def AuthorizeService(self, device: dbus.ObjectPath, uuid: str) -> None:
         self._require_expected(device)
+        log.debug("authorizing Bluetooth service %s for %s", uuid, device)
 
     @dbus.service.method(AGENT_INTERFACE, in_signature="", out_signature="")
     def Cancel(self) -> None:
-        pass
+        log.debug("BlueZ cancelled the pairing-agent request")
 
 
 class RegisteredPairingAgent:
-    """Register a same-thread agent for one interactive pairing transaction.
+    """Register the default agent for one interactive pairing transaction.
 
     The agent's D-Bus callbacks are dispatched by a GLib loop running on the
     caller's thread (``wait_for_pair``). An earlier design ran the loop on a
@@ -223,16 +193,26 @@ class RegisteredPairingAgent:
 
     def __enter__(self) -> RegisteredPairingAgent:
         try:
+            log.info(
+                "registering device-scoped pairing agent for %s",
+                self._expected_device,
+            )
             self._manager.RegisterAgent(
                 dbus.ObjectPath(AGENT_PATH),
                 "DisplayYesNo",
                 timeout=10.0,
             )
             self._registered = True
-            # Do not displace an existing desktop pairing agent such as
-            # BlueDevil, GNOME Bluetooth, or Blueman. BlueZ keeps that agent
-            # as the default; when none exists, the first registered agent is
-            # automatically used for incoming pairing requests.
+            # The BlueFerry client owns the confirmation UI for this explicit
+            # transaction. Become default so an iPhone-initiated request
+            # reaches this scoped agent even if a desktop or headless agent was
+            # registered first. UnregisterAgent removes us from BlueZ's
+            # default-agent queue and restores the previous agent afterward.
+            self._manager.RequestDefaultAgent(
+                dbus.ObjectPath(AGENT_PATH),
+                timeout=10.0,
+            )
+            log.info("BlueFerry pairing agent is now the BlueZ default")
         except dbus.exceptions.DBusException as error:
             self._unregister()
             self._agent.remove_from_connection()
@@ -248,16 +228,27 @@ class RegisteredPairingAgent:
         if not self._registered:
             return
         try:
+            log.info(
+                "unregistering BlueFerry pairing agent; restoring previous default"
+            )
             self._manager.UnregisterAgent(
                 dbus.ObjectPath(AGENT_PATH),
                 timeout=10.0,
             )
-        except dbus.exceptions.DBusException:
-            pass
+        except dbus.exceptions.DBusException as error:
+            log.debug(
+                "could not unregister pairing agent: %s",
+                error.get_dbus_name() or str(error),
+            )
         self._registered = False
 
     def wait_for_pair(self, timeout: float = 120.0) -> None:
         """Dispatch Agent1 callbacks until BlueZ reports the device paired."""
+        log.debug(
+            "waiting up to %.0fs for Device1.Paired on %s",
+            timeout,
+            self._expected_device,
+        )
         loop = GLib.MainLoop()
         deadline = time.monotonic() + timeout
         failure: list[PairingError] = []
@@ -281,6 +272,7 @@ class RegisteredPairingAgent:
                     loop.quit()
                     return GLib.SOURCE_REMOVE
             if paired:
+                log.info("BlueZ reports the selected device paired")
                 loop.quit()
                 return GLib.SOURCE_REMOVE
             if time.monotonic() >= deadline:

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -12,12 +12,22 @@ from blueferry.client import BackendClient, BackendError
 from blueferry.errors import PairingError
 from blueferry.setup_client import SetupClient
 from blueferry.setup_verification import (
-    CONTACTS,
-    MESSAGE_NOTIFICATIONS,
     NOTIFICATION_ACCESS,
     remaining_iphone_setup_tasks,
 )
 from blueferry.text_safety import terminal_text
+
+
+def _confirm_pairing(passkey: int | None) -> bool:
+    if passkey is None:
+        prompt = "Approve this Bluetooth pairing request?"
+    else:
+        prompt = f"Do both devices show Bluetooth code {passkey:06d}?"
+    return typer.confirm(prompt, default=False)
+
+
+def _display_pairing_code(passkey: int) -> None:
+    typer.echo(f"Bluetooth pairing code: {passkey:06d}")
 
 
 def run_wizard(*, verify_after: bool = True) -> int:
@@ -27,6 +37,34 @@ def run_wizard(*, verify_after: bool = True) -> int:
     )
 
     setup = SetupClient()
+    try:
+        configuration = setup.configuration()
+    except PairingError as error:
+        typer.echo(typer.style(str(error), fg=typer.colors.RED))
+        return 1
+    if configuration.saved:
+        typer.echo(
+            typer.style(
+                f"\nBlueFerry already has {configuration.mac} configured.",
+                fg=typer.colors.YELLOW,
+            )
+        )
+        typer.echo("Before answering Yes, forget this PC on the iPhone too:")
+        typer.echo("Settings → Bluetooth → (i) next to this PC → Forget This Device")
+        if not typer.confirm(
+            "Forget BlueFerry's configured target and start fresh?",
+            default=False,
+        ):
+            typer.echo("Existing pairing and configuration left unchanged.")
+            return 0
+        try:
+            setup.forget(configuration.mac)
+        except PairingError as error:
+            typer.echo(typer.style(str(error), fg=typer.colors.RED))
+            return 1
+        typer.echo(typer.style("✓ Previous target forgotten", fg=typer.colors.GREEN))
+        configuration = setup.configuration()
+
     try:
         compatibility = setup.compatibility()
     except PairingError as error:
@@ -80,7 +118,7 @@ def run_wizard(*, verify_after: bool = True) -> int:
     candidates = iphone_candidates(
         devices,
         adapter=compatibility.adapter,
-        configured_mac=setup.configuration().mac,
+        configured_mac=configuration.mac,
         include_unpaired=True,
     )
     if not candidates:
@@ -124,7 +162,11 @@ def run_wizard(*, verify_after: bool = True) -> int:
 
     typer.echo("\nActivating Bluetooth, then starting secure pairing…")
     try:
-        result = setup.complete(chosen.mac)
+        result = setup.complete(
+            chosen.mac,
+            confirmation=_confirm_pairing,
+            display=_display_pairing_code,
+        )
     except PairingError as error:
         typer.echo(typer.style(str(error), fg=typer.colors.RED))
         return 1
@@ -195,23 +237,20 @@ def _print_iphone_steps(
     typer.echo(typer.style("\n=== On the iPhone ===\n", fg=typer.colors.CYAN, bold=True))
     typer.echo("  1. Open Settings → Bluetooth")
     typer.echo("  2. Tap the (i) next to your computer's name in My Devices")
-    labels = {
-        MESSAGE_NOTIFICATIONS: "Enable: Show Message Notifications",
-        CONTACTS: "Enable: Sync Contacts",
-        NOTIFICATION_ACCESS: "Allow Notification Access when prompted",
-    }
-    for number, task in enumerate(remaining, 3):
-        typer.echo(
-            typer.style(
-                f"  {number}. {labels[task]}",
-                fg=typer.colors.WHITE,
-                bold=True,
-            )
+    typer.echo("  3. Allow Notification Access when prompted")
+    typer.echo(
+        typer.style(
+            "  4. Toggle on Show Message Notifications and Sync Contacts",
+            fg=typer.colors.WHITE,
+            bold=True,
         )
+    )
+    typer.echo("     Note: You may need to back out and tap the (i) again to make")
+    typer.echo("     these toggles appear.")
     if NOTIFICATION_ACCESS in remaining:
         typer.echo("\nANCS notification access is negotiated during pairing. Some")
         typer.echo("iOS versions do not show a separate system-notification toggle.")
-    typer.echo("If an expected toggle is missing, run `blueferry doctor` before re-pairing.")
+    typer.echo("If the toggles still do not appear, run `blueferry doctor` before re-pairing.")
 
     ancs_uuid = "7905f431-b5ce-4e99-a40f-4b1e122d00d0"
     if not notifications_supported:

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -250,6 +250,11 @@ def _print_iphone_steps(
     if NOTIFICATION_ACCESS in remaining:
         typer.echo("\nANCS notification access is negotiated during pairing. Some")
         typer.echo("iOS versions do not show a separate system-notification toggle.")
+    if NOTIFICATION_ACCESS in remaining or not notifications_supported:
+        typer.echo(
+            "Without System Notification access, group texts appear as "
+            "individual conversations with their sender."
+        )
     typer.echo("If the toggles still do not appear, run `blueferry doctor` before re-pairing.")
 
     ancs_uuid = "7905f431-b5ce-4e99-a40f-4b1e122d00d0"

--- a/src/blueferry/profile_supervisor.py
+++ b/src/blueferry/profile_supervisor.py
@@ -68,6 +68,7 @@ class ProfileSupervisor:
         on_ready: Callable[[], None],
         on_lost: Callable[[str], None],
         on_status: Callable[[], None],
+        on_first_attempt_complete: Callable[[], None] | None = None,
         schedule: Schedule = GLib.timeout_add_seconds,
         cancel: Cancel = GLib.source_remove,
     ) -> None:
@@ -77,6 +78,7 @@ class ProfileSupervisor:
         self._on_ready = on_ready
         self._on_lost = on_lost
         self._on_status = on_status
+        self._on_first_attempt_complete = on_first_attempt_complete
         self._schedule = schedule
         self._cancel = cancel
         self._retry_id: int | None = None
@@ -86,6 +88,7 @@ class ProfileSupervisor:
         self._ever_ready = False
         self._stopping = False
         self._generation = 0
+        self._first_attempt_completed = False
         self.sessions.set_on_lost(self.session_lost)
 
     @property
@@ -164,6 +167,7 @@ class ProfileSupervisor:
         if self._stopping or generation != self._generation or self._closing:
             return
         self._opening = False
+        self._complete_first_attempt()
         log.info("MAP/PBAP sessions opened")
         self._mark_ready()
 
@@ -186,6 +190,7 @@ class ProfileSupervisor:
         if self._stopping or generation != self._generation:
             return
         self._opening = False
+        self._complete_first_attempt()
         message = str(error)
         log.warning("could not open MAP/PBAP sessions: %s", message)
         authorization_required = isinstance(error, SessionError) and (
@@ -207,6 +212,13 @@ class ProfileSupervisor:
         )
         self._on_status()
         self._schedule_retry(delay)
+
+    def _complete_first_attempt(self) -> None:
+        if self._first_attempt_completed:
+            return
+        self._first_attempt_completed = True
+        if self._on_first_attempt_complete is not None:
+            self._on_first_attempt_complete()
 
     def _closed(self, generation: int) -> None:
         if self._stopping or generation != self._generation:

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -552,7 +552,11 @@ class BridgeController(QObject):
             _ = passkey
 
         self._run(
-            lambda: self._setup.complete(
+            # PairingAgent callbacks require a dispatching GLib D-Bus loop.
+            # Qt setup work runs on a worker whose private dbus-python
+            # connection deliberately uses NULL_MAIN_LOOP, so host the agent
+            # in the same isolated helper used by the GTK client.
+            lambda: self._setup.complete_isolated(
                 mac,
                 confirmation=confirm,
                 display=display,

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -80,8 +80,13 @@ Kirigami.ApplicationWindow {
 
     function pendingIphoneSetupText() {
         const tasks = pendingIphoneSetupTasks()
-        return qsTr("Open Settings → Bluetooth on the iPhone, tap ⓘ next to this computer, then finish the settings below. After approving “Allow System Notifications,” you may need to return to the Bluetooth device list and reopen this computer before the other settings appear:\n• ")
+        let detail = qsTr("Open Settings → Bluetooth on the iPhone, tap ⓘ next to this computer, then finish the settings below. After approving “Allow System Notifications,” you may need to return to the Bluetooth device list and reopen this computer before the other settings appear:\n• ")
             + tasks.join("\n• ")
+        const verified = bridge.status.verified_iphone_setup || []
+        if (bridge.compatibility.notifications_supported
+                && verified.indexOf("notification-access") < 0)
+            detail += qsTr("\n\nWithout System Notification access, group texts appear as individual conversations with their sender.")
+        return detail
     }
 
     function openPhoneSettings() {
@@ -129,11 +134,11 @@ Kirigami.ApplicationWindow {
             "checking": qsTr("Inspecting the selected Bluetooth controller without changing it."),
             "incompatible": bridge.compatibility.issue || qsTr("A controller with BR/EDR and secure pairing is required."),
             "activate-bluetooth": qsTr("The packaged BlueZ bearer support needs one authorized Bluetooth restart."),
-            "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds."),
+            "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."),
             "starting": qsTr("The configured backend is starting. This normally takes a few seconds."),
             "iphone-settings": pendingIphoneSetupText(),
             "ready": qsTr("Bluetooth services and iPhone permissions have been verified."),
-            "ready-without-ancs": qsTr("Messages and contacts have been verified; per-app notifications are unavailable.")
+            "ready-without-ancs": qsTr("Messages and contacts have been verified. System notifications are unavailable, so group texts may appear as individual conversations.")
         }
         return details[stage] || ""
     }

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -54,7 +54,10 @@ class IPhonePage(Gtk.Box):
                 "Scan for and select your iPhone here, then choose Pair. On the "
                 "iPhone, open Settings → Bluetooth, find this computer under "
                 '"Other Devices", tap it, and approve the matching codes. Pairing '
-                "may appear idle for up to 15 seconds."
+                "may appear idle for up to 15 seconds. System Notification "
+                "access is also how BlueFerry recognizes group text threads; "
+                "without it, a group text appears as a one-to-one conversation "
+                "with its sender."
             ),
         )
         self._device_model = Gtk.StringList()
@@ -167,7 +170,10 @@ class IPhonePage(Gtk.Box):
             (
                 NOTIFICATION_ACCESS,
                 _("Notification Access"),
-                _("Authorized during pairing; some iOS versions show no separate toggle"),
+                _(
+                    "Required for system notifications and group text identification; "
+                    "without it, groups look like individual conversations"
+                ),
             ),
         ):
             row = Adw.ActionRow(title=item, subtitle=sub)

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -5,7 +5,7 @@ import struct
 
 from blueferry.ancs import client as client_module
 from blueferry.ancs.client import AncsClient
-from blueferry.ancs.constants import CommandID, EventFlag, EventID
+from blueferry.ancs.constants import MESSAGES_APP_ID, CommandID, EventFlag, EventID
 from blueferry.ancs.parsers import Notification
 
 
@@ -43,6 +43,21 @@ def _complete_full_response(
         + _attribute(1, "Alice")
         + _attribute(2, "To you & Bob")
         + _attribute(3, "hello")
+    )
+    client._on_ds_changed(
+        "org.bluez.GattCharacteristic1", {"Value": response}, []
+    )
+
+
+def _complete_authorization_probe(client: AncsClient) -> None:
+    request = client._active_request
+    assert request is not None
+    assert request.authorization_probe is True
+    response = (
+        bytes([CommandID.GetAppAttributes])
+        + MESSAGES_APP_ID.encode()
+        + b"\0"
+        + _attribute(0, "Messages")
     )
     client._on_ds_changed(
         "org.bluez.GattCharacteristic1", {"Value": response}, []
@@ -239,6 +254,7 @@ def test_characteristic_removal_discards_all_characteristic_receivers(
 
 def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
     scheduled = []
+    writes = []
 
     class _Characteristic:
         def __init__(self, *, fail_once: bool = False) -> None:
@@ -257,11 +273,23 @@ def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
         def StopNotify(self, **_kwargs) -> None:
             pass
 
+        def WriteValue(self, value, _options, **_kwargs) -> None:
+            writes.append(bytes(value))
+
     ns = _Characteristic(fail_once=True)
     ds = _Characteristic()
-    bus = _CharacteristicBus({"/device/ns": ns, "/device/ds": ds})
+    cp = _Characteristic()
+    bus = _CharacteristicBus(
+        {"/device/ns": ns, "/device/ds": ds, "/device/cp": cp}
+    )
     monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
     monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda _delay, _callback: 9,
+    )
+    monkeypatch.setattr(client_module.GLib, "source_remove", lambda _timer: None)
     client = AncsClient(
         "/device",
         lambda _event: None,
@@ -280,6 +308,57 @@ def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
 
     scheduled[0][1]()
 
+    assert client.connected is False
+    assert len(writes) == 1
+    _complete_authorization_probe(client)
     assert client.connected is True
     assert ns.start_calls == 2
     assert ds.start_calls == 1
+
+
+def test_control_point_failure_keeps_ancs_unready_and_retries(
+    monkeypatch, caplog,
+) -> None:
+    scheduled = []
+
+    class _ControlPoint:
+        def __init__(self) -> None:
+            self.fail = True
+
+        def WriteValue(self, _value, _options, **_kwargs) -> None:
+            if self.fail:
+                self.fail = False
+                raise client_module.dbus.exceptions.DBusException(
+                    "Insufficient authorization",
+                    name="org.bluez.Error.Failed",
+                )
+
+    cp = _ControlPoint()
+    bus = _CharacteristicBus({"/device/cp": cp})
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda _delay, _callback: 9,
+    )
+    monkeypatch.setattr(client_module.GLib, "source_remove", lambda _timer: None)
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    client._started = True
+    client._notify_started = True
+    client._cp_path = "/device/cp"
+
+    client._queue_authorization_probe()
+
+    assert client.connected is False
+    assert scheduled[0][0] == client_module.AUTHORIZATION_RETRY_SECONDS
+    assert "org.bluez.Error.Failed: Insufficient authorization" in caplog.text
+
+    scheduled[0][1]()
+    assert client.connected is False
+    _complete_authorization_probe(client)
+    assert client.connected is True

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import logging
+
 from blueferry.bearer_supervisor import BearerSupervisor
 
 
-def test_connects_classic_before_le() -> None:
+def test_connects_classic_before_le(caplog) -> None:
     state = {"bredr": False, "le": False}
     connections = []
     scheduled = []
+    caplog.set_level(logging.DEBUG, logger="blueferry.bearer_supervisor")
 
     def connect(kind, on_success, _on_error):
         connections.append(kind)
@@ -35,6 +38,10 @@ def test_connects_classic_before_le() -> None:
     state["le"] = True
     scheduled[0][1]()
     assert supervisor.snapshot() == {"bredr": True, "le": True}
+    assert "probing iPhone BR/EDR and LE bearer state" in caplog.text
+    assert "iPhone BREDR bearer state: disconnected" in caplog.text
+    assert "iPhone BREDR bearer state: connected" in caplog.text
+    assert "iPhone LE bearer state: connected" in caplog.text
 
 
 def test_le_is_not_connected_if_classic_drops_during_settling() -> None:

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+from blueferry import bearer_supervisor
 from blueferry.bearer_supervisor import BearerSupervisor
 
 
@@ -66,6 +67,86 @@ def test_le_is_not_connected_if_classic_drops_during_settling() -> None:
 
     assert connections == ["bredr"]
     assert "le" not in connections
+
+
+def test_le_can_be_held_until_classic_profile_attempt_finishes() -> None:
+    state = {"bredr": True, "le": False}
+    connections = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        le_enabled=False,
+        read_connected=state.get,
+        connect=lambda kind, on_success, _on_error: (
+            connections.append(kind),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+
+    supervisor.start()
+    assert connections == []
+    assert [delay for delay, _callback in scheduled] == [5]
+
+    supervisor.enable_le()
+    assert [delay for delay, _callback in scheduled] == [5, 3]
+    scheduled[-1][1]()
+    assert connections == ["le"]
+
+
+def test_selects_each_bearer_before_requesting_its_connection() -> None:
+    state = {"bredr": False, "le": False}
+    calls = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        prefer=lambda kind: calls.append(("prefer", kind)),
+        connect=lambda kind, on_success, _on_error: (
+            calls.append(("connect", kind)),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+
+    supervisor.start()
+    assert calls == [("prefer", "bredr"), ("connect", "bredr")]
+
+    state["bredr"] = True
+    scheduled[0][1]()
+    scheduled[1][1]()
+    assert calls[-2:] == [("prefer", "le"), ("connect", "le")]
+
+
+def test_bluez_preference_selects_requested_bearer(monkeypatch) -> None:
+    calls = []
+
+    class Properties:
+        @staticmethod
+        def Set(interface, name, value, *, timeout):
+            calls.append((interface, name, str(value), timeout))
+
+    class Bus:
+        @staticmethod
+        def get_object(service, path):
+            calls.append((service, path))
+            return object()
+
+    monkeypatch.setattr(bearer_supervisor, "get_system_bus", Bus)
+    monkeypatch.setattr(
+        bearer_supervisor.dbus,
+        "Interface",
+        lambda _object, interface: calls.append(("interface", interface)) or Properties(),
+    )
+    supervisor = BearerSupervisor("/device")
+
+    supervisor._prefer_bluez("le")
+
+    assert calls == [
+        ("org.bluez", "/device"),
+        ("interface", "org.freedesktop.DBus.Properties"),
+        ("org.bluez.Device1", "PreferredBearer", "le", 5.0),
+    ]
 
 
 def test_failed_connection_is_retried_after_backoff() -> None:

--- a/tests/test_cli_pairing.py
+++ b/tests/test_cli_pairing.py
@@ -7,7 +7,22 @@ from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
-from blueferry import cli, setup_client
+from blueferry import cli, pairing_cli, setup_client
+
+
+def test_pair_setup_debug_enables_diagnostic_logging(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "_setup_logging", lambda enabled: calls.append(("debug", enabled)))
+    monkeypatch.setattr(
+        pairing_cli,
+        "run_wizard",
+        lambda *, verify_after: calls.append(("wizard", verify_after)) or 0,
+    )
+
+    result = CliRunner().invoke(cli.app, ["pair-setup", "--debug", "--no-verify"])
+
+    assert result.exit_code == 0
+    assert calls == [("debug", True), ("wizard", False)]
 
 
 def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -162,6 +162,41 @@ def test_clearing_saved_target_stops_daemon_without_restart(monkeypatch):
     assert stopped == [True]
 
 
+def test_removing_bond_stops_active_daemon_without_restart(monkeypatch):
+    instance = _bare_daemon()
+    stopped = []
+    monkeypatch.setattr(
+        daemon_mod.config,
+        "current_target",
+        lambda: ("02:00:00:00:00:01", "hci0"),
+    )
+    monkeypatch.setattr(daemon_mod.config, "IPHONE_MAC", "02:00:00:00:00:01")
+    monkeypatch.setattr(daemon_mod.config, "ADAPTER", "hci0")
+    monkeypatch.setattr(daemon_mod, "bond_status", lambda *_args: False)
+    monkeypatch.setattr(daemon_mod.main_loop, "quit", lambda: stopped.append(True))
+
+    assert instance._check_target_config() is False
+    assert instance._restart_after_upgrade is False
+    assert stopped == [True]
+
+
+def test_transient_bond_inspection_failure_keeps_daemon_running(monkeypatch):
+    instance = _bare_daemon()
+    stopped = []
+    monkeypatch.setattr(
+        daemon_mod.config,
+        "current_target",
+        lambda: ("02:00:00:00:00:01", "hci0"),
+    )
+    monkeypatch.setattr(daemon_mod.config, "IPHONE_MAC", "02:00:00:00:00:01")
+    monkeypatch.setattr(daemon_mod.config, "ADAPTER", "hci0")
+    monkeypatch.setattr(daemon_mod, "bond_status", lambda *_args: None)
+    monkeypatch.setattr(daemon_mod.main_loop, "quit", lambda: stopped.append(True))
+
+    assert instance._check_target_config() is True
+    assert stopped == []
+
+
 def test_changing_saved_target_requests_restart(monkeypatch):
     instance = _bare_daemon()
     stopped = []

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import stat
 
 import pytest
@@ -510,10 +511,11 @@ def test_classic_connect_requires_observable_settled_connection(monkeypatch):
     ]
 
 
-def test_ancs_retries_local_abort_after_classic_resettles(monkeypatch):
+def test_ancs_retries_local_abort_after_classic_resettles(monkeypatch, caplog):
     device = _device(paired=True)
     connects = []
     settled = []
+    caplog.set_level(logging.DEBUG, logger="blueferry.pair_setup")
 
     class Manager:
         @staticmethod
@@ -563,6 +565,11 @@ def test_ancs_retries_local_abort_after_classic_resettles(monkeypatch):
     assert pair_setup._connect_ancs(device) == "connected"
     assert len(connects) == 2
     assert settled == [device.device_path]
+    assert "LE bearer probe: paired=False bonded=False connected=False" in caplog.text
+    assert "sending Bearer.LE1.Connect (attempt 1/2)" in caplog.text
+    assert "le-connection-abort-by-local" in caplog.text
+    assert "sending Bearer.LE1.Connect (attempt 2/2)" in caplog.text
+    assert "LE bearer connected" in caplog.text
 
 
 def test_complete_pairing_headless_pairs_from_linux(monkeypatch):
@@ -636,21 +643,40 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
     _compatible(monkeypatch)
     monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
     monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(bluez_setup, "unregister_advert", lambda _adapter: None)
-    monkeypatch.setattr(pairing_agent, "RegisteredPairingAgent", Agent)
     monkeypatch.setattr(
-        pairing_agent, "desktop_pairing_manager_present", lambda: False
+        bluez_setup,
+        "unregister_advert",
+        lambda _adapter: calls.append("advert-exit"),
     )
+    monkeypatch.setattr(pairing_agent, "RegisteredPairingAgent", Agent)
 
     def connect_classic(path, **kwargs):
         if "timeout" in kwargs:
             calls.append(("connect", path, kwargs["timeout"]))
+        else:
+            calls.append(("post-pair-connect", path))
 
     monkeypatch.setattr(pair_setup, "_connect_classic", connect_classic)
-    monkeypatch.setattr(pair_setup, "_connect_ancs", lambda _device: "connected")
-    monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: None)
-    monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: None)
-    monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: None)
+    monkeypatch.setattr(
+        pair_setup,
+        "_connect_ancs",
+        lambda _device: calls.append("ancs") or "connected",
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "trust_device",
+        lambda *_args: calls.append("trust"),
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "write_local_env",
+        lambda *_args: calls.append("persist"),
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_restart_user_service",
+        lambda: calls.append("daemon"),
+    )
 
     pair_setup.complete_pairing(
         unpaired.mac,
@@ -659,63 +685,23 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
     )
 
     # Connecting the unpaired ACL makes iOS initiate pairing (and derive the
-    # LE keys); there must be no competing Linux-side Device1.Pair() call,
-    # and the agent must be alive before the connect provokes iOS.
+    # LE keys); there must be no competing Linux-side Device1.Pair() call.
+    # Keep our agent default until the Classic-to-LE handoff finishes so a
+    # restored desktop agent cannot race the remainder of the transaction.
     assert calls == [
         ("agent", unpaired.device_path, confirmation, display),
         "agent-enter",
         ("connect", unpaired.device_path, 60.0),
         ("wait", 120.0),
-        "agent-exit",
         "settled",
+        "trust",
+        ("post-pair-connect", unpaired.device_path),
+        "ancs",
+        "advert-exit",
+        "agent-exit",
+        "persist",
+        "daemon",
     ]
-
-
-def test_interactive_pairing_uses_device_pair_with_desktop_manager(monkeypatch):
-    from blueferry import pairing_agent
-
-    unpaired = _device(paired=False)
-    paired = _device(paired=True)
-    calls = []
-
-    class DeviceInterface:
-        def Pair(self, **kwargs):
-            calls.append(("pair", kwargs["timeout"]))
-
-    class Bus:
-        @staticmethod
-        def get_object(*_args):
-            return object()
-
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: unpaired)
-    monkeypatch.setattr(pair_setup, "_wait_for_paired_device", lambda _mac: paired)
-    _compatible(monkeypatch)
-    monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
-    monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
-    monkeypatch.setattr(bluez_setup, "unregister_advert", lambda _adapter: None)
-    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
-    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: DeviceInterface())
-    monkeypatch.setattr(
-        pairing_agent, "desktop_pairing_manager_present", lambda: True
-    )
-    monkeypatch.setattr(
-        pairing_agent,
-        "RegisteredPairingAgent",
-        lambda *_args: (_ for _ in ()).throw(AssertionError("agent must not register")),
-    )
-    monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: None)
-    monkeypatch.setattr(pair_setup, "_connect_classic", lambda _path: None)
-    monkeypatch.setattr(pair_setup, "_connect_ancs", lambda _device: "connected")
-    monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: None)
-    monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: None)
-
-    result = pair_setup.complete_pairing(
-        unpaired.mac,
-        confirmation=lambda _passkey: True,
-    )
-
-    assert calls == [("pair", 120.0)]
-    assert result["ok"] is True
 
 
 def test_peer_initiated_pairing_is_allowed_to_finish(monkeypatch):

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -429,9 +429,17 @@ def _compatible(monkeypatch, *, notifications: bool = True) -> None:
             "bearer_api_active": True,
         },
     )
+    monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
+    monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
+    monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path: None)
+    monkeypatch.setattr(
+        pair_setup,
+        "_wait_for_daemon_transports",
+        lambda: (True, True, True),
+    )
 
 
-def test_complete_pairing_advertises_only_after_bond_then_hands_to_daemon(monkeypatch):
+def test_complete_pairing_starts_profiles_while_pairing_advert_is_active(monkeypatch):
     device = _device(paired=True)
     calls = []
     monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
@@ -452,12 +460,16 @@ def test_complete_pairing_advertises_only_after_bond_then_hands_to_daemon(monkey
         lambda adapter: calls.append(("unregister", adapter)),
     )
     monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: calls.append("trust"))
+    monkeypatch.setattr(
+        pair_setup,
+        "_prefer_bredr",
+        lambda path: calls.append(("prefer-bredr", path)),
+    )
     monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: calls.append("config"))
     monkeypatch.setattr(
-        pair_setup, "_connect_classic", lambda _path: calls.append("classic-connect")
-    )
-    monkeypatch.setattr(
-        pair_setup, "_connect_ancs", lambda _device: calls.append("ancs") or "connected"
+        pair_setup,
+        "_wait_for_classic_settled",
+        lambda path: calls.append(("classic-settled", path)),
     )
     monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: calls.append("restart"))
 
@@ -469,12 +481,12 @@ def test_complete_pairing_advertises_only_after_bond_then_hands_to_daemon(monkey
     assert calls == [
         ("prepare_classic", "hci0"),
         "trust",
-        "classic-connect",
+        ("prefer-bredr", device.device_path),
+        ("classic-settled", device.device_path),
         ("advert", "hci0"),
-        "ancs",
-        ("unregister", "hci0"),
         "config",
         "restart",
+        ("unregister", "hci0"),
     ]
 
 
@@ -508,6 +520,68 @@ def test_classic_connect_requires_observable_settled_connection(monkeypatch):
     assert calls == [
         "connect",
         ("settled", "/org/bluez/hci0/dev_02_00_00_00_00_01", 1.0),
+    ]
+
+
+def test_post_pair_bearer_preference_is_forced_to_bredr(monkeypatch):
+    calls = []
+
+    class Properties:
+        @staticmethod
+        def Set(interface, name, value):
+            calls.append((interface, name, str(value)))
+
+    class Bus:
+        @staticmethod
+        def get_object(service, path):
+            calls.append((service, path))
+            return object()
+
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(
+        pair_setup.dbus,
+        "Interface",
+        lambda _obj, interface: (
+            calls.append(("interface", interface)) or Properties()
+        ),
+    )
+
+    pair_setup._prefer_bredr("/org/bluez/hci0/dev_02_00_00_00_00_01")
+
+    assert calls == [
+        ("org.bluez", "/org/bluez/hci0/dev_02_00_00_00_00_01"),
+        ("interface", "org.freedesktop.DBus.Properties"),
+        ("org.bluez.Device1", "PreferredBearer", "bredr"),
+    ]
+
+
+def test_obex_mns_is_activated_before_pairing(monkeypatch):
+    calls = []
+
+    class Peer:
+        @staticmethod
+        def Ping(*, timeout):
+            calls.append(("ping", timeout))
+
+    class Bus:
+        @staticmethod
+        def get_object(service, path):
+            calls.append((service, path))
+            return object()
+
+    monkeypatch.setattr(pair_setup, "get_session_bus", Bus)
+    monkeypatch.setattr(
+        pair_setup.dbus,
+        "Interface",
+        lambda _object, interface: calls.append(("interface", interface)) or Peer(),
+    )
+
+    pair_setup._activate_obex_mns()
+
+    assert calls == [
+        ("org.bluez.obex", "/org/bluez/obex"),
+        ("interface", "org.freedesktop.DBus.Peer"),
+        ("ping", 10.0),
     ]
 
 
@@ -595,8 +669,6 @@ def test_complete_pairing_headless_pairs_from_linux(monkeypatch):
     monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
     monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: DeviceInterface())
     monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: None)
-    monkeypatch.setattr(pair_setup, "_connect_classic", lambda _path: None)
-    monkeypatch.setattr(pair_setup, "_connect_ancs", lambda _device: "connected")
     monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: None)
     monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: None)
 
@@ -651,21 +723,23 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
     monkeypatch.setattr(pairing_agent, "RegisteredPairingAgent", Agent)
 
     def connect_classic(path, **kwargs):
-        if "timeout" in kwargs:
-            calls.append(("connect", path, kwargs["timeout"]))
-        else:
-            calls.append(("post-pair-connect", path))
+        calls.append(("connect", path, kwargs["timeout"]))
 
     monkeypatch.setattr(pair_setup, "_connect_classic", connect_classic)
     monkeypatch.setattr(
         pair_setup,
-        "_connect_ancs",
-        lambda _device: calls.append("ancs") or "connected",
+        "_wait_for_classic_settled",
+        lambda path: calls.append(("classic-settled", path)),
     )
     monkeypatch.setattr(
         pair_setup,
         "trust_device",
         lambda *_args: calls.append("trust"),
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_prefer_bredr",
+        lambda path: calls.append(("prefer-bredr", path)),
     )
     monkeypatch.setattr(
         pair_setup,
@@ -686,8 +760,8 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
 
     # Connecting the unpaired ACL makes iOS initiate pairing (and derive the
     # LE keys); there must be no competing Linux-side Device1.Pair() call.
-    # Keep our agent default until the Classic-to-LE handoff finishes so a
-    # restored desktop agent cannot race the remainder of the transaction.
+    # Keep our agent default while the daemon makes the first MAP/PBAP attempt
+    # and only then enables LE.
     assert calls == [
         ("agent", unpaired.device_path, confirmation, display),
         "agent-enter",
@@ -695,12 +769,12 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
         ("wait", 120.0),
         "settled",
         "trust",
-        ("post-pair-connect", unpaired.device_path),
-        "ancs",
-        "advert-exit",
-        "agent-exit",
+        ("prefer-bredr", paired.device_path),
+        ("classic-settled", paired.device_path),
         "persist",
         "daemon",
+        "advert-exit",
+        "agent-exit",
     ]
 
 
@@ -731,8 +805,6 @@ def test_peer_initiated_pairing_is_allowed_to_finish(monkeypatch):
     monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
     monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: DeviceInterface())
     monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: None)
-    monkeypatch.setattr(pair_setup, "_connect_classic", lambda _path: None)
-    monkeypatch.setattr(pair_setup, "_connect_ancs", lambda _device: "connected")
     monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: None)
     monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: None)
 
@@ -742,7 +814,7 @@ def test_peer_initiated_pairing_is_allowed_to_finish(monkeypatch):
     assert result["ok"] is True
 
 
-def test_pairing_does_not_save_or_start_daemon_when_ancs_is_missing(monkeypatch):
+def test_pairing_starts_daemon_even_when_ancs_is_still_missing(monkeypatch):
     device = _device(paired=True)
     device.uuids = frozenset()
     monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
@@ -754,22 +826,22 @@ def test_pairing_does_not_save_or_start_daemon_when_ancs_is_missing(monkeypatch)
     saved = []
     restarted = []
     monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: saved.append(True))
-    monkeypatch.setattr(pair_setup, "_connect_classic", lambda _path: None)
-
-    def no_le(_device):
-        raise pair_setup.PairingError("LE bond missing")
-
-    monkeypatch.setattr(pair_setup, "_connect_ancs", no_le)
+    monkeypatch.setattr(
+        pair_setup,
+        "_wait_for_daemon_transports",
+        lambda: (True, True, False),
+    )
     monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: restarted.append(True))
 
-    with pytest.raises(pair_setup.PairingError, match="iPhone was not saved"):
-        pair_setup.complete_pairing(device.mac)
+    result = pair_setup.complete_pairing(device.mac)
 
-    assert saved == []
-    assert restarted == []
+    assert saved == [True]
+    assert restarted == [True]
+    assert result["ancs"] == "daemon connecting"
+    assert result["ancs_ready"] is False
 
 
-def test_pairing_does_not_save_while_waiting_for_inbound_ancs(monkeypatch):
+def test_pairing_does_not_gate_map_on_inbound_ancs(monkeypatch):
     device = _device(paired=True)
     monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
     _compatible(monkeypatch)
@@ -777,19 +849,19 @@ def test_pairing_does_not_save_while_waiting_for_inbound_ancs(monkeypatch):
     monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(bluez_setup, "unregister_advert", lambda _adapter: None)
     monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: None)
-    monkeypatch.setattr(pair_setup, "_connect_classic", lambda _path: None)
     monkeypatch.setattr(
         pair_setup,
-        "_connect_ancs",
-        lambda _device: "waiting for iPhone to connect",
+        "_wait_for_daemon_transports",
+        lambda: (False, False, False),
     )
     saved = []
     monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: saved.append(True))
+    monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: None)
 
-    with pytest.raises(pair_setup.PairingError, match="iPhone was not saved"):
-        pair_setup.complete_pairing(device.mac)
+    result = pair_setup.complete_pairing(device.mac)
 
-    assert saved == []
+    assert saved == [True]
+    assert result["ancs_ready"] is False
 
 
 def test_pairing_rejects_controller_without_ancs_before_saving_target(monkeypatch):

--- a/tests/test_pairing_agent.py
+++ b/tests/test_pairing_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 
 import dbus
@@ -89,63 +90,86 @@ def test_agent_rejects_requests_for_any_other_device():
     assert raised.value.get_dbus_name() == "org.bluez.Error.Rejected"
 
 
-def test_gnome_shell_is_recognized_as_desktop_pairing_manager():
-    class Bus:
-        @staticmethod
-        def list_names():
-            return ["org.gnome.Shell", "org.bluez.obex"]
-
-    assert pairing_agent.desktop_pairing_manager_present(Bus()) is True
-
-
-def test_kde_requires_loaded_bluedevil_module(monkeypatch):
-    class Bus:
-        @staticmethod
-        def list_names():
-            return ["org.kde.kded6"]
-
-        @staticmethod
-        def get_object(*_args):
-            return object()
-
-    class Kded:
-        @staticmethod
-        def loadedModules(**_kwargs):
-            return ["networkmanagement", "bluedevil"]
-
-    monkeypatch.setattr(pairing_agent.dbus, "Interface", lambda *_args: Kded())
-
-    assert pairing_agent.desktop_pairing_manager_present(Bus()) is True
-
-
-def test_headless_bluez_services_are_not_treated_as_interactive_manager():
-    class Bus:
-        @staticmethod
-        def list_names():
-            return ["org.bluez.obex", "io.weirdware.BlueFerry"]
-
-    assert pairing_agent.desktop_pairing_manager_present(Bus()) is False
-
-
-def test_registered_agent_does_not_displace_desktop_default():
+def test_registered_agent_is_default_only_for_context_lifetime(caplog):
     calls = []
+    caplog.set_level(logging.DEBUG, logger="blueferry.pairing_agent")
 
     class Manager:
         def RegisterAgent(self, path, capability, **kwargs):
             calls.append(("register", str(path), capability, kwargs["timeout"]))
 
         def RequestDefaultAgent(self, path, **kwargs):
-            raise AssertionError(f"must not take default-agent ownership: {path} {kwargs}")
+            calls.append(("default", str(path), kwargs["timeout"]))
+
+        def UnregisterAgent(self, path, **kwargs):
+            calls.append(("unregister", str(path), kwargs["timeout"]))
+
+    class Agent:
+        def remove_from_connection(self):
+            calls.append("removed")
 
     registered = pairing_agent.RegisteredPairingAgent.__new__(
         pairing_agent.RegisteredPairingAgent
     )
     registered._manager = Manager()
-    registered._agent = object()
+    registered._agent = Agent()
     registered._registered = False
+    registered._expected_device = "/device"
 
-    assert registered.__enter__() is registered
-    assert calls == [("register", pairing_agent.AGENT_PATH, "DisplayYesNo", 10.0)]
+    with registered:
+        calls.append("pairing")
+
+    assert calls == [
+        ("register", pairing_agent.AGENT_PATH, "DisplayYesNo", 10.0),
+        ("default", pairing_agent.AGENT_PATH, 10.0),
+        "pairing",
+        ("unregister", pairing_agent.AGENT_PATH, 10.0),
+        "removed",
+    ]
+    assert registered._registered is False
+    assert "registering device-scoped pairing agent" in caplog.text
+    assert "pairing agent is now the BlueZ default" in caplog.text
+    assert "restoring previous default" in caplog.text
+
+
+def test_registered_agent_cleans_up_when_default_request_fails():
+    calls = []
+
+    class Manager:
+        def RegisterAgent(self, path, _capability, **_kwargs):
+            calls.append(("register", str(path)))
+
+        def RequestDefaultAgent(self, path, **_kwargs):
+            calls.append(("default", str(path)))
+            raise dbus.exceptions.DBusException(
+                "not authorized", name="org.bluez.Error.Rejected"
+            )
+
+        def UnregisterAgent(self, path, **_kwargs):
+            calls.append(("unregister", str(path)))
+
+    class Agent:
+        def remove_from_connection(self):
+            calls.append("removed")
+
+    registered = pairing_agent.RegisteredPairingAgent.__new__(
+        pairing_agent.RegisteredPairingAgent
+    )
+    registered._manager = Manager()
+    registered._agent = Agent()
+    registered._registered = False
+    registered._expected_device = "/device"
+
+    with pytest.raises(pairing_agent.PairingError, match="not authorized"):
+        registered.__enter__()
+
+    assert calls == [
+        ("register", pairing_agent.AGENT_PATH),
+        ("default", pairing_agent.AGENT_PATH),
+        ("unregister", pairing_agent.AGENT_PATH),
+        "removed",
+    ]
+    assert registered._registered is False
 
 
 def test_registered_agent_cleans_up_when_registration_fails():
@@ -171,6 +195,7 @@ def test_registered_agent_cleans_up_when_registration_fails():
     registered._manager = Manager()
     registered._agent = Agent()
     registered._registered = False
+    registered._expected_device = "/device"
 
     with pytest.raises(pairing_agent.PairingError):
         registered.__enter__()

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -33,6 +33,20 @@ def test_cli_setup_always_prints_required_bluetooth_toggles(capsys) -> None:
     assert "Show Message Notifications" in output
 
 
+def test_cli_explains_group_threads_need_notification_access(capsys) -> None:
+    _print_iphone_steps(
+        frozenset(),
+        remaining=("notification-access",),
+        notifications_supported=True,
+        ancs_ready=False,
+    )
+
+    assert (
+        "Without System Notification access, group texts appear as individual "
+        "conversations with their sender."
+    ) in capsys.readouterr().out
+
+
 def test_cli_just_works_pairing_still_requires_confirmation(monkeypatch) -> None:
     prompts = []
     monkeypatch.setattr(

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -1,3 +1,7 @@
+from types import SimpleNamespace
+
+from blueferry import pairing_cli
+from blueferry.bluetooth_devices import PairedDevice
 from blueferry.pairing_cli import _print_iphone_steps
 from blueferry.setup_verification import CONTACTS
 
@@ -13,7 +17,7 @@ def test_verified_cli_setup_omits_the_iphone_section(capsys) -> None:
     assert capsys.readouterr().out == ""
 
 
-def test_cli_setup_prints_only_remaining_tasks(capsys) -> None:
+def test_cli_setup_always_prints_required_bluetooth_toggles(capsys) -> None:
     _print_iphone_steps(
         frozenset(),
         remaining=(CONTACTS,),
@@ -22,6 +26,124 @@ def test_cli_setup_prints_only_remaining_tasks(capsys) -> None:
     )
 
     output = capsys.readouterr().out
+    assert "3. Allow Notification Access when prompted" in output
+    assert "4. Toggle on Show Message Notifications and Sync Contacts" in output
+    assert "back out and tap the (i) again" in output
     assert "Sync Contacts" in output
-    assert "Show Message Notifications" not in output
-    assert "Notification Access" not in output
+    assert "Show Message Notifications" in output
+
+
+def test_cli_just_works_pairing_still_requires_confirmation(monkeypatch) -> None:
+    prompts = []
+    monkeypatch.setattr(
+        pairing_cli.typer,
+        "confirm",
+        lambda prompt, **kwargs: prompts.append((prompt, kwargs)) or False,
+    )
+
+    assert pairing_cli._confirm_pairing(None) is False
+    assert prompts == [
+        ("Approve this Bluetooth pairing request?", {"default": False})
+    ]
+
+
+def test_cli_requires_phone_side_forget_before_clearing_saved_target(
+    monkeypatch,
+    capsys,
+) -> None:
+    prompts = []
+    forgotten = []
+
+    class Setup:
+        @staticmethod
+        def configuration():
+            return SimpleNamespace(saved=True, mac="02:00:00:00:00:01")
+
+        @staticmethod
+        def forget(mac):
+            forgotten.append(mac)
+            raise pairing_cli.PairingError("stop after forget")
+
+    monkeypatch.setattr(pairing_cli, "SetupClient", Setup)
+    monkeypatch.setattr(
+        pairing_cli.typer,
+        "confirm",
+        lambda prompt, **kwargs: prompts.append((prompt, kwargs)) or True,
+    )
+
+    assert pairing_cli.run_wizard(verify_after=False) == 1
+    assert forgotten == ["02:00:00:00:00:01"]
+    assert prompts == [
+        (
+            "Forget BlueFerry's configured target and start fresh?",
+            {"default": False},
+        )
+    ]
+    output = capsys.readouterr().out
+    assert "Before answering Yes, forget this PC on the iPhone too" in output
+    assert "Forget This Device" in output
+
+
+def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> None:
+    prompts = []
+    observed = []
+    device = PairedDevice(
+        mac="02:00:00:00:00:01",
+        name="iPhone",
+        icon="phone",
+        trusted=False,
+        connected=False,
+        paired=False,
+        adapter_path="/org/bluez/hci0",
+        device_path="/org/bluez/hci0/dev_02_00_00_00_00_01",
+        uuids=frozenset(),
+    )
+    compatibility = SimpleNamespace(
+        adapter="hci0",
+        hardware_supported=True,
+        issue="",
+        notifications_supported=True,
+        bearer_api_active=True,
+    )
+
+    class Setup:
+        @staticmethod
+        def compatibility():
+            return compatibility
+
+        @staticmethod
+        def devices(*, scan_seconds):
+            assert scan_seconds == 8
+            return [device]
+
+        @staticmethod
+        def configuration():
+            return SimpleNamespace(saved=False, mac="")
+
+        @staticmethod
+        def complete(mac, *, confirmation, display):
+            observed.append((mac, confirmation(12345)))
+            display(12345)
+            return SimpleNamespace(device=device, ancs_ready=True)
+
+    class Backend:
+        @staticmethod
+        def status():
+            return SimpleNamespace(verified_iphone_setup=())
+
+    def confirm(prompt, **kwargs):
+        prompts.append((prompt, kwargs))
+        return True
+
+    monkeypatch.setattr(pairing_cli, "SetupClient", Setup)
+    monkeypatch.setattr(pairing_cli, "BackendClient", Backend)
+    monkeypatch.setattr(pairing_cli.typer, "confirm", confirm)
+    monkeypatch.setattr(pairing_cli, "_print_iphone_steps", lambda *_args, **_kwargs: None)
+
+    assert pairing_cli.run_wizard(verify_after=False) == 0
+    assert observed == [(device.mac, True)]
+    assert prompts == [
+        ("\nUse this device?", {"default": True}),
+        ("Do both devices show Bluetooth code 012345?", {"default": False}),
+    ]
+    assert "Bluetooth pairing code: 012345" in capsys.readouterr().out

--- a/tests/test_profile_supervisor.py
+++ b/tests/test_profile_supervisor.py
@@ -58,7 +58,7 @@ class FakeWorker:
         failure(error)
 
 
-def make_supervisor():
+def make_supervisor(*, first_attempt=None):
     sessions = FakeSessions()
     worker = FakeWorker()
     scheduled = []
@@ -72,6 +72,7 @@ def make_supervisor():
         on_ready=lambda: ready.append(True),
         on_lost=lost.append,
         on_status=lambda: statuses.append(True),
+        on_first_attempt_complete=first_attempt,
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 99,
         cancel=lambda _source: True,
     )
@@ -107,6 +108,21 @@ def test_forbidden_failure_polls_and_retries() -> None:
     assert scheduled[0][0] == INITIAL_MAP_CONNECT_POLL_SECONDS
     assert scheduled[0][1]() is False
     assert len(worker.jobs) == 1
+
+
+def test_first_attempt_callback_runs_once_across_failure_and_retry() -> None:
+    attempted = []
+    supervisor, _sessions, worker, scheduled, _ready, _lost, _statuses = (
+        make_supervisor(first_attempt=lambda: attempted.append(True))
+    )
+
+    supervisor.start()
+    worker.fail(RuntimeError("not authorized yet"))
+    assert attempted == [True]
+
+    scheduled[-1][1]()
+    worker.succeed()
+    assert attempted == [True]
 
 
 def test_map_connection_refusal_is_exposed_and_polls_quickly_until_ready() -> None:

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -177,10 +177,14 @@ def test_pairing_uses_interactive_agent_and_accepts_matching_code(monkeypatch):
     observed = []
 
     class Setup:
-        def complete(self, mac, *, confirmation, display):
+        def complete_isolated(self, mac, *, confirmation, display):
             observed.append((mac, confirmation(12345)))
             display(12345)
             return object()
+
+        @staticmethod
+        def complete(*_args, **_kwargs):
+            raise AssertionError("Qt pairing must not host the D-Bus agent on its worker")
 
     controller = BridgeController(
         backend=_Backend(),
@@ -216,7 +220,7 @@ def test_pairing_rejects_when_confirmation_is_declined(monkeypatch):
     observed = []
 
     class Setup:
-        def complete(self, _mac, *, confirmation, display):
+        def complete_isolated(self, _mac, *, confirmation, display):
             observed.append(confirmation(None))
             return object()
 


### PR DESCRIPTION
Marking this as 0.6.2. Fixes and new stuff:

1. Hopefully resolved Issue 1 - complete failure to pair when ANCS is not available. When ANCS won't negotiate - I presume for iOS versions under 26 - we'll gracefully fall back to a messages-only pair.
2. Fixed an issue in the CLI pairing flow where it wouldn't present a keycode with a yes/no selector.
3. Added a TUI client! ```blueferry-tui```, it comes with the blueferry-backend package.