### PR TITLE
Fix distro compatibility, contact sync, and client resilience

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,39 @@
+name: Quality
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    steps:
+      - name: Install system and test dependencies
+        run: >-
+          pacman -Syu --noconfirm
+          appstream bandit dbus desktop-file-utils git gtk4 kirigami
+          libadwaita libsecret mypy python-build python-coverage
+          python-cryptography python-dbus python-gobject python-hypothesis
+          python-installer python-pytest python-setuptools python-textual
+          python-typer python-wheel pyside6 qt6-declarative quickshell ruff
+      - uses: actions/checkout@v6
+      - name: Static analysis
+        run: |
+          ruff check .
+          bandit -r src/blueferry -q
+          mypy src/blueferry
+      - name: Hermetic tests and coverage
+        run: |
+          dbus-run-session --config-file=tests/dbus-test.conf -- sh -c '
+            export DBUS_SYSTEM_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"
+            export BLUEFERRY_TEST_DBUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"
+            export PYTHONPATH="$PWD/src"
+            python -m coverage run -m pytest -q
+            python -m coverage report
+          '
+      - name: QML syntax
+        run: /usr/lib/qt6/bin/qmllint src/blueferry/qt/qml/*.qml data/quickshell/*.qml

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,7 +28,7 @@ jobs:
           mypy src/blueferry
       - name: Hermetic tests and coverage
         run: |
-          dbus-run-session --config-file=tests/dbus-test.conf -- sh -c '
+          dbus-run-session --config-file=tests/dbus-test.conf -- sh -ec '
             export DBUS_SYSTEM_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"
             export BLUEFERRY_TEST_DBUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"
             export PYTHONPATH="$PWD/src"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,10 +55,13 @@ in `blueferry.models`; those records retain unknown fields for forward
 compatibility. Toolkit presentation code either consumes their typed fields or
 explicitly converts them to dictionaries. Quickshell's CLI adapter converts
 the same models back to JSON rather than defining a separate backend client.
+All Python transports share `client_wire` for response-shape validation and
+model conversion; synchronous and toolkit-specific scheduling remain separate.
 
 `backend_operations` owns validation, thread routing, and application policy.
 `dbus_service` is only a wire-type adapter over those operations. `daemon`
-orchestrates lifecycle, while `event_dispatcher` owns persistence/notification
+orchestrates lifecycle and supplies one typed `BackendDependencies` object,
+while `event_dispatcher` owns persistence/notification
 fan-out. `ProfileSupervisor` owns MAP/PBAP open, close, retry, loss, and resume
 transitions; its worker, session, and timer protocols make those races testable
 without BlueZ. Interactive pairing rendering lives separately from the BlueZ
@@ -160,6 +163,10 @@ touching daemon state. Bluetooth transfers, parsers, contact cardinality,
 desktop read-state watches, D-Bus replies, and retained payload bytes all have
 explicit resource ceilings.
 
+PBAP download and vCard parsing live in `contacts`; `contact_repository` owns
+the contact schema, replacement transaction, encrypted records, and legacy
+plaintext cleanup. This keeps Bluetooth failure handling outside persistence.
+
 Slow public D-Bus methods use deferred replies, so Bluetooth waits never block
 the daemon's event loop. Status, lifecycle signals, and incoming BlueZ events
 remain dispatchable while an OBEX transfer is active. The GTK client serializes
@@ -217,5 +224,8 @@ not on one-off experiment scripts.
   unicast `Messages1` snapshot calls.
 - Split `cli.py` or the Qt page module when a new feature would add another
   independent domain; avoid moving code solely to reduce line counts.
+- Keep toolkit root files focused on navigation and composition. Put cohesive
+  state derivation and presentation in loadable QML components with behavioral
+  tests rather than growing root-level functions.
 - Prefer narrowly tested helpers over broad exception handling. Best-effort
   cleanup may catch broadly, but command paths must return actionable errors.

--- a/TESTING.md
+++ b/TESTING.md
@@ -26,6 +26,10 @@ dbus-run-session --config-file=tests/dbus-test.conf -- sh -c '
 '
 ```
 
+The repository quality workflow runs the same hermetic suite on Arch Linux,
+along with Ruff, Bandit, mypy, QML linting, and a coverage report. The package
+build remains the final split-package and desktop-metadata integration check.
+
 ## What belongs in the suite
 
 - Protocol tests use inert strings or captured, reviewed fixtures and assert

--- a/data/quickshell/OnboardingState.qml
+++ b/data/quickshell/OnboardingState.qml
@@ -1,0 +1,48 @@
+import QtQuick
+
+QtObject {
+  required property bool hardwareSupported
+  required property bool notificationsSupported
+  required property bool bluezActive
+  required property bool configured
+  required property var backendStatus
+
+  readonly property string stage: {
+    if (!hardwareSupported) return "incompatible"
+    if (notificationsSupported && !bluezActive) return "activate-bluetooth"
+    if (!configured) return "select-device"
+    if (backendStatus.map && backendStatus.pbap) {
+      if (pendingIphoneSetupTasks().length > 0) return "iphone-settings"
+      return notificationsSupported ? "ready" : "ready-without-ancs"
+    }
+    return backendStatus.daemon ? "iphone-settings" : "starting"
+  }
+
+  function mapConnectionRefused() {
+    return backendStatus.map_connection_refused === true
+  }
+
+  function pendingIphoneSetupTasks() {
+    var verified = backendStatus.verified_iphone_setup || []
+    var tasks = []
+    if (verified.indexOf("message-notifications") < 0)
+      tasks.push("Enable Show Message Notifications")
+    if (verified.indexOf("contacts") < 0)
+      tasks.push("Enable Sync Contacts")
+    if (notificationsSupported && verified.indexOf("notification-access") < 0)
+      tasks.push("Allow Notification Access when prompted")
+    return tasks
+  }
+
+  function pendingIphoneSetupText() {
+    var tasks = pendingIphoneSetupTasks().join("\n• ")
+    var instructions = "After approving “Allow System Notifications,” you may need to return to the Bluetooth device list and reopen this computer before the other settings appear."
+    var text = configured
+      ? instructions + "\n• " + tasks
+      : "On the iPhone open Settings → Bluetooth, tap ⓘ next to this computer, then finish the settings below. " + instructions + "\n• " + tasks
+    var verified = backendStatus.verified_iphone_setup || []
+    if (notificationsSupported && verified.indexOf("notification-access") < 0)
+      text += "\n\nWithout System Notification access, group texts appear as individual conversations with their sender."
+    return text
+  }
+}

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -754,6 +754,7 @@ ShellRoot {
                         anchors.centerIn: parent
                         text: threadDelegate.modelData.is_group ? "#"
                           : String(threadDelegate.modelData.name || "?").charAt(0).toUpperCase()
+                        textFormat: Text.PlainText
                         color: threadDelegate.highlighted
                           ? theme.primaryText : theme.windowText
                         font.family: theme.fontFamily
@@ -770,6 +771,7 @@ ShellRoot {
                       Text {
                         width: parent.width
                         text: threadDelegate.modelData.name
+                        textFormat: Text.PlainText
                         color: theme.windowText
                         font.family: theme.fontFamily
                         font.pixelSize: theme.baseFontSize
@@ -782,6 +784,7 @@ ShellRoot {
                           ? (threadDelegate.modelData.messages[threadDelegate.modelData.messages.length - 1].outgoing ? "You: " : "")
                             + threadDelegate.modelData.messages[threadDelegate.modelData.messages.length - 1].body
                           : "No messages"
+                        textFormat: Text.PlainText
                         color: theme.muted
                         font.family: theme.fontFamily
                         font.pixelSize: theme.captionSize
@@ -1392,6 +1395,7 @@ ShellRoot {
                 id: newContactText
                 Text {
                   text: newContactDelegate.modelData.name
+                  textFormat: Text.PlainText
                   color: theme.windowText
                   font.family: theme.fontFamily
                   font.pixelSize: theme.baseFontSize
@@ -1400,6 +1404,7 @@ ShellRoot {
                   text: newContactDelegate.modelData.address.indexOf("@") >= 0
                     ? newContactDelegate.modelData.address
                     : "+" + newContactDelegate.modelData.address
+                  textFormat: Text.PlainText
                   color: theme.muted
                   font.family: theme.fontFamily
                   font.pixelSize: theme.captionSize
@@ -1452,6 +1457,7 @@ ShellRoot {
 
   component FerryLabel: Label {
     color: theme.windowText
+    textFormat: Text.PlainText
     font.family: theme.fontFamily
     font.pixelSize: theme.baseFontSize
   }
@@ -1468,6 +1474,7 @@ ShellRoot {
 
     contentItem: Text {
       text: control.text
+      textFormat: Text.PlainText
       color: !control.enabled ? theme.muted
         : control.bare && control.hovered ? theme.accent
         : control.highlighted ? theme.primaryText : theme.windowText
@@ -1581,6 +1588,7 @@ ShellRoot {
       highlighted: control.highlightedIndex === index
       contentItem: Text {
         text: option.modelData
+        textFormat: Text.PlainText
         color: theme.windowText
         font: control.font
         verticalAlignment: Text.AlignVCenter

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -33,7 +33,7 @@ ShellRoot {
   property string pairingPasskey: ""
   property bool pairingResultReceived: false
   property string adapterName: ""
-  property string onboardingStage: "checking"
+  property string onboardingStage: onboarding.stage
   property var backendStatus: ({})
   property string notificationPolicy: "messages"
   property string storagePolicy: "encrypted"
@@ -43,6 +43,14 @@ ShellRoot {
   property string statusErrorText: ""
 
   Theme { id: theme }
+  OnboardingState {
+    id: onboarding
+    hardwareSupported: root.hardwareSupported
+    notificationsSupported: root.notificationsSupported
+    bluezActive: root.bluezActive
+    configured: root.configured
+    backendStatus: root.backendStatus
+  }
 
   Connections {
     target: Quickshell
@@ -129,51 +137,6 @@ ShellRoot {
     return thread.key + "\n" + JSON.stringify(thread.recipients || [])
   }
 
-  function mapConnectionRefused() {
-    if (backendStatus.connectivity_state === "map-connection-refused") return true
-    var detail = String(backendStatus.connectivity_detail || "").toLowerCase()
-    return detail.indexOf("createsession(map)") >= 0
-      && detail.indexOf("connection refused") >= 0 && detail.indexOf("111") >= 0
-  }
-
-  function pendingIphoneSetupTasks() {
-    var verified = backendStatus.verified_iphone_setup || []
-    var tasks = []
-    if (verified.indexOf("message-notifications") < 0)
-      tasks.push("Enable Show Message Notifications")
-    if (verified.indexOf("contacts") < 0)
-      tasks.push("Enable Sync Contacts")
-    if (notificationsSupported && verified.indexOf("notification-access") < 0)
-      tasks.push("Allow Notification Access when prompted")
-    return tasks
-  }
-
-  function pendingIphoneSetupText() {
-    var tasks = pendingIphoneSetupTasks().join("\n• ")
-    var instructions = "After approving “Allow System Notifications,” you may need to return to the Bluetooth device list and reopen this computer before the other settings appear."
-    var text = root.configured
-      ? instructions + "\n• " + tasks
-      : "On the iPhone open Settings → Bluetooth, tap ⓘ next to this computer, then finish the settings below. " + instructions + "\n• " + tasks
-    var verified = backendStatus.verified_iphone_setup || []
-    if (notificationsSupported && verified.indexOf("notification-access") < 0)
-      text += "\n\nWithout System Notification access, group texts appear as individual conversations with their sender."
-    return text
-  }
-
-  function updateOnboarding() {
-    var device = selectedPairingDevice()
-    if (!hardwareSupported) onboardingStage = "incompatible"
-    else if (notificationsSupported && !bluezActive) onboardingStage = "activate-bluetooth"
-    else if (!configured) onboardingStage = "select-device"
-    else if (backendStatus.map && backendStatus.pbap) {
-      if (pendingIphoneSetupTasks().length > 0) onboardingStage = "iphone-settings"
-      else if (!notificationsSupported) onboardingStage = "ready-without-ancs"
-      else onboardingStage = "ready"
-    }
-    else if (backendStatus.daemon) onboardingStage = "iphone-settings"
-    else onboardingStage = "starting"
-  }
-
   function loadPairingDevices(scan) {
     if (deviceProcess.running) return
     deviceProcess.command = scan
@@ -198,7 +161,6 @@ ShellRoot {
   function markStatusUnavailable(message) {
     backendStatus = ({})
     statusErrorText = message
-    updateOnboarding()
   }
 
   function markCompatibilityUnavailable(message) {
@@ -208,7 +170,6 @@ ShellRoot {
     bluezActive = false
     adapterName = ""
     pairingStatus = message
-    updateOnboarding()
   }
 
   function handlePairingLine(line) {
@@ -244,7 +205,6 @@ ShellRoot {
       root.configuredMac = parsed.device ? (parsed.device.mac || "") : ""
       root.loadPairingDevices(false)
       root.reload()
-      root.updateOnboarding()
     } catch (error) {
       root.pairingStatus = "Pairing returned invalid data."
     }
@@ -267,7 +227,6 @@ ShellRoot {
           root.storageState = parsed.storage_state || "locked"
           root.storageDetail = parsed.storage_detail || "Storage status unavailable"
           root.statusErrorText = ""
-          root.updateOnboarding()
           root.maybeUnlockStorage()
         } catch (error) {
           root.markStatusUnavailable("BlueFerry backend returned invalid status data")
@@ -293,7 +252,6 @@ ShellRoot {
           root.bluezActive = parsed.bearer_api_active === true
           root.adapterName = parsed.adapter || ""
           if (!root.hardwareSupported) root.pairingStatus = parsed.issue || "Bluetooth controller is incompatible."
-          root.updateOnboarding()
           root.loadPairingDevices(false)
         } catch (error) {
           root.markCompatibilityUnavailable("Bluetooth compatibility check returned invalid data.")
@@ -323,7 +281,6 @@ ShellRoot {
             root.pairingStatus = "This phone is no longer paired in BlueZ. Clear the saved phone, then scan and pair again."
           if (!root.configured) root.phoneSettingsVisible = true
           else root.reload()
-          root.updateOnboarding()
         } catch (error) { root.phoneSettingsVisible = true }
       }
     }
@@ -500,7 +457,6 @@ ShellRoot {
               ? "Linux pairing is complete. Check the required iPhone settings below."
               : "Step 2: select the iPhone, then choose Pair Selected iPhone."
             : "No devices found. Unlock the iPhone, keep Bluetooth settings open, and scan again."
-          root.updateOnboarding()
         } catch (error) { root.pairingStatus = "Bluetooth scan returned invalid data." }
       }
     }
@@ -574,7 +530,6 @@ ShellRoot {
             root.configuredMac = ""
             root.backendStatus = ({})
             root.pairingDevices = []
-            root.updateOnboarding()
             root.loadPairingDevices(false)
           }
         } catch (error) { root.pairingStatus = "Forget operation returned invalid data." }
@@ -658,7 +613,7 @@ ShellRoot {
         Rectangle {
           Layout.fillWidth: true
           implicitHeight: mapRefusedLabel.implicitHeight + theme.scaled(16)
-          visible: !root.phoneSettingsVisible && root.mapConnectionRefused()
+          visible: !root.phoneSettingsVisible && onboarding.mapConnectionRefused()
           color: Qt.rgba(theme.warning.r, theme.warning.g, theme.warning.b, 0.14)
           border.color: theme.warning
           radius: theme.controlRadius
@@ -1087,7 +1042,7 @@ ShellRoot {
               : root.onboardingStage === "ready-without-ancs"
                 ? "Messages and contacts have been verified. System notifications are unavailable, so group texts may appear as individual conversations."
                 : root.onboardingStage === "iphone-settings"
-                    ? root.mapConnectionRefused()
+                    ? onboarding.mapConnectionRefused()
                       ? "Cannot retrieve or send messages - are you connected to another computer? We will reconnect once your phone is free"
                       : "Connected. Finish the remaining iPhone permissions below."
                     : "Controller: " + (root.adapterName || "checking…")
@@ -1205,26 +1160,26 @@ ShellRoot {
           }
           FerrySectionLabel {
             text: "Finish Setup on the iPhone"
-            visible: root.configured && root.pendingIphoneSetupTasks().length > 0
+            visible: root.configured && onboarding.pendingIphoneSetupTasks().length > 0
           }
           FerryLabel {
-            text: root.pendingIphoneSetupText()
+            text: onboarding.pendingIphoneSetupText()
             wrapMode: Text.Wrap
             Layout.fillWidth: true
-            visible: root.configured && root.pendingIphoneSetupTasks().length > 0
+            visible: root.configured && onboarding.pendingIphoneSetupTasks().length > 0
           }
           FerrySectionLabel {
             text: "Connection health"
           }
           FerryInfoRow {
             label: "Messages"
-            value: root.mapConnectionRefused()
+            value: onboarding.mapConnectionRefused()
               ? "Connection refused"
               : root.backendStatus.map ? "Connected" : "Unavailable"
             Layout.fillWidth: true
           }
           FerryLabel {
-            visible: root.mapConnectionRefused()
+            visible: onboarding.mapConnectionRefused()
             text: "iPhone is refusing message connections; is it connected to another computer?"
             textFormat: Text.PlainText
             color: theme.warning

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -32,6 +32,7 @@ ShellRoot {
   property bool pairingConfirmationPending: false
   property string pairingPasskey: ""
   property bool pairingResultReceived: false
+  property var pendingPairingDevice: null
   property string adapterName: ""
   property string onboardingStage: onboarding.stage
   property var backendStatus: ({})
@@ -149,6 +150,17 @@ ShellRoot {
   function selectedPairingDevice() {
     var index = pairingDeviceCombo.currentIndex
     return index >= 0 && index < pairingDevices.length ? pairingDevices[index] : null
+  }
+
+  function startPairing(device, replaceSavedTarget) {
+    pairingStatus = "Activating Bluetooth, then starting secure pairing…"
+    pairingResultReceived = false
+    pairProcess.command = [
+      "/usr/bin/blueferry", "pairing-complete", device.mac, "--interactive-agent"
+    ]
+    if (replaceSavedTarget)
+      pairProcess.command.push("--replace-saved-mac", configuredMac)
+    pairProcess.running = true
   }
 
   function configuredPairingDevice() {
@@ -864,7 +876,7 @@ ShellRoot {
                     anchors.right: messageRow.modelData.outgoing ? parent.right : undefined
                     anchors.left: messageRow.modelData.outgoing ? undefined : parent.left
                     color: messageRow.modelData.outgoing
-                      ? theme.primarySurface : theme.raisedSurface
+                      ? theme.selectedSurface : theme.raisedSurface
                     border.color: messageRow.modelData.outgoing
                       ? "transparent" : theme.divider
                     radius: theme.controlRadius
@@ -882,8 +894,7 @@ ShellRoot {
                         width: parent.width
                         text: messageRow.modelData.body
                         textFormat: Text.PlainText
-                        color: messageRow.modelData.outgoing
-                          ? theme.primaryText : theme.windowText
+                        color: theme.windowText
                         font.family: theme.fontFamily
                         font.pixelSize: theme.baseFontSize
                         wrapMode: Text.Wrap
@@ -895,8 +906,8 @@ ShellRoot {
                         text: messageRow.modelData.display_timestamp || ""
                         textFormat: Text.PlainText
                         color: messageRow.modelData.outgoing
-                          ? Qt.rgba(theme.primaryText.r, theme.primaryText.g,
-                                    theme.primaryText.b, 0.62)
+                          ? Qt.rgba(theme.windowText.r, theme.windowText.g,
+                                    theme.windowText.b, 0.62)
                           : theme.muted
                         font.family: theme.fontFamily
                         font.pixelSize: theme.captionSize
@@ -1051,22 +1062,22 @@ ShellRoot {
           }
           FerrySectionLabel {
             text: "Pair an iPhone"
-            visible: !root.configured && !root.targetSaved
+            visible: !root.configured
           }
           FerryLabel {
-            text: "Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."
+            text: "Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. While it does, return to the Bluetooth device list and reopen this computer's ⓘ page a few times; turn on any new toggles that appear. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."
             wrapMode: Text.Wrap
             Layout.fillWidth: true
-            visible: !root.configured && !root.targetSaved
+            visible: !root.configured
           }
           FerryCheckBox {
             id: confirmBluetoothRestart
-            visible: !root.configured && !root.targetSaved
+            visible: !root.configured
                      && root.notificationsSupported && !root.bluezActive
             text: "I understand this briefly disconnects all Bluetooth devices"
           }
           FerryButton {
-            visible: !root.configured && !root.targetSaved
+            visible: !root.configured
                      && root.notificationsSupported && !root.bluezActive
             text: bluezActivateProcess.running ? "Activating…" : "Activate Bluetooth support"
             enabled: confirmBluetoothRestart.checked && !bluezActivateProcess.running
@@ -1077,20 +1088,20 @@ ShellRoot {
             }
           }
           FerryButton {
-            visible: !root.configured && !root.targetSaved
+            visible: !root.configured
             text: deviceProcess.running ? "Scanning…" : "1. Scan for iPhone"
             enabled: !deviceProcess.running && !pairProcess.running
             onClicked: root.loadPairingDevices(true)
           }
           FerryComboBox {
             id: pairingDeviceCombo
-            visible: !root.configured && !root.targetSaved
+            visible: !root.configured
             Layout.fillWidth: true
             model: root.pairingDevices
             textRole: "label"
           }
           FerryButton {
-            visible: !root.configured && !root.targetSaved
+            visible: !root.configured
             text: pairProcess.running ? "Pairing…"
               : root.selectedPairingDevice() && root.selectedPairingDevice().paired
                 ? "Use existing pairing" : "2. Pair Selected iPhone"
@@ -1099,12 +1110,10 @@ ShellRoot {
                      && !deviceProcess.running && !pairProcess.running
             onClicked: {
               var device = root.selectedPairingDevice()
-              root.pairingStatus = "Activating Bluetooth, then starting secure pairing…"
-              root.pairingResultReceived = false
-              pairProcess.command = [
-                "/usr/bin/blueferry", "pairing-complete", device.mac, "--interactive-agent"
-              ]
-              pairProcess.running = true
+              if (!device.paired && root.targetSaved) {
+                root.pendingPairingDevice = device
+                replaceTargetPopup.open()
+              } else root.startPairing(device, false)
             }
           }
           FerryLabel {
@@ -1274,6 +1283,59 @@ ShellRoot {
                 onClicked: root.phoneSettingsVisible = false
               }
               Item { Layout.fillWidth: true }
+            }
+          }
+        }
+      }
+
+      Popup {
+        id: replaceTargetPopup
+        parent: applicationSurface
+        x: Math.max(0, (applicationSurface.width - width) / 2)
+        y: Math.max(0, (applicationSurface.height - height) / 2)
+        width: Math.min(theme.scaled(440), applicationSurface.width - theme.scaled(24))
+        modal: true
+        focus: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        padding: theme.scaled(18)
+
+        background: Rectangle {
+          color: theme.cardSurface
+          border.color: theme.divider
+          radius: theme.panelRadius
+        }
+
+        Overlay.modal: Rectangle {
+          color: Qt.rgba(theme.windowSurface.r, theme.windowSurface.g,
+                         theme.windowSurface.b, 0.72)
+        }
+
+        contentItem: ColumnLayout {
+          spacing: theme.scaled(12)
+          FerryLabel {
+            text: "Replace the saved iPhone?"
+            font.bold: true
+            font.pixelSize: theme.headingSize
+          }
+          FerryLabel {
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            text: "Pairing this iPhone will remove BlueFerry's saved phone and its local Bluetooth bond. Before continuing, also forget this computer in the old iPhone's Bluetooth settings."
+          }
+          RowLayout {
+            Layout.alignment: Qt.AlignRight
+            FerryButton {
+              text: "Cancel"
+              onClicked: replaceTargetPopup.close()
+            }
+            FerryButton {
+              text: "Replace and pair"
+              highlighted: true
+              onClicked: {
+                var device = root.pendingPairingDevice
+                replaceTargetPopup.close()
+                if (device !== null) root.startPairing(device, true)
+              }
             }
           }
         }

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -29,6 +29,7 @@ checkdepends=(
   'libsecret'
   'mypy'
   'python-cryptography'
+  'python-coverage'
   'python-dbus'
   'python-gobject'
   'python-hypothesis'
@@ -70,7 +71,8 @@ check() {
     export DBUS_SYSTEM_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"
     export BLUEFERRY_TEST_DBUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"
     export PYTHONPATH="$BLUEFERRY_TEST_ROOT/src"
-    python -m pytest -q
+    python -m coverage run -m pytest -q
+    python -m coverage report
   '
   desktop-file-validate data/io.weirdware.BlueFerry.Gtk.desktop
   desktop-file-validate data/io.weirdware.BlueFerry.Qt.desktop
@@ -181,10 +183,8 @@ package_blueferry-quickshell() {
   cd "$pkgbase-$pkgver"
   install -Dm755 data/blueferry-quickshell \
     "$pkgdir/usr/bin/blueferry-quickshell"
-  install -Dm644 data/quickshell/shell.qml \
-    "$pkgdir/usr/share/blueferry/quickshell/shell.qml"
-  install -Dm644 data/quickshell/Theme.qml \
-    "$pkgdir/usr/share/blueferry/quickshell/Theme.qml"
+  install -Dm644 data/quickshell/*.qml \
+    -t "$pkgdir/usr/share/blueferry/quickshell"
   install -Dm644 data/io.weirdware.BlueFerry.Quickshell.desktop \
     "$pkgdir/usr/share/applications/io.weirdware.BlueFerry.Quickshell.desktop"
   install -Dm644 data/io.weirdware.BlueFerry.Quickshell.metainfo.xml \

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -135,7 +135,7 @@ package_blueferry-gtk() {
   depends=(
     "blueferry-backend=$pkgver-$pkgrel"
     'gtk4'
-    'libadwaita>=1.6'
+    'libadwaita>=1.5'
     'python-gobject'
   )
 

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -4,6 +4,11 @@ BlueFerry builds as four split pacman packages: the backend plus one client
 each for GNOME, KDE, and Quickshell. All build and runtime dependencies come
 from the official Arch repositories.
 
+The `blueferry-bluetooth.conf` systemd drop-in is Arch-specific. In particular,
+its `/usr/lib/bluetooth/bluetoothd` executable path must not be copied to
+Debian or Ubuntu, where the usual path is `/usr/libexec/bluetooth/bluetoothd`.
+Using the wrong path prevents the entire Bluetooth service from starting.
+
 From the repository root, build and install everything with:
 
 ```bash

--- a/packaging/arch/blueferry-bluetooth.conf
+++ b/packaging/arch/blueferry-bluetooth.conf
@@ -1,3 +1,7 @@
+# Arch Linux only: Debian and Ubuntu install this executable at
+# /usr/libexec/bluetooth/bluetoothd. Do not copy this drop-in across distros
+# without adjusting ExecStart; an invalid path prevents Bluetooth from starting.
+#
 # Expose BlueZ's per-transport Bearer.LE1/Bearer.BREDR1 interfaces. BlueFerry
 # supervises both so ANCS stays on LE while MAP/PBAP use BR/EDR.
 [Service]

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -6,3 +6,4 @@ src/blueferry/ui/status_presenter.py
 src/blueferry/qt/controller.py
 src/blueferry/qt/qml/Main.qml
 src/blueferry/qt/qml/MessageBubble.qml
+src/blueferry/qt/qml/OnboardingSummary.qml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Issues = "https://github.com/erikwb/blueferry/issues"
 [project.optional-dependencies]
 dev = [
   "bandit>=1.9",
+  "coverage[toml]>=7.6",
   "hypothesis>=6.100",
   "mypy>=1.10",
   "pytest>=7",
@@ -89,3 +90,22 @@ exclude = "^src/blueferry/(ui|qt)/"
 ignore_missing_imports = true
 warn_unused_ignores = true
 check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = [
+  "blueferry.backend_operations",
+  "blueferry.client",
+  "blueferry.client_wire",
+  "blueferry.contact_repository",
+  "blueferry.contacts",
+  "blueferry.protocol",
+]
+disallow_untyped_defs = true
+
+[tool.coverage.run]
+branch = true
+source = ["blueferry"]
+
+[tool.coverage.report]
+skip_covered = true
+show_missing = true

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any, Protocol
 
 from blueferry.contacts import clear_contact_cache
 from blueferry.errors import (
@@ -42,7 +43,7 @@ from blueferry.obex.map_send import (
     send_message,
     validate_recipient,
 )
-from blueferry.storage_security import STORAGE_POLICIES
+from blueferry.storage_security import STORAGE_POLICIES, StorageSecurity
 from blueferry.threads import ConversationIndex, build_threads
 
 log = logging.getLogger(__name__)
@@ -53,6 +54,52 @@ _PUBLIC_EVENT_KINDS = frozenset({"sms_received", "sms_sent", "sms_seen"})
 
 Success = Callable[[Any], None]
 Failure = Callable[[Exception], None]
+Operation = Callable[[], Any]
+
+
+class SessionState(Protocol):
+    @property
+    def map(self) -> object | None: ...
+
+    @property
+    def pbap(self) -> object | None: ...
+
+    @property
+    def map_path(self) -> str: ...
+
+    def report_error(self, error: Exception) -> None: ...
+
+
+class ContactIndex(Protocol):
+    def find_by_name(self, query: str) -> list[tuple[str, str]]: ...
+
+    def resolve(self, address: str | None) -> str | None: ...
+
+    def refresh(self) -> int: ...
+
+
+class NotificationPolicy(Protocol):
+    @property
+    def value(self) -> str: ...
+
+    def set(self, value: str) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class BackendDependencies:
+    """Explicit optional capabilities supplied by the daemon composition root."""
+
+    submit_obex: Callable[..., object] | None = None
+    on_sent: Callable[[str, str, str], None] | None = None
+    on_group_sent: Callable[..., None] | None = None
+    pull_contacts: Callable[[], int] | None = None
+    on_contacts_pulled: Callable[[int], int] | None = None
+    contacts: ContactIndex | None = None
+    status_provider: Callable[[], dict[str, Any]] | None = None
+    notification_policy: NotificationPolicy | None = None
+    on_notification_policy_changed: Callable[[], None] | None = None
+    storage: StorageSecurity | None = None
+    on_storage_changed: Callable[[], None] | None = None
 
 
 class BackendOperations:
@@ -60,41 +107,20 @@ class BackendOperations:
 
     def __init__(
         self,
-        sessions,
-        *,
-        submit_obex=None,
-        on_sent=None,
-        on_group_sent=None,
-        pull_contacts=None,
-        on_contacts_pulled=None,
-        contacts=None,
-        status_provider=None,
-        notification_policy=None,
-        on_notification_policy_changed=None,
-        storage=None,
-        on_storage_changed=None,
+        sessions: SessionState,
+        dependencies: BackendDependencies | None = None,
     ) -> None:
         self.sessions = sessions
-        self._submit_obex = submit_obex
-        self._on_sent = on_sent
-        self._on_group_sent = on_group_sent
-        self._pull_contacts = pull_contacts
-        self._on_contacts_pulled = on_contacts_pulled
-        self._contacts = contacts
-        self._status_provider = status_provider
-        self._notification_policy = notification_policy
-        self._on_notification_policy_changed = on_notification_policy_changed
-        self._storage = storage
-        self._on_storage_changed = on_storage_changed
+        self.dependencies = dependencies or BackendDependencies()
         self._confirmed_group_keys: set[str] = set()
         self._conversations = ConversationIndex(
             lambda: read_events(
                 limit=MAX_CONVERSATION_EVENTS,
                 max_body_chars=MAX_THREAD_BODY_CHARS,
-                storage=self._storage,
+                storage=self.dependencies.storage,
             ),
-            lambda events: build_threads(events, self._contacts),
-            revision=lambda: history_revision(storage=self._storage),
+            lambda events: build_threads(events, self.dependencies.contacts),
+            revision=lambda: history_revision(storage=self.dependencies.storage),
         )
 
     def _require_map(self) -> None:
@@ -113,12 +139,16 @@ class BackendOperations:
             )
         return body
 
-    def _queue(self, operation, success: Success, failure: Failure) -> None:
-        if self._submit_obex is None:
+    def _queue(
+        self, operation: Operation, success: Success, failure: Failure
+    ) -> None:
+        if self.dependencies.submit_obex is None:
             failure(NotReadyError("OBEX worker is unavailable"))
             return
         try:
-            self._submit_obex(operation, on_success=success, on_error=failure)
+            self.dependencies.submit_obex(
+                operation, on_success=success, on_error=failure
+            )
         except Exception as error:
             failure(error)
 
@@ -134,9 +164,9 @@ class BackendOperations:
         map_path = self.sessions.map_path
 
         def succeeded(transfer: str) -> None:
-            if self._on_sent is not None:
+            if self.dependencies.on_sent is not None:
                 try:
-                    self._on_sent(recipient, body, transfer)
+                    self.dependencies.on_sent(recipient, body, transfer)
                 except Exception:
                     log.exception("on_sent hook failed (message was still sent)")
             success(transfer)
@@ -198,9 +228,9 @@ class BackendOperations:
 
             def succeeded(transfer: str) -> None:
                 self._confirmed_group_keys.add(thread_key)
-                if self._on_group_sent is not None:
+                if self.dependencies.on_group_sent is not None:
                     try:
-                        self._on_group_sent(
+                        self.dependencies.on_group_sent(
                             group_recipients, thread["key"],
                             thread["name"], body, transfer,
                             thread["members"],
@@ -221,7 +251,7 @@ class BackendOperations:
             raise NotReadyError("one-to-one thread has an invalid recipient set")
         self._queue_send(thread["recipients"][0], body, success, failure)
 
-    def list_events(self, kinds, limit: int) -> list[dict]:
+    def list_events(self, kinds: Iterable[object], limit: int) -> list[dict]:
         raw_kinds = list(kinds)
         if len(raw_kinds) > MAX_EVENT_KINDS:
             raise InvalidArgumentsError("too many event kinds")
@@ -240,7 +270,7 @@ class BackendOperations:
             kinds=selected or set(_PUBLIC_EVENT_KINDS),
             limit=bounded,
             max_body_chars=MAX_THREAD_BODY_CHARS,
-            storage=self._storage,
+            storage=self.dependencies.storage,
         )
 
     def list_threads(self, limit: int) -> list[dict]:
@@ -253,11 +283,13 @@ class BackendOperations:
             return []
         if len(selected) > MAX_CONTACT_QUERY_CHARS:
             raise InvalidArgumentsError("contact query is too long")
-        if self._contacts is None:
+        if self.dependencies.contacts is None:
             raise NotReadyError("contact cache is unavailable")
         return [
             {"name": name, "address": address}
-            for name, address in self._contacts.find_by_name(selected)[:MAX_CONTACT_RESULTS]
+            for name, address in self.dependencies.contacts.find_by_name(selected)[
+                :MAX_CONTACT_RESULTS
+            ]
         ]
 
     def invalidate_conversations(self) -> None:
@@ -270,8 +302,8 @@ class BackendOperations:
             "pbap": self.sessions.pbap is not None,
             "notification_policy": self.get_notification_policy(),
         }
-        if self._status_provider is not None:
-            status.update(self._status_provider())
+        if self.dependencies.status_provider is not None:
+            status.update(self.dependencies.status_provider())
         return status
 
     def clear_history(self, confirmed: bool) -> None:
@@ -283,12 +315,12 @@ class BackendOperations:
         self.invalidate_conversations()
 
     def get_storage_policy(self) -> str:
-        if self._storage is None:
+        if self.dependencies.storage is None:
             return "encrypted"
-        return self._storage.status.policy
+        return self.dependencies.storage.status.policy
 
     def set_storage_policy(self, value: str) -> dict:
-        if self._storage is None:
+        if self.dependencies.storage is None:
             raise NotReadyError("local storage is unavailable")
         selected = str(value).strip().casefold()
         if selected not in STORAGE_POLICIES:
@@ -296,25 +328,27 @@ class BackendOperations:
             raise InvalidArgumentsError(
                 f"local data policy must be one of: {choices}"
             )
-        if selected != self._storage.status.policy:
+        if selected != self.dependencies.storage.status.policy:
             # Never mix plaintext and ciphertext in one archive. Clear before
             # changing policy so a crash can leave stale settings or an empty
             # archive, but never private data under the wrong policy.
             clear_events()
             clear_contact_cache()
         try:
-            status = self._storage.set_policy(selected, allow_prompt=True)
+            status = self.dependencies.storage.set_policy(
+                selected, allow_prompt=True
+            )
         except ValueError as error:
             raise InvalidArgumentsError(str(error)) from error
         if status.policy == "none":
-            if self._contacts is not None:
-                self._contacts.refresh()
+            if self.dependencies.contacts is not None:
+                self.dependencies.contacts.refresh()
         elif status.can_read:
-            if self._contacts is not None:
-                self._contacts.refresh()
+            if self.dependencies.contacts is not None:
+                self.dependencies.contacts.refresh()
         self.invalidate_conversations()
-        if self._on_storage_changed is not None:
-            self._on_storage_changed()
+        if self.dependencies.on_storage_changed is not None:
+            self.dependencies.on_storage_changed()
         return {
             "storage_policy": status.policy,
             "storage_state": status.state,
@@ -322,15 +356,15 @@ class BackendOperations:
         }
 
     def unlock_storage(self) -> dict:
-        if self._storage is None:
+        if self.dependencies.storage is None:
             raise NotReadyError("local storage is unavailable")
-        status = self._storage.refresh(allow_prompt=True)
+        status = self.dependencies.storage.refresh(allow_prompt=True)
         if status.can_read:
-            if self._contacts is not None:
-                self._contacts.refresh()
+            if self.dependencies.contacts is not None:
+                self.dependencies.contacts.refresh()
             self.invalidate_conversations()
-        if self._on_storage_changed is not None:
-            self._on_storage_changed()
+        if self.dependencies.on_storage_changed is not None:
+            self.dependencies.on_storage_changed()
         return {
             "storage_policy": status.policy,
             "storage_state": status.state,
@@ -338,19 +372,19 @@ class BackendOperations:
         }
 
     def get_notification_policy(self) -> str:
-        if self._notification_policy is None:
+        if self.dependencies.notification_policy is None:
             return "messages"
-        return str(self._notification_policy.value)
+        return str(self.dependencies.notification_policy.value)
 
     def set_notification_policy(self, value: str) -> str:
-        if self._notification_policy is None:
+        if self.dependencies.notification_policy is None:
             raise NotReadyError("notification policy storage is unavailable")
         try:
-            selected = self._notification_policy.set(value)
+            selected = self.dependencies.notification_policy.set(value)
         except ValueError as error:
             raise InvalidArgumentsError(str(error)) from error
-        if self._on_notification_policy_changed is not None:
-            self._on_notification_policy_changed()
+        if self.dependencies.on_notification_policy_changed is not None:
+            self.dependencies.on_notification_policy_changed()
         return selected
 
     def list_recent(
@@ -364,14 +398,14 @@ class BackendOperations:
         map_path = self.sessions.map_path
 
         def succeeded(messages: list[dict]) -> None:
-            if self._contacts is not None:
+            if self.dependencies.contacts is not None:
                 for message in messages:
                     address = (
                         message.get("sender")
                         or message.get("sender_address")
                         or message.get("sender_phone_norm")
                     )
-                    resolved = self._contacts.resolve(address)
+                    resolved = self.dependencies.contacts.resolve(address)
                     if resolved:
                         message["contact_name"] = resolved
             success(messages)
@@ -389,19 +423,24 @@ class BackendOperations:
             raise NotReadyError(
                 "PBAP session not open — check Sync Contacts on the iPhone"
             )
-        if self._pull_contacts is None or self._on_contacts_pulled is None:
+        if (
+            self.dependencies.pull_contacts is None
+            or self.dependencies.on_contacts_pulled is None
+        ):
             raise NotReadyError("contact sync is unavailable")
+        pull_contacts = self.dependencies.pull_contacts
+        on_contacts_pulled = self.dependencies.on_contacts_pulled
 
         def succeeded(pulled: int) -> None:
             try:
-                count = self._on_contacts_pulled(pulled)
+                count = on_contacts_pulled(pulled)
                 self.invalidate_conversations()
                 success(count)
             except Exception as error:
                 self._operation_failed("ContactSync", error, failure)
 
         self._queue(
-            self._pull_contacts,
+            pull_contacts,
             succeeded,
             lambda error: self._operation_failed("ContactSync", error, failure),
         )

--- a/src/blueferry/cli.py
+++ b/src/blueferry/cli.py
@@ -225,6 +225,7 @@ def pairing_activate_bluez() -> None:
 def pairing_complete(
     mac: str,
     interactive_agent: bool = typer.Option(False, "--interactive-agent", hidden=True),
+    replace_saved_mac: str = typer.Option("", "--replace-saved-mac", hidden=True),
     debug: bool = typer.Option(False, "--debug"),
 ) -> None:
     """Pair and perform all Linux-side setup for graphical clients."""
@@ -253,7 +254,10 @@ def pairing_complete(
         emit({"event": "display", "passkey": f"{passkey:06d}"})
 
     try:
-        result = SetupClient().complete(
+        setup = SetupClient()
+        if replace_saved_mac:
+            setup.prepare_replacement(replace_saved_mac, mac)
+        result = setup.complete(
             mac,
             confirmation=confirm if interactive_agent else None,
             display=display if interactive_agent else None,

--- a/src/blueferry/client.py
+++ b/src/blueferry/client.py
@@ -1,19 +1,31 @@
 """Toolkit-neutral synchronous client for the BlueFerry daemon."""
 from __future__ import annotations
 
-import json
-
 import dbus
 import dbus.exceptions
 
 from blueferry.bus import get_session_bus
+from blueferry.client_wire import (
+    decode_contacts,
+    decode_events,
+    decode_json,
+    decode_mapping,
+    decode_status,
+    decode_threads,
+)
 from blueferry.errors import BlueFerryError
 from blueferry.models import BackendStatus, EventRecord, Thread
 from blueferry.protocol import (
     BUS_NAME,
+    CLEAR_CALL_TIMEOUT_SEC,
+    CONTACT_CALL_TIMEOUT_SEC,
     MESSAGES_IFACE,
     OBEX_CALL_TIMEOUT_SEC,
     OBJECT_PATH,
+    POLICY_CALL_TIMEOUT_SEC,
+    SNAPSHOT_CALL_TIMEOUT_SEC,
+    STATUS_CALL_TIMEOUT_SEC,
+    STORAGE_CALL_TIMEOUT_SEC,
 )
 
 
@@ -26,54 +38,38 @@ class BackendClient:
         bus = get_session_bus()
         return dbus.Interface(bus.get_object(BUS_NAME, OBJECT_PATH), name)
 
-    @staticmethod
-    def _json(value, expected_type):
-        parsed = json.loads(str(value))
-        if not isinstance(parsed, expected_type):
-            raise ValueError(f"backend returned {type(parsed).__name__}, expected "
-                             f"{expected_type.__name__}")
-        return parsed
-
     def status(self) -> BackendStatus:
         try:
-            value = self._json(
-                self._iface(MESSAGES_IFACE).GetStatus(timeout=8), dict,
+            return decode_status(
+                self._iface(MESSAGES_IFACE).GetStatus(
+                    timeout=STATUS_CALL_TIMEOUT_SEC
+                )
             )
-            return BackendStatus.from_dict(value)
         except (dbus.exceptions.DBusException, ValueError) as error:
             raise BackendError(str(error)) from error
 
     def threads(self, limit: int = 1000) -> list[Thread]:
         try:
-            values = self._json(self._iface(MESSAGES_IFACE).ListThreads(
-                dbus.UInt32(limit), timeout=15,
-            ), list)
-            return [Thread.from_dict(value) for value in values
-                    if isinstance(value, dict)]
+            return decode_threads(self._iface(MESSAGES_IFACE).ListThreads(
+                dbus.UInt32(limit), timeout=SNAPSHOT_CALL_TIMEOUT_SEC,
+            ))
         except (dbus.exceptions.DBusException, ValueError) as error:
             raise BackendError(str(error)) from error
 
     def events(self, kinds: list[str], limit: int = 1000) -> list[EventRecord]:
         try:
-            values = self._json(self._iface(MESSAGES_IFACE).ListEvents(
-                dbus.Array(kinds, signature="s"), dbus.UInt32(limit), timeout=15,
-            ), list)
-            return [EventRecord.from_dict(value) for value in values
-                    if isinstance(value, dict)]
+            return decode_events(self._iface(MESSAGES_IFACE).ListEvents(
+                dbus.Array(kinds, signature="s"), dbus.UInt32(limit),
+                timeout=SNAPSHOT_CALL_TIMEOUT_SEC,
+            ))
         except (dbus.exceptions.DBusException, ValueError) as error:
             raise BackendError(str(error)) from error
 
     def find_contacts(self, query: str) -> list[tuple[str, str]]:
         try:
-            values = self._json(self._iface(MESSAGES_IFACE).FindContacts(
-                query, timeout=8
-            ), list)
-            return [
-                (str(value["name"]), str(value["address"]))
-                for value in values
-                if isinstance(value, dict)
-                and "name" in value and "address" in value
-            ]
+            return decode_contacts(self._iface(MESSAGES_IFACE).FindContacts(
+                query, timeout=CONTACT_CALL_TIMEOUT_SEC
+            ))
         except (dbus.exceptions.DBusException, ValueError) as error:
             raise BackendError(str(error)) from error
 
@@ -98,7 +94,7 @@ class BackendClient:
 
     def recent(self, folder: str, limit: int) -> list[dict]:
         try:
-            return self._json(self._iface(MESSAGES_IFACE).ListRecent(
+            return decode_json(self._iface(MESSAGES_IFACE).ListRecent(
                 folder, dbus.UInt32(limit), timeout=OBEX_CALL_TIMEOUT_SEC,
             ), list)
         except (dbus.exceptions.DBusException, ValueError) as error:
@@ -115,43 +111,49 @@ class BackendClient:
     def clear_history(self) -> None:
         try:
             self._iface(MESSAGES_IFACE).ClearHistory(
-                dbus.Boolean(True), timeout=15
+                dbus.Boolean(True), timeout=CLEAR_CALL_TIMEOUT_SEC
             )
         except dbus.exceptions.DBusException as error:
             raise BackendError(error.get_dbus_message() or str(error)) from error
 
     def notification_policy(self) -> str:
         try:
-            return str(self._iface(MESSAGES_IFACE).GetNotificationPolicy(timeout=8))
+            return str(self._iface(MESSAGES_IFACE).GetNotificationPolicy(
+                timeout=POLICY_CALL_TIMEOUT_SEC
+            ))
         except dbus.exceptions.DBusException as error:
             raise BackendError(error.get_dbus_message() or str(error)) from error
 
     def set_notification_policy(self, policy: str) -> str:
         try:
             return str(self._iface(MESSAGES_IFACE).SetNotificationPolicy(
-                policy, timeout=8
+                policy, timeout=POLICY_CALL_TIMEOUT_SEC
             ))
         except dbus.exceptions.DBusException as error:
             raise BackendError(error.get_dbus_message() or str(error)) from error
 
     def storage_policy(self) -> str:
         try:
-            return str(self._iface(MESSAGES_IFACE).GetStoragePolicy(timeout=8))
+            return str(self._iface(MESSAGES_IFACE).GetStoragePolicy(
+                timeout=POLICY_CALL_TIMEOUT_SEC
+            ))
         except dbus.exceptions.DBusException as error:
             raise BackendError(error.get_dbus_message() or str(error)) from error
 
     def set_storage_policy(self, policy: str) -> dict:
         try:
-            return self._json(self._iface(MESSAGES_IFACE).SetStoragePolicy(
-                policy, timeout=30
-            ), dict)
+            return decode_mapping(self._iface(MESSAGES_IFACE).SetStoragePolicy(
+                policy, timeout=STORAGE_CALL_TIMEOUT_SEC
+            ))
         except (dbus.exceptions.DBusException, ValueError) as error:
             raise BackendError(str(error)) from error
 
     def unlock_storage(self) -> dict:
         try:
-            return self._json(
-                self._iface(MESSAGES_IFACE).UnlockStorage(timeout=30), dict
+            return decode_mapping(
+                self._iface(MESSAGES_IFACE).UnlockStorage(
+                    timeout=STORAGE_CALL_TIMEOUT_SEC
+                )
             )
         except (dbus.exceptions.DBusException, ValueError) as error:
             raise BackendError(str(error)) from error

--- a/src/blueferry/client_wire.py
+++ b/src/blueferry/client_wire.py
@@ -1,0 +1,52 @@
+"""Shared decoding for the stable Messages1 JSON wire contract.
+
+Transport adapters remain toolkit-specific, but every Python client validates
+and converts daemon replies through this module so model and shape handling
+cannot drift between synchronous and asynchronous clients.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from blueferry.models import BackendStatus, EventRecord, Thread
+
+T = TypeVar("T")
+
+
+def decode_json(value: object, expected_type: type[T]) -> T:
+    parsed: object = json.loads(str(value))
+    if not isinstance(parsed, expected_type):
+        raise ValueError(
+            f"backend returned {type(parsed).__name__}, "
+            f"expected {expected_type.__name__}"
+        )
+    return cast(T, parsed)
+
+
+def decode_mapping(value: object) -> dict[str, Any]:
+    return decode_json(value, dict)
+
+
+def decode_status(value: object) -> BackendStatus:
+    return BackendStatus.from_dict(decode_mapping(value))
+
+
+def decode_threads(value: object) -> list[Thread]:
+    items = decode_json(value, list)
+    return [Thread.from_dict(item) for item in items if isinstance(item, Mapping)]
+
+
+def decode_events(value: object) -> list[EventRecord]:
+    items = decode_json(value, list)
+    return [EventRecord.from_dict(item) for item in items if isinstance(item, Mapping)]
+
+
+def decode_contacts(value: object) -> list[tuple[str, str]]:
+    items = decode_json(value, list)
+    return [
+        (str(item["name"]), str(item["address"]))
+        for item in items
+        if isinstance(item, Mapping) and "name" in item and "address" in item
+    ]

--- a/src/blueferry/connectivity.py
+++ b/src/blueferry/connectivity.py
@@ -16,6 +16,23 @@ class ConnectivityState(str, Enum):
     STOPPING = "stopping"
 
 
+def is_map_connection_refused(
+    detail: Exception | str = "",
+    *,
+    state: ConnectivityState | str = "",
+) -> bool:
+    """Recognize current state and legacy MAP RFCOMM refusal details."""
+    state_value = state.value if isinstance(state, ConnectivityState) else state
+    if state_value == ConnectivityState.MAP_CONNECTION_REFUSED.value:
+        return True
+    message = str(detail).casefold()
+    return (
+        "createsession(map)" in message
+        and "connection refused" in message
+        and "111" in message
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class RetryPolicy:
     initial_seconds: int = 5

--- a/src/blueferry/contact_repository.py
+++ b/src/blueferry/contact_repository.py
@@ -1,0 +1,211 @@
+"""Persistent contact-cache repository.
+
+PBAP transport and vCard parsing live in :mod:`blueferry.contacts`; this
+module exclusively owns the SQLite schema, replacement transaction, legacy
+plaintext cleanup, and encrypted-record loading.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+from contextlib import closing
+
+from blueferry import config
+from blueferry.events import is_email_shaped
+from blueferry.limits import (
+    MAX_CONTACT_ADDRESS_CHARS,
+    MAX_CONTACT_NAME_CHARS,
+    MAX_PHONEBOOK_CONTACTS,
+)
+from blueferry.storage_security import CorruptStorageError, StorageSecurity
+
+log = logging.getLogger(__name__)
+
+ContactRecord = tuple[str | None, list[str], list[str]]
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS contacts (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    full_name    TEXT NOT NULL,
+    updated_at   REAL NOT NULL
+);
+CREATE TABLE IF NOT EXISTS phones (
+    phone_norm   TEXT NOT NULL,
+    contact_id   INTEGER NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+    UNIQUE(phone_norm, contact_id)
+);
+CREATE INDEX IF NOT EXISTS idx_phones_norm ON phones(phone_norm);
+
+CREATE TABLE IF NOT EXISTS emails (
+    email        TEXT NOT NULL,
+    contact_id   INTEGER NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+    UNIQUE(email, contact_id)
+);
+CREATE INDEX IF NOT EXISTS idx_emails_address ON emails(email);
+
+CREATE TABLE IF NOT EXISTS secure_contacts (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    payload      TEXT NOT NULL
+);
+"""
+
+
+def _open_db() -> sqlite3.Connection:
+    config.ensure_dirs()
+    with config.open_state_file(config.CONTACTS_DB, "a"):
+        pass
+    connection = sqlite3.connect(config.CONTACTS_DB)
+    connection.executescript(_SCHEMA)
+    return connection
+
+
+class ContactRepository:
+    """Replace and load one policy-aware contact cache."""
+
+    def __init__(self, storage: StorageSecurity | None = None) -> None:
+        self.storage = storage
+
+    @staticmethod
+    def _delete_all(connection: sqlite3.Connection) -> None:
+        connection.execute("DELETE FROM phones")
+        connection.execute("DELETE FROM emails")
+        connection.execute("DELETE FROM contacts")
+        connection.execute("DELETE FROM secure_contacts")
+
+    def clear(self) -> None:
+        with closing(_open_db()) as connection:
+            connection.execute("PRAGMA secure_delete = ON")
+            with connection:
+                self._delete_all(connection)
+            connection.execute("VACUUM")
+
+    def replace(self, records: list[ContactRecord]) -> int:
+        now = time.time()
+        with closing(_open_db()) as connection:
+            connection.execute("PRAGMA secure_delete = ON")
+            with connection:
+                self._delete_all(connection)
+                for name, phones, emails in records:
+                    if not name and not phones and not emails:
+                        continue
+                    if self.storage is not None:
+                        payload = json.dumps(
+                            {"name": name or "", "phones": phones, "emails": emails},
+                            ensure_ascii=False,
+                            separators=(",", ":"),
+                        )
+                        connection.execute(
+                            "INSERT INTO secure_contacts(payload) VALUES (?)",
+                            (self.storage.encrypt(
+                                payload, purpose="contact-record-v1"
+                            ),),
+                        )
+                        continue
+                    cursor = connection.execute(
+                        "INSERT INTO contacts(full_name, updated_at) VALUES (?, ?)",
+                        (name or "", now),
+                    )
+                    contact_id = cursor.lastrowid
+                    for phone in phones:
+                        connection.execute(
+                            "INSERT OR IGNORE INTO phones"
+                            "(phone_norm, contact_id) VALUES (?, ?)",
+                            (phone, contact_id),
+                        )
+                    for email in emails:
+                        connection.execute(
+                            "INSERT OR IGNORE INTO emails"
+                            "(email, contact_id) VALUES (?, ?)",
+                            (email, contact_id),
+                        )
+            if self.storage is not None:
+                connection.execute("VACUUM")
+        return len(records)
+
+    @staticmethod
+    def _plaintext_records(connection: sqlite3.Connection) -> list[ContactRecord]:
+        records: list[ContactRecord] = []
+        for contact_id, name in connection.execute(
+            "SELECT id, full_name FROM contacts ORDER BY id"
+        ):
+            phones = [str(row[0]) for row in connection.execute(
+                "SELECT phone_norm FROM phones WHERE contact_id = ? ORDER BY rowid",
+                (contact_id,),
+            )]
+            emails = [str(row[0]) for row in connection.execute(
+                "SELECT email FROM emails WHERE contact_id = ? ORDER BY rowid",
+                (contact_id,),
+            )]
+            records.append((str(name), phones, emails))
+        return records
+
+    @staticmethod
+    def _discard_plaintext(connection: sqlite3.Connection) -> bool:
+        count = int(connection.execute(
+            "SELECT (SELECT COUNT(*) FROM contacts) + "
+            "(SELECT COUNT(*) FROM phones) + "
+            "(SELECT COUNT(*) FROM emails)"
+        ).fetchone()[0])
+        if not count:
+            return False
+        connection.execute("PRAGMA secure_delete = ON")
+        with connection:
+            connection.execute("DELETE FROM phones")
+            connection.execute("DELETE FROM emails")
+            connection.execute("DELETE FROM contacts")
+        return True
+
+    def _secure_records(self, connection: sqlite3.Connection) -> list[ContactRecord]:
+        if self.storage is None or not self.storage.status.can_read:
+            return []
+        records: list[ContactRecord] = []
+        for (payload,) in connection.execute(
+            "SELECT payload FROM secure_contacts ORDER BY id LIMIT ?",
+            (MAX_PHONEBOOK_CONTACTS,),
+        ):
+            try:
+                plaintext = self.storage.decrypt(
+                    str(payload), purpose="contact-record-v1"
+                )
+                value = json.loads(plaintext)
+                if not isinstance(value, dict):
+                    continue
+                name = str(value.get("name") or "")[:MAX_CONTACT_NAME_CHARS]
+                phones = [
+                    str(item) for item in value.get("phones", [])
+                    if isinstance(item, str)
+                    and len(item) <= MAX_CONTACT_ADDRESS_CHARS
+                ]
+                emails = [
+                    str(item).casefold() for item in value.get("emails", [])
+                    if isinstance(item, str)
+                    and len(item) <= MAX_CONTACT_ADDRESS_CHARS
+                    and is_email_shaped(item)
+                ]
+            except CorruptStorageError:
+                self.storage.fail_closed(
+                    "Encrypted contacts could not be authenticated"
+                )
+                return []
+            except (ValueError, RuntimeError, TypeError):
+                continue
+            records.append((name, phones, emails))
+        return records
+
+    def load(self) -> list[ContactRecord]:
+        if self.storage is not None and not self.storage.status.can_read:
+            return []
+        try:
+            with closing(_open_db()) as connection:
+                if self.storage is None:
+                    return self._plaintext_records(connection)
+                discarded = self._discard_plaintext(connection)
+                records = self._secure_records(connection)
+                if discarded:
+                    connection.execute("VACUUM")
+                return records
+        except sqlite3.Error as error:
+            log.warning("contacts cache warm failed: %s", error)
+            return []

--- a/src/blueferry/contacts.py
+++ b/src/blueferry/contacts.py
@@ -6,21 +6,18 @@ not `SetFolder`. Then `PullAll(targetfile, filters)`.
 """
 from __future__ import annotations
 
-import json
 import logging
 import os
 import re
-import sqlite3
 import tempfile
 import time
-from contextlib import closing
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import dbus
 
-from blueferry import config
 from blueferry.bus import obex
+from blueferry.contact_repository import ContactRecord, ContactRepository
 from blueferry.events import is_email_shaped, normalize_phone
 from blueferry.limits import (
     MAX_CONTACT_ADDRESS_CHARS,
@@ -32,7 +29,6 @@ from blueferry.limits import (
 from blueferry.obex.sessions import SessionManager
 from blueferry.obex.transfer import wait_for_transfer
 from blueferry.private_files import ensure_private_directory
-from blueferry.storage_security import CorruptStorageError
 
 if TYPE_CHECKING:
     from blueferry.storage_security import StorageSecurity
@@ -104,57 +100,9 @@ def _parse_vcard_records(
     return out
 
 
-# ---- SQLite schema ------------------------------------------------------
-
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS contacts (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    full_name    TEXT NOT NULL,
-    updated_at   REAL NOT NULL
-);
-CREATE TABLE IF NOT EXISTS phones (
-    phone_norm   TEXT NOT NULL,
-    contact_id   INTEGER NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
-    UNIQUE(phone_norm, contact_id)
-);
-CREATE INDEX IF NOT EXISTS idx_phones_norm ON phones(phone_norm);
-
-CREATE TABLE IF NOT EXISTS emails (
-    email        TEXT NOT NULL,
-    contact_id   INTEGER NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
-    UNIQUE(email, contact_id)
-);
-CREATE INDEX IF NOT EXISTS idx_emails_address ON emails(email);
-
-CREATE TABLE IF NOT EXISTS secure_contacts (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    payload      TEXT NOT NULL
-);
-
-"""
-
-
-def _open_db() -> sqlite3.Connection:
-    config.ensure_dirs()
-    # Create/repair the database through the same fail-closed 0600 path used by
-    # message history before SQLite opens it.
-    with config.open_state_file(config.CONTACTS_DB, "a"):
-        pass
-    conn = sqlite3.connect(config.CONTACTS_DB)
-    conn.executescript(_SCHEMA)
-    return conn
-
-
 def clear_contact_cache() -> None:
     """Erase every retained contact representation."""
-    with closing(_open_db()) as db:
-        db.execute("PRAGMA secure_delete = ON")
-        with db:
-            db.execute("DELETE FROM phones")
-            db.execute("DELETE FROM emails")
-            db.execute("DELETE FROM contacts")
-            db.execute("DELETE FROM secure_contacts")
-        db.execute("VACUUM")
+    ContactRepository().clear()
 
 
 # ---- PBAP pull ----------------------------------------------------------
@@ -256,51 +204,7 @@ def pull_phonebook(
         parsed = _parse_vcard_records(blob, maximum=max_contacts)
         log.info("parsed %d contacts from %d bytes", len(parsed), size)
 
-        now = time.time()
-        with closing(_open_db()) as db:
-            db.execute("PRAGMA secure_delete = ON")
-            with db:  # transaction
-                db.execute("DELETE FROM phones")
-                db.execute("DELETE FROM emails")
-                db.execute("DELETE FROM contacts")
-                db.execute("DELETE FROM secure_contacts")
-                for fn, phones, emails in parsed:
-                    if not fn and not phones and not emails:
-                        continue
-                    if storage is not None:
-                        payload = json.dumps(
-                            {"name": fn or "", "phones": phones, "emails": emails},
-                            ensure_ascii=False,
-                            separators=(",", ":"),
-                        )
-                        db.execute(
-                            "INSERT INTO secure_contacts(payload) VALUES (?)",
-                            (storage.encrypt(
-                                payload, purpose="contact-record-v1"
-                            ),),
-                        )
-                        continue
-                    cur = db.execute(
-                        "INSERT INTO contacts(full_name, updated_at) "
-                        "VALUES (?, ?)",
-                        (fn or "", now),
-                    )
-                    cid = cur.lastrowid
-                    for p in phones:
-                        db.execute(
-                            "INSERT OR IGNORE INTO phones"
-                            "(phone_norm, contact_id) VALUES (?, ?)",
-                            (p, cid),
-                        )
-                    for email in emails:
-                        db.execute(
-                            "INSERT OR IGNORE INTO emails"
-                            "(email, contact_id) VALUES (?, ?)",
-                            (email, cid),
-                        )
-            if storage is not None:
-                db.execute("VACUUM")
-        return len(parsed)
+        return ContactRepository(storage).replace(parsed)
 
 
 # ---- Lookup -------------------------------------------------------------
@@ -315,109 +219,17 @@ class ContactsResolver:
 
     def __init__(self, *, storage: StorageSecurity | None = None) -> None:
         self.storage = storage
+        self._repository = ContactRepository(storage)
         self._mem: dict[str, str] = {}
-        self._records: list[tuple[str, list[str], list[str]]] = []
+        self._records: list[ContactRecord] = []
         self._warm()
 
-    @staticmethod
-    def _plaintext_records(db: sqlite3.Connection) -> list[tuple[str, list[str], list[str]]]:
-        records: list[tuple[str, list[str], list[str]]] = []
-        for contact_id, name in db.execute(
-            "SELECT id, full_name FROM contacts ORDER BY id"
-        ):
-            phones = [str(row[0]) for row in db.execute(
-                "SELECT phone_norm FROM phones WHERE contact_id = ? ORDER BY rowid",
-                (contact_id,),
-            )]
-            emails = [str(row[0]) for row in db.execute(
-                "SELECT email FROM emails WHERE contact_id = ? ORDER BY rowid",
-                (contact_id,),
-            )]
-            records.append((str(name), phones, emails))
-        return records
-
-    def _load_secure(self, db: sqlite3.Connection) -> None:
-        if self.storage is None or not self.storage.status.can_read:
-            return
-        for (payload,) in db.execute(
-            "SELECT payload FROM secure_contacts ORDER BY id LIMIT ?",
-            (MAX_PHONEBOOK_CONTACTS,),
-        ):
-            try:
-                plaintext = self.storage.decrypt(
-                    str(payload), purpose="contact-record-v1"
-                )
-                value = json.loads(plaintext)
-                if not isinstance(value, dict):
-                    continue
-                name = str(value.get("name") or "")[:MAX_CONTACT_NAME_CHARS]
-                phones = [
-                    str(item) for item in value.get("phones", [])
-                    if isinstance(item, str) and len(item) <= MAX_CONTACT_ADDRESS_CHARS
-                ]
-                emails = [
-                    str(item).casefold() for item in value.get("emails", [])
-                    if isinstance(item, str)
-                    and len(item) <= MAX_CONTACT_ADDRESS_CHARS
-                    and is_email_shaped(item)
-                ]
-            except CorruptStorageError:
-                self.storage.fail_closed(
-                    "Encrypted contacts could not be authenticated"
-                )
-                self._mem.clear()
-                self._records.clear()
-                return
-            except (ValueError, RuntimeError, TypeError):
-                continue
-            self._records.append((name, phones, emails))
+    def _warm(self) -> None:
+        self._records.extend(self._repository.load())
+        for name, phones, emails in self._records:
             if name:
                 for address in (*phones, *emails):
                     self._mem[address] = name
-
-    @staticmethod
-    def _discard_plaintext(db: sqlite3.Connection) -> bool:
-        """Remove legacy rows when policy-managed contact storage is active."""
-        count = int(db.execute(
-            "SELECT (SELECT COUNT(*) FROM contacts) + "
-            "(SELECT COUNT(*) FROM phones) + "
-            "(SELECT COUNT(*) FROM emails)"
-        ).fetchone()[0])
-        if not count:
-            return False
-        db.execute("PRAGMA secure_delete = ON")
-        with db:
-            db.execute("DELETE FROM phones")
-            db.execute("DELETE FROM emails")
-            db.execute("DELETE FROM contacts")
-        return True
-
-    def _warm(self) -> None:
-        if self.storage is not None and not self.storage.status.can_read:
-            return
-        try:
-            with closing(_open_db()) as db:
-                if self.storage is not None:
-                    discarded = self._discard_plaintext(db)
-                    self._load_secure(db)
-                    if discarded:
-                        db.execute("VACUUM")
-                    return
-                for phone, name in db.execute(
-                    "SELECT p.phone_norm, c.full_name "
-                    "FROM phones p JOIN contacts c ON c.id = p.contact_id "
-                    "WHERE c.full_name != ''"
-                ):
-                    self._mem[phone] = name
-                for email, name in db.execute(
-                    "SELECT e.email, c.full_name "
-                    "FROM emails e JOIN contacts c ON c.id = e.contact_id "
-                    "WHERE c.full_name != ''"
-                ):
-                    self._mem[email.casefold()] = name
-                self._records.extend(self._plaintext_records(db))
-        except sqlite3.Error as e:
-            log.warning("contacts cache warm failed: %s", e)
 
     def refresh(self) -> int:
         """Re-read the SQLite cache into memory. Returns new count."""

--- a/src/blueferry/contacts.py
+++ b/src/blueferry/contacts.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import sqlite3
 import tempfile
@@ -30,6 +31,7 @@ from blueferry.limits import (
 )
 from blueferry.obex.sessions import SessionManager
 from blueferry.obex.transfer import wait_for_transfer
+from blueferry.private_files import ensure_private_directory
 from blueferry.storage_security import CorruptStorageError
 
 if TYPE_CHECKING:
@@ -155,6 +157,17 @@ def clear_contact_cache() -> None:
 
 # ---- PBAP pull ----------------------------------------------------------
 
+def _phonebook_temp_root() -> Path:
+    """Return an owner-only location for transient plaintext phonebooks."""
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        root = Path(runtime_dir) / "blueferry"
+        ensure_private_directory(root)
+        return root
+    config.ensure_dirs()
+    return config.STATE_DIR
+
+
 def pull_phonebook(
     sessions: SessionManager,
     *,
@@ -172,9 +185,10 @@ def pull_phonebook(
     log.info("PBAP Select(int, pb)")
     pbap.Select("int", "pb", timeout=10.0)
 
-    temp_dir = Path(tempfile.mkdtemp(prefix="blueferry_pb_"))
-    out = temp_dir / "pb.vcf"
-    try:
+    with tempfile.TemporaryDirectory(
+        prefix="phonebook-", dir=_phonebook_temp_root()
+    ) as temporary_name:
+        out = Path(temporary_name) / "pb.vcf"
         log.info("PBAP PullAll → %s (max=%d)", out, max_contacts)
         ret = pbap.PullAll(
             str(out), _pbap_pull_filters(max_contacts), timeout=30.0
@@ -197,18 +211,20 @@ def pull_phonebook(
             raise RuntimeError(
                 f"phonebook exceeds {MAX_PHONEBOOK_BYTES} byte safety limit"
             )
-        def check_size() -> None:
-            if out.exists() and out.stat().st_size > MAX_PHONEBOOK_BYTES:
+        def phonebook_size() -> int:
+            size = out.stat().st_size if out.exists() else 0
+            if size > MAX_PHONEBOOK_BYTES:
                 raise RuntimeError(
                     f"phonebook exceeds {MAX_PHONEBOOK_BYTES} byte safety limit"
                 )
+            return size
 
         status = wait_for_transfer(
             transfer_path,
             initial_status=initial_status,
             timeout_s=60,
             property_timeout_s=10.0,
-            check_progress=check_size,
+            get_progress=phonebook_size,
         )
 
         # obexd may remove a completed transfer object just before its output
@@ -228,7 +244,7 @@ def pull_phonebook(
                 "iPhone returned an empty phonebook; verify Settings → "
                 "Bluetooth → this computer → Sync Contacts is enabled"
             )
-        check_size()
+        phonebook_size()
 
         blob = out.read_text(errors="replace")
         parsed = _parse_vcard_records(blob, maximum=max_contacts)
@@ -279,12 +295,6 @@ def pull_phonebook(
             if storage is not None:
                 db.execute("VACUUM")
         return len(parsed)
-    finally:
-        try:
-            out.unlink(missing_ok=True)
-            temp_dir.rmdir()
-        except OSError:
-            pass
 
 
 # ---- Lookup -------------------------------------------------------------

--- a/src/blueferry/contacts.py
+++ b/src/blueferry/contacts.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+_PHONEBOOK_TRANSFER_MAX_SECONDS = 30 * 60
+
 
 # ---- vCard parsing ------------------------------------------------------
 
@@ -160,12 +162,14 @@ def clear_contact_cache() -> None:
 def _phonebook_temp_root() -> Path:
     """Return an owner-only location for transient plaintext phonebooks."""
     runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
-    if runtime_dir:
-        root = Path(runtime_dir) / "blueferry"
-        ensure_private_directory(root)
-        return root
-    config.ensure_dirs()
-    return config.STATE_DIR
+    if not runtime_dir:
+        raise RuntimeError(
+            "contact sync requires XDG_RUNTIME_DIR so its plaintext "
+            "phonebook cannot be written to persistent storage"
+        )
+    root = Path(runtime_dir) / "blueferry"
+    ensure_private_directory(root)
+    return root
 
 
 def pull_phonebook(
@@ -181,12 +185,13 @@ def pull_phonebook(
     max_contacts = max(1, min(int(max_contacts), MAX_PHONEBOOK_CONTACTS))
     if storage is not None and not storage.status.can_write:
         raise RuntimeError(storage.status.detail)
+    temporary_root = _phonebook_temp_root()
     pbap = obex(sessions.pbap_path, "org.bluez.obex.PhonebookAccess1")
     log.info("PBAP Select(int, pb)")
     pbap.Select("int", "pb", timeout=10.0)
 
     with tempfile.TemporaryDirectory(
-        prefix="phonebook-", dir=_phonebook_temp_root()
+        prefix="phonebook-", dir=temporary_root
     ) as temporary_name:
         out = Path(temporary_name) / "pb.vcf"
         log.info("PBAP PullAll → %s (max=%d)", out, max_contacts)
@@ -223,6 +228,7 @@ def pull_phonebook(
             transfer_path,
             initial_status=initial_status,
             timeout_s=60,
+            overall_timeout_s=_PHONEBOOK_TRANSFER_MAX_SECONDS,
             property_timeout_s=10.0,
             get_progress=phonebook_size,
         )

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -15,6 +15,7 @@ from gi.repository import GLib
 from blueferry import __version__, bluez_setup, config
 from blueferry.ancs.client import AncsClient
 from blueferry.backend_lifecycle import installed_release
+from blueferry.backend_operations import BackendDependencies
 from blueferry.bearer_supervisor import BearerSupervisor
 from blueferry.bus import get_system_bus, main_loop
 from blueferry.connectivity import Connectivity
@@ -149,17 +150,19 @@ class Daemon:
         self._dbus_service = MessagesService(
             self._bus_name,
             self.sessions,
-            on_sent=self.events.sent,
-            on_group_sent=self.events.group_sent,
-            submit_obex=self.obex_worker.submit,
-            pull_contacts=self._pull_contacts,
-            on_contacts_pulled=self._contacts_pulled,
-            contacts=self.contacts,
-            status_provider=self._status,
-            notification_policy=self.notification_policy,
-            on_notification_policy_changed=self._emit_status,
-            storage=self.storage,
-            on_storage_changed=self._emit_status,
+            BackendDependencies(
+                on_sent=self.events.sent,
+                on_group_sent=self.events.group_sent,
+                submit_obex=self.obex_worker.submit,
+                pull_contacts=self._pull_contacts,
+                on_contacts_pulled=self._contacts_pulled,
+                contacts=self.contacts,
+                status_provider=self._status,
+                notification_policy=self.notification_policy,
+                on_notification_policy_changed=self._emit_status,
+                storage=self.storage,
+                on_storage_changed=self._emit_status,
+            ),
         )
         self.events.set_dbus_service(self._dbus_service)
         log.info("DBus service ready: %s", BUS_NAME)

--- a/src/blueferry/dbus_service.py
+++ b/src/blueferry/dbus_service.py
@@ -8,7 +8,7 @@ import dbus
 import dbus.exceptions
 import dbus.service
 
-from blueferry.backend_operations import BackendOperations
+from blueferry.backend_operations import BackendDependencies, BackendOperations, SessionState
 from blueferry.bus import get_session_bus
 from blueferry.dbus_security import CallerGuard
 from blueferry.errors import BlueFerryError, OperationFailedError, ResponseTooLargeError
@@ -32,38 +32,15 @@ class MessagesService(dbus.service.Object):
     def __init__(
         self,
         bus_name: dbus.service.BusName,
-        sessions,
-        on_sent=None,
-        on_group_sent=None,
-        submit_obex=None,
-        pull_contacts=None,
-        on_contacts_pulled=None,
-        contacts=None,
-        status_provider=None,
-        notification_policy=None,
-        on_notification_policy_changed=None,
-        storage=None,
-        on_storage_changed=None,
+        sessions: SessionState,
+        dependencies: BackendDependencies | None = None,
         operations: BackendOperations | None = None,
         caller_guard: CallerGuard | None = None,
     ) -> None:
         super().__init__(bus_name, OBJECT_PATH)
         self._caller_guard = caller_guard or CallerGuard(bus_name.get_bus())
         self._change_revision = 0
-        self.operations = operations or BackendOperations(
-            sessions,
-            on_sent=on_sent,
-            on_group_sent=on_group_sent,
-            submit_obex=submit_obex,
-            pull_contacts=pull_contacts,
-            on_contacts_pulled=on_contacts_pulled,
-            contacts=contacts,
-            status_provider=status_provider,
-            notification_policy=notification_policy,
-            on_notification_policy_changed=on_notification_policy_changed,
-            storage=storage,
-            on_storage_changed=on_storage_changed,
-        )
+        self.operations = operations or BackendOperations(sessions, dependencies)
 
     @staticmethod
     def _dbus_error(error: Exception) -> dbus.exceptions.DBusException:

--- a/src/blueferry/models.py
+++ b/src/blueferry/models.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+from blueferry.connectivity import is_map_connection_refused
 from blueferry.time_display import format_message_timestamp
 
 
@@ -49,6 +50,14 @@ class BackendStatus:
     storage_detail: str = ""
     extra: Mapping[str, Any] = field(default_factory=dict, repr=False)
 
+    @property
+    def map_connection_refused(self) -> bool:
+        """Normalize current and legacy MAP refusal status representations."""
+        return is_map_connection_refused(
+            self.connectivity_detail,
+            state=self.connectivity_state,
+        )
+
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> BackendStatus:
         known = {
@@ -71,6 +80,7 @@ class BackendStatus:
             "storage_policy",
             "storage_state",
             "storage_detail",
+            "map_connection_refused",
         }
         return cls(
             daemon=_bool(value.get("daemon")),
@@ -121,6 +131,7 @@ class BackendStatus:
             "storage_policy": self.storage_policy,
             "storage_state": self.storage_state,
             "storage_detail": self.storage_detail,
+            "map_connection_refused": self.map_connection_refused,
         }
 
 

--- a/src/blueferry/obex/transfer.py
+++ b/src/blueferry/obex/transfer.py
@@ -31,11 +31,12 @@ def wait_for_transfer(
     *,
     initial_status: str = "queued",
     timeout_s: float,
+    overall_timeout_s: float | None = None,
     poll_interval_s: float = 0.1,
     property_timeout_s: float | None = None,
     get_status: Callable[[], str] | None = None,
     check_progress: Callable[[], None] | None = None,
-    get_progress: Callable[[], object] | None = None,
+    get_progress: Callable[[], int] | None = None,
     monotonic: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
 ) -> str:
@@ -46,7 +47,8 @@ def wait_for_transfer(
     unrelated bus failures remain failures. A non-terminal status at the
     deadline is always a timeout, never an implicit success. When
     ``get_progress`` is supplied, the deadline measures inactivity and is
-    restarted whenever its value changes.
+    restarted whenever its integer value increases. ``overall_timeout_s``
+    optionally imposes a hard deadline that progress cannot extend.
     """
     status = str(initial_status or "queued").casefold()
     if check_progress is not None:
@@ -65,15 +67,28 @@ def wait_for_transfer(
         status_reader = read_status
 
     timeout = max(0.0, float(timeout_s))
-    deadline = monotonic() + timeout
+    started_at = monotonic()
+    deadline = started_at + timeout
+    overall_deadline = (
+        started_at + max(0.0, float(overall_timeout_s))
+        if overall_timeout_s is not None
+        else None
+    )
     last_progress = get_progress() if get_progress is not None else None
     while status not in {"complete", "error"}:
         if get_progress is not None:
             progress = get_progress()
-            if progress != last_progress:
+            if last_progress is None or progress > last_progress:
                 last_progress = progress
                 deadline = monotonic() + timeout
-        if monotonic() >= deadline:
+        now = monotonic()
+        if overall_deadline is not None and now >= overall_deadline:
+            raise TimeoutError(
+                f"OBEX transfer {transfer_path} exceeded its "
+                f"{overall_timeout_s:g}s overall limit "
+                f"(last status: {status or 'unknown'})"
+            )
+        if now >= deadline:
             raise TimeoutError(
                 f"OBEX transfer {transfer_path} timed out after {timeout_s:g}s "
                 f"(last status: {status or 'unknown'})"

--- a/src/blueferry/obex/transfer.py
+++ b/src/blueferry/obex/transfer.py
@@ -35,6 +35,7 @@ def wait_for_transfer(
     property_timeout_s: float | None = None,
     get_status: Callable[[], str] | None = None,
     check_progress: Callable[[], None] | None = None,
+    get_progress: Callable[[], object] | None = None,
     monotonic: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
 ) -> str:
@@ -43,7 +44,9 @@ def wait_for_transfer(
     BlueZ removes short-lived transfer objects soon after completion. Only an
     explicit UnknownObject/NotFound error represents that successful race;
     unrelated bus failures remain failures. A non-terminal status at the
-    deadline is always a timeout, never an implicit success.
+    deadline is always a timeout, never an implicit success. When
+    ``get_progress`` is supplied, the deadline measures inactivity and is
+    restarted whenever its value changes.
     """
     status = str(initial_status or "queued").casefold()
     if check_progress is not None:
@@ -61,8 +64,15 @@ def wait_for_transfer(
 
         status_reader = read_status
 
-    deadline = monotonic() + max(0.0, float(timeout_s))
+    timeout = max(0.0, float(timeout_s))
+    deadline = monotonic() + timeout
+    last_progress = get_progress() if get_progress is not None else None
     while status not in {"complete", "error"}:
+        if get_progress is not None:
+            progress = get_progress()
+            if progress != last_progress:
+                last_progress = progress
+                deadline = monotonic() + timeout
         if monotonic() >= deadline:
             raise TimeoutError(
                 f"OBEX transfer {transfer_path} timed out after {timeout_s:g}s "

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -694,6 +694,24 @@ def forget_device(mac: str) -> None:
     log.info("cleared configured BlueFerry target %s", normalized)
 
 
+def prepare_target_replacement(previous_mac: str, next_mac: str) -> None:
+    """Clear the saved target without losing the unpaired device being selected."""
+    previous = previous_mac.strip().upper()
+    selected = next_mac.strip().upper()
+    if not config.is_valid_mac(previous) or not config.is_valid_mac(selected):
+        raise PairingError("invalid Bluetooth device address")
+    device = _find_device(previous)
+    if previous != selected or (device is not None and device.paired):
+        forget_device(previous)
+        return
+    # A stale saved MAC can refer to the unpaired device just discovered for
+    # this attempt. Removing that BlueZ object would also remove the scan
+    # result before complete_pairing() can address it.
+    _stop_user_service()
+    clear_local_target()
+    log.info("cleared stale BlueFerry target %s before pairing", previous)
+
+
 def clear_local_target() -> Path:
     """Forget the selected phone without discarding unrelated preferences."""
     existing = config.read_local_env(LOCAL_ENV_PATH)

--- a/src/blueferry/profile_supervisor.py
+++ b/src/blueferry/profile_supervisor.py
@@ -12,23 +12,13 @@ from typing import Any, Protocol
 
 from gi.repository import GLib
 
-from blueferry.connectivity import Connectivity
+from blueferry.connectivity import Connectivity, is_map_connection_refused
 from blueferry.obex.sessions import ObexSession, SessionError
 
 log = logging.getLogger(__name__)
 
 INITIAL_MAP_CONNECT_POLL_SECONDS = 5
 MAP_RECONNECT_POLL_SECONDS = 15
-
-
-def _is_map_connection_refused(error: Exception | str) -> bool:
-    """Recognize the iPhone's explicit MAP RFCOMM refusal."""
-    message = str(error).casefold()
-    return (
-        "createsession(map)" in message
-        and "connection refused" in message
-        and "111" in message
-    )
 
 
 class ProfileSessions(Protocol):
@@ -199,7 +189,7 @@ class ProfileSupervisor:
         if authorization_required:
             log.warning("  → Check Show Message Notifications and Sync Contacts")
             log.warning("    under the iPhone's Bluetooth entry for this computer.")
-        map_connection_refused = _is_map_connection_refused(error)
+        map_connection_refused = is_map_connection_refused(error)
         if map_connection_refused:
             log.warning(
                 "  → iPhone refused MAP; it may be connected to another computer."

--- a/src/blueferry/protocol.py
+++ b/src/blueferry/protocol.py
@@ -6,6 +6,15 @@ MESSAGES_IFACE = f"{BUS_NAME}.Messages1"
 EVENTS_IFACE = f"{BUS_NAME}.Events1"
 ERROR_PREFIX = f"{BUS_NAME}.Error"
 
+# Read/control timeouts are part of the client policy rather than toolkit
+# behavior. Keep them here so synchronous, GTK, Qt, and TUI callers agree.
+STATUS_CALL_TIMEOUT_SEC = 10
+SNAPSHOT_CALL_TIMEOUT_SEC = 20
+CONTACT_CALL_TIMEOUT_SEC = 8
+POLICY_CALL_TIMEOUT_SEC = 10
+STORAGE_CALL_TIMEOUT_SEC = 30
+CLEAR_CALL_TIMEOUT_SEC = 20
+
 # One phonebook pull or incoming-body fetch may already be ahead of an
 # interactive request on the serialized OBEX worker. This is a client-side
 # D-Bus wait limit, not an individual Bluetooth transfer timeout.

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -70,6 +70,7 @@ class BridgeController(QObject):
         self._error_text = ""
         self._compatibility: dict = {}
         self._configured = False
+        self._target_saved = False
         self._configured_mac = ""
         self._setup_loaded = False
         self._onboarding_stage = str(
@@ -130,6 +131,10 @@ class BridgeController(QObject):
     @Property(bool, notify=configuredChanged)
     def configured(self) -> bool:
         return self._configured
+
+    @Property(bool, notify=configuredChanged)
+    def targetSaved(self) -> bool:
+        return self._target_saved
 
     @Property(str, notify=configuredChanged)
     def configuredMac(self) -> str:
@@ -250,6 +255,7 @@ class BridgeController(QObject):
         def ready(result: object) -> None:
             configuration, status = result
             self._configured = configuration.configured
+            self._target_saved = configuration.saved
             self._configured_mac = configuration.mac
             self._setup_loaded = True
             self.configuredChanged.emit()
@@ -284,6 +290,7 @@ class BridgeController(QObject):
             compatibility, configuration = value
             self._compatibility = compatibility.to_dict()
             self._configured = configuration.configured
+            self._target_saved = configuration.saved
             self._configured_mac = configuration.mac
             self._setup_loaded = True
             self._bluetooth_active = compatibility.bearer_api_active
@@ -519,8 +526,16 @@ class BridgeController(QObject):
 
     @Slot(str)
     def completePairing(self, mac: str) -> None:
+        self._start_pairing(mac)
+
+    @Slot(str, str)
+    def replaceAndPair(self, previous_mac: str, mac: str) -> None:
+        self._start_pairing(mac, replace_saved_mac=previous_mac)
+
+    def _start_pairing(self, mac: str, *, replace_saved_mac: str = "") -> None:
         def completed(_value: object) -> None:
             self._configured = True
+            self._target_saved = True
             self._configured_mac = mac
             self.configuredChanged.emit()
             self._update_onboarding_stage()
@@ -551,17 +566,34 @@ class BridgeController(QObject):
             # without prompting the user twice.
             _ = passkey
 
+        def operation():
+            if replace_saved_mac:
+                return self._setup.complete_isolated(
+                    mac,
+                    confirmation=confirm,
+                    display=display,
+                    replace_saved_mac=replace_saved_mac,
+                )
+            return self._setup.complete_isolated(
+                mac,
+                confirmation=confirm,
+                display=display,
+            )
+
+        def failed(message: str) -> None:
+            self._operation_failed(message)
+            if replace_saved_mac:
+                self.loadSetupState()
+                self.loadDevices(False)
+
         self._run(
             # PairingAgent callbacks require a dispatching GLib D-Bus loop.
             # Qt setup work runs on a worker whose private dbus-python
             # connection deliberately uses NULL_MAIN_LOOP, so host the agent
             # in the same isolated helper used by the GTK client.
-            lambda: self._setup.complete_isolated(
-                mac,
-                confirmation=confirm,
-                display=display,
-            ),
+            operation,
             completed,
+            failed,
         )
 
     @Slot(bool)
@@ -579,6 +611,7 @@ class BridgeController(QObject):
     def forgetDevice(self, mac: str) -> None:
         def completed(_value: object) -> None:
             self._configured = False
+            self._target_saved = False
             self._configured_mac = ""
             self._status = {}
             self._threads = []

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -290,6 +290,23 @@ Kirigami.ApplicationWindow {
     }
 
     Kirigami.PromptDialog {
+        id: replaceTargetDialog
+        property string mac: ""
+        title: qsTr("Replace the Saved iPhone?")
+        subtitle: qsTr("Pairing this iPhone will remove BlueFerry's saved phone and its local Bluetooth bond. Before continuing, also forget this computer in the old iPhone's Bluetooth settings.")
+        dialogType: Kirigami.PromptDialog.Warning
+        standardButtons: Kirigami.Dialog.Cancel
+        customFooterActions: [Kirigami.Action {
+            text: qsTr("Replace and Pair")
+            icon.name: "edit-delete-remove"
+            onTriggered: {
+                root.bridge.replaceAndPair(root.bridge.configuredMac, replaceTargetDialog.mac)
+                replaceTargetDialog.close()
+            }
+        }]
+    }
+
+    Kirigami.PromptDialog {
         id: shortcutsDialog
         title: qsTr("Keyboard Shortcuts")
         subtitle: qsTr("Refresh — Ctrl+R\nQuit — Ctrl+Q\nKeyboard Shortcuts — Ctrl+?")
@@ -714,7 +731,7 @@ Kirigami.ApplicationWindow {
                     Layout.fillWidth: true
                     visible: !root.bridge.configured
                     wrapMode: Text.Wrap
-                    text: qsTr("Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds.")
+                    text: qsTr("Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. While it does, return to the Bluetooth device list and reopen this computer's ⓘ page a few times; turn on any new toggles that appear.")
                 }
 
                 Kirigami.FormLayout {
@@ -819,7 +836,14 @@ Kirigami.ApplicationWindow {
                         enabled: iphonePage.device !== null
                             && root.bridge.compatibility.pairing_ready
                             && !root.bridge.busy
-                        onClicked: root.bridge.completePairing(iphonePage.device.mac)
+                        onClicked: {
+                            if (!iphonePage.device.paired && root.bridge.targetSaved) {
+                                replaceTargetDialog.mac = iphonePage.device.mac
+                                replaceTargetDialog.open()
+                            } else {
+                                root.bridge.completePairing(iphonePage.device.mac)
+                            }
+                        }
                     }
                     Controls.Button {
                         text: qsTr("Forget")

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -57,36 +57,7 @@ Kirigami.ApplicationWindow {
 
     function mapConnectionRefused() {
         const status = bridge.status || ({})
-        if (status.connectivity_state === "map-connection-refused")
-            return true
-        const detail = String(status.connectivity_detail || "").toLowerCase()
-        return detail.indexOf("createsession(map)") >= 0
-            && detail.indexOf("connection refused") >= 0
-            && detail.indexOf("111") >= 0
-    }
-
-    function pendingIphoneSetupTasks() {
-        const verified = bridge.status.verified_iphone_setup || []
-        const tasks = []
-        if (verified.indexOf("message-notifications") < 0)
-            tasks.push(qsTr("Enable Show Message Notifications"))
-        if (verified.indexOf("contacts") < 0)
-            tasks.push(qsTr("Enable Sync Contacts"))
-        if (bridge.compatibility.notifications_supported
-                && verified.indexOf("notification-access") < 0)
-            tasks.push(qsTr("Allow Notification Access when prompted"))
-        return tasks
-    }
-
-    function pendingIphoneSetupText() {
-        const tasks = pendingIphoneSetupTasks()
-        let detail = qsTr("Open Settings → Bluetooth on the iPhone, tap ⓘ next to this computer, then finish the settings below. After approving “Allow System Notifications,” you may need to return to the Bluetooth device list and reopen this computer before the other settings appear:\n• ")
-            + tasks.join("\n• ")
-        const verified = bridge.status.verified_iphone_setup || []
-        if (bridge.compatibility.notifications_supported
-                && verified.indexOf("notification-access") < 0)
-            detail += qsTr("\n\nWithout System Notification access, group texts appear as individual conversations with their sender.")
-        return detail
+        return status.map_connection_refused === true
     }
 
     function openPhoneSettings() {
@@ -113,34 +84,6 @@ Kirigami.ApplicationWindow {
             closePhoneSettings()
         else
             openPhoneSettings()
-    }
-
-    function onboardingTitle(stage) {
-        const titles = {
-            "checking": qsTr("Checking Bluetooth Support"),
-            "incompatible": qsTr("Bluetooth Controller Is Not Compatible"),
-            "activate-bluetooth": qsTr("Activate Bluetooth Support"),
-            "select-device": qsTr("Pair an iPhone"),
-            "starting": qsTr("Starting the Background Service"),
-            "iphone-settings": qsTr("Finish Setup on the iPhone"),
-            "ready": qsTr("BlueFerry Is Connected"),
-            "ready-without-ancs": qsTr("Messages Are Connected")
-        }
-        return titles[stage] || qsTr("Set Up BlueFerry")
-    }
-
-    function onboardingDetail(stage) {
-        const details = {
-            "checking": qsTr("Inspecting the selected Bluetooth controller without changing it."),
-            "incompatible": bridge.compatibility.issue || qsTr("A controller with BR/EDR and secure pairing is required."),
-            "activate-bluetooth": qsTr("The packaged BlueZ bearer support needs one authorized Bluetooth restart."),
-            "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."),
-            "starting": qsTr("The configured backend is starting. This normally takes a few seconds."),
-            "iphone-settings": pendingIphoneSetupText(),
-            "ready": qsTr("Bluetooth services and iPhone permissions have been verified."),
-            "ready-without-ancs": qsTr("Messages and contacts have been verified. System notifications are unavailable, so group texts may appear as individual conversations.")
-        }
-        return details[stage] || ""
     }
 
     Connections {
@@ -755,17 +698,11 @@ Kirigami.ApplicationWindow {
                     text: qsTr("Keep the iPhone unlocked with its Bluetooth settings open during pairing.")
                 }
 
-                Kirigami.InlineMessage {
+                OnboardingSummary {
                     Layout.fillWidth: true
-                    visible: true
-                    text: root.htmlEscape(root.onboardingTitle(iphonePage.effectiveStage))
-                        + "\n" + root.htmlEscape(root.onboardingDetail(iphonePage.effectiveStage))
-                    type: iphonePage.effectiveStage === "incompatible"
-                        ? Kirigami.MessageType.Warning
-                        : iphonePage.effectiveStage === "ready"
-                            || iphonePage.effectiveStage === "ready-without-ancs"
-                            ? Kirigami.MessageType.Positive
-                            : Kirigami.MessageType.Information
+                    stage: iphonePage.effectiveStage
+                    compatibility: root.bridge.compatibility
+                    status: root.bridge.status
                 }
 
                 Kirigami.Heading {

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -413,6 +413,11 @@ Kirigami.ApplicationWindow {
                         modelData.address.indexOf("@") >= 0
                             ? modelData.address : "+" + modelData.address
                     )
+                    contentItem: Controls.Label {
+                        text: contactDelegate.text
+                        textFormat: Text.PlainText
+                        elide: Text.ElideRight
+                    }
                     onClicked: {
                         newRecipient.text = modelData.address
                         root.bridge.findContacts("")
@@ -782,6 +787,7 @@ Kirigami.ApplicationWindow {
                     Controls.Label {
                         Kirigami.FormData.label: qsTr("Controller:")
                         text: root.bridge.compatibility.adapter || qsTr("Checking…")
+                        textFormat: Text.PlainText
                     }
 
                     Controls.Label {
@@ -846,6 +852,23 @@ Kirigami.ApplicationWindow {
                         textRole: "display_name"
                         valueRole: "mac"
                         enabled: !root.bridge.busy
+                        delegate: Controls.ItemDelegate {
+                            id: deviceOption
+                            required property var modelData
+                            width: deviceCombo.width
+                            text: modelData.display_name
+                            contentItem: Controls.Label {
+                                text: deviceOption.text
+                                textFormat: Text.PlainText
+                                elide: Text.ElideRight
+                            }
+                        }
+                        contentItem: Controls.Label {
+                            text: deviceCombo.displayText
+                            textFormat: Text.PlainText
+                            verticalAlignment: Text.AlignVCenter
+                            elide: Text.ElideRight
+                        }
                         onCurrentIndexChanged: iphonePage.selectedDevice = currentIndex
                     }
                 }
@@ -882,6 +905,7 @@ Kirigami.ApplicationWindow {
                         text: iphonePage.configuredDevice !== null
                             ? iphonePage.configuredDevice.name
                             : qsTr("iPhone")
+                        textFormat: Text.PlainText
                     }
                     Controls.Button {
                         text: qsTr("Unpair")

--- a/src/blueferry/qt/qml/MessageBubble.qml
+++ b/src/blueferry/qt/qml/MessageBubble.qml
@@ -10,6 +10,15 @@ Rectangle {
 
     required property var message
     required property real availableWidth
+    readonly property color outgoingBackground: Qt.rgba(
+        Kirigami.Theme.backgroundColor.r * 0.78
+            + Kirigami.Theme.highlightColor.r * 0.22,
+        Kirigami.Theme.backgroundColor.g * 0.78
+            + Kirigami.Theme.highlightColor.g * 0.22,
+        Kirigami.Theme.backgroundColor.b * 0.78
+            + Kirigami.Theme.highlightColor.b * 0.22,
+        1
+    )
 
     width: Math.min(
         availableWidth * 0.78,
@@ -18,7 +27,7 @@ Rectangle {
     implicitHeight: bodyColumn.implicitHeight + Kirigami.Units.largeSpacing
     radius: Kirigami.Units.cornerRadius
     color: message.outgoing
-        ? Kirigami.Theme.highlightColor
+        ? outgoingBackground
         : Kirigami.Theme.alternateBackgroundColor
 
     ColumnLayout {
@@ -35,9 +44,7 @@ Rectangle {
             selectByMouse: true
             wrapMode: Text.Wrap
             background: null
-            color: root.message.outgoing
-                ? Kirigami.Theme.highlightedTextColor
-                : Kirigami.Theme.textColor
+            color: Kirigami.Theme.textColor
             Accessible.name: qsTr("Message: ") + text
         }
         Controls.Label {
@@ -46,9 +53,7 @@ Rectangle {
             textFormat: Text.PlainText
             font: Kirigami.Theme.smallFont
             opacity: 0.7
-            color: root.message.outgoing
-                ? Kirigami.Theme.highlightedTextColor
-                : Kirigami.Theme.textColor
+            color: Kirigami.Theme.textColor
         }
     }
 }

--- a/src/blueferry/qt/qml/OnboardingSummary.qml
+++ b/src/blueferry/qt/qml/OnboardingSummary.qml
@@ -1,0 +1,76 @@
+import QtQuick
+import org.kde.kirigami as Kirigami
+
+Kirigami.InlineMessage {
+    id: root
+
+    required property string stage
+    required property var compatibility
+    required property var status
+
+    visible: true
+    text: htmlEscape(titleForStage()) + "\n" + htmlEscape(detailForStage())
+    type: stage === "incompatible"
+        ? Kirigami.MessageType.Warning
+        : stage === "ready" || stage === "ready-without-ancs"
+            ? Kirigami.MessageType.Positive
+            : Kirigami.MessageType.Information
+
+    function htmlEscape(value) {
+        return String(value || "")
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+    }
+
+    function pendingTasks() {
+        const verified = status.verified_iphone_setup || []
+        const tasks = []
+        if (verified.indexOf("message-notifications") < 0)
+            tasks.push(qsTr("Enable Show Message Notifications"))
+        if (verified.indexOf("contacts") < 0)
+            tasks.push(qsTr("Enable Sync Contacts"))
+        if (compatibility.notifications_supported
+                && verified.indexOf("notification-access") < 0)
+            tasks.push(qsTr("Allow Notification Access when prompted"))
+        return tasks
+    }
+
+    function pendingTasksText() {
+        let detail = qsTr("Open Settings → Bluetooth on the iPhone, tap ⓘ next to this computer, then finish the settings below. After approving “Allow System Notifications,” you may need to return to the Bluetooth device list and reopen this computer before the other settings appear:\n• ")
+            + pendingTasks().join("\n• ")
+        const verified = status.verified_iphone_setup || []
+        if (compatibility.notifications_supported
+                && verified.indexOf("notification-access") < 0)
+            detail += qsTr("\n\nWithout System Notification access, group texts appear as individual conversations with their sender.")
+        return detail
+    }
+
+    function titleForStage() {
+        const titles = {
+            "checking": qsTr("Checking Bluetooth Support"),
+            "incompatible": qsTr("Bluetooth Controller Is Not Compatible"),
+            "activate-bluetooth": qsTr("Activate Bluetooth Support"),
+            "select-device": qsTr("Pair an iPhone"),
+            "starting": qsTr("Starting the Background Service"),
+            "iphone-settings": qsTr("Finish Setup on the iPhone"),
+            "ready": qsTr("BlueFerry Is Connected"),
+            "ready-without-ancs": qsTr("Messages Are Connected")
+        }
+        return titles[stage] || qsTr("Set Up BlueFerry")
+    }
+
+    function detailForStage() {
+        const details = {
+            "checking": qsTr("Inspecting the selected Bluetooth controller without changing it."),
+            "incompatible": compatibility.issue || qsTr("A controller with BR/EDR and secure pairing is required."),
+            "activate-bluetooth": qsTr("The packaged BlueZ bearer support needs one authorized Bluetooth restart."),
+            "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."),
+            "starting": qsTr("The configured backend is starting. This normally takes a few seconds."),
+            "iphone-settings": pendingTasksText(),
+            "ready": qsTr("Bluetooth services and iPhone permissions have been verified."),
+            "ready-without-ancs": qsTr("Messages and contacts have been verified. System notifications are unavailable, so group texts may appear as individual conversations.")
+        }
+        return details[stage] || ""
+    }
+}

--- a/src/blueferry/qt/qml/OnboardingSummary.qml
+++ b/src/blueferry/qt/qml/OnboardingSummary.qml
@@ -65,7 +65,7 @@ Kirigami.InlineMessage {
             "checking": qsTr("Inspecting the selected Bluetooth controller without changing it."),
             "incompatible": compatibility.issue || qsTr("A controller with BR/EDR and secure pairing is required."),
             "activate-bluetooth": qsTr("The packaged BlueZ bearer support needs one authorized Bluetooth restart."),
-            "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."),
+            "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. While it does, return to the Bluetooth device list and reopen this computer's ⓘ page a few times; turn on any new toggles that appear. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."),
             "starting": qsTr("The configured backend is starting. This normally takes a few seconds."),
             "iphone-settings": pendingTasksText(),
             "ready": qsTr("Bluetooth services and iPhone permissions have been verified."),

--- a/src/blueferry/setup_client.py
+++ b/src/blueferry/setup_client.py
@@ -199,17 +199,21 @@ class SetupClient:
         *,
         confirmation: pair_setup.ConfirmationCallback,
         display: pair_setup.DisplayCallback | None = None,
+        replace_saved_mac: str = "",
     ) -> PairingResult:
         """Run interactive pairing in a D-Bus/GLib-isolated child process."""
+        command = [
+            sys.executable,
+            "-m",
+            "blueferry",
+            "pairing-complete",
+            mac,
+            "--interactive-agent",
+        ]
+        if replace_saved_mac:
+            command.extend(["--replace-saved-mac", replace_saved_mac])
         process = subprocess.Popen(  # nosec B603
-            [
-                sys.executable,
-                "-m",
-                "blueferry",
-                "pairing-complete",
-                mac,
-                "--interactive-agent",
-            ],
+            command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -248,3 +252,6 @@ class SetupClient:
 
     def forget(self, mac: str) -> None:
         pair_setup.forget_device(mac)
+
+    def prepare_replacement(self, previous_mac: str, next_mac: str) -> None:
+        pair_setup.prepare_target_replacement(previous_mac, next_mac)

--- a/src/blueferry/storage_security.py
+++ b/src/blueferry/storage_security.py
@@ -78,8 +78,7 @@ class SecretServiceKeyProvider:
         Secret = self._secret_module()
         try:
             service = Secret.Service.get_sync(
-                Secret.ServiceFlags.LOAD_COLLECTIONS
-                | Secret.ServiceFlags.OPEN_SESSION,
+                Secret.ServiceFlags.OPEN_SESSION,
                 None,
             )
             schema = Secret.Schema.new(
@@ -134,8 +133,9 @@ class SecretServiceKeyProvider:
         except StorageUnavailableError:
             raise
         except Exception as error:
-            # Do not leak provider-specific D-Bus details through status or logs.
-            log.info("Secret Service is not ready: %s", type(error).__name__)
+            # Keep provider-specific details out of the public status while
+            # retaining the actionable D-Bus error in the local journal.
+            log.info("Secret Service is not ready: %s", error)
             raise StorageUnavailableError("the desktop keyring is unavailable") from error
 
     def delete(self, *, allow_prompt: bool) -> bool:

--- a/src/blueferry/ui/app.py
+++ b/src/blueferry/ui/app.py
@@ -27,8 +27,8 @@ APP_ID = "io.weirdware.BlueFerry.Gtk"
 _CSS = """
 .msg-bubble { padding: 6px 10px; }
 .msg-out {
-  background: var(--accent-bg-color);
-  color: var(--accent-fg-color);
+  background: @accent_bg_color;
+  color: @accent_fg_color;
 }
 """
 

--- a/src/blueferry/ui/client.py
+++ b/src/blueferry/ui/client.py
@@ -12,7 +12,6 @@ Slow methods are issued asynchronously so the UI never blocks.
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -25,14 +24,26 @@ from gi.repository import GLib, GObject
 
 from blueferry.backend_lifecycle import ensure_backend_current
 from blueferry.bus import get_session_bus
+from blueferry.client_wire import (
+    decode_contacts,
+    decode_mapping,
+    decode_status,
+    decode_threads,
+)
 from blueferry.models import BackendStatus, Thread
 from blueferry.pair_setup import configuration_status
 from blueferry.protocol import (
     BUS_NAME,
+    CLEAR_CALL_TIMEOUT_SEC,
+    CONTACT_CALL_TIMEOUT_SEC,
     EVENTS_IFACE,
     MESSAGES_IFACE,
     OBEX_CALL_TIMEOUT_SEC,
     OBJECT_PATH,
+    POLICY_CALL_TIMEOUT_SEC,
+    SNAPSHOT_CALL_TIMEOUT_SEC,
+    STATUS_CALL_TIMEOUT_SEC,
+    STORAGE_CALL_TIMEOUT_SEC,
 )
 
 log = logging.getLogger(__name__)
@@ -192,11 +203,9 @@ class DaemonClient(GObject.Object):
     def ensure_backend_current_async(self) -> None:
         def operation() -> Mapping:
             def private_status() -> dict:
-                raw = str(self._private_call("GetStatus", timeout=20))
-                value = json.loads(raw)
-                if not isinstance(value, dict):
-                    raise ValueError("backend returned an invalid status response")
-                return value
+                return decode_mapping(self._private_call(
+                    "GetStatus", timeout=SNAPSHOT_CALL_TIMEOUT_SEC
+                ))
 
             return ensure_backend_current(status_reader=private_status)
 
@@ -280,18 +289,11 @@ class DaemonClient(GObject.Object):
 
     def list_threads_async(self, on_ok, on_err=None, limit: int = 1000) -> None:
         def operation() -> list[Thread]:
-            raw = str(
+            return decode_threads(
                 self._private_call(
-                    "ListThreads",
-                    dbus.UInt32(limit),
-                    timeout=20,
+                    "ListThreads", dbus.UInt32(limit),
+                    timeout=SNAPSHOT_CALL_TIMEOUT_SEC,
                 )
-            )
-            value = json.loads(raw)
-            return (
-                [Thread.from_dict(item) for item in value if isinstance(item, Mapping)]
-                if isinstance(value, list)
-                else []
             )
 
         self._submit(operation, on_ok, on_err)
@@ -304,60 +306,52 @@ class DaemonClient(GObject.Object):
             return
 
         def operation() -> list[tuple[str, str]]:
-            raw = str(
+            return decode_contacts(
                 self._private_call(
-                    "FindContacts",
-                    selected,
-                    timeout=8,
+                    "FindContacts", selected, timeout=CONTACT_CALL_TIMEOUT_SEC,
                 )
             )
-            value = json.loads(raw)
-            if not isinstance(value, list):
-                return []
-            return [
-                (str(item["name"]), str(item["address"]))
-                for item in value
-                if isinstance(item, Mapping)
-                and "name" in item
-                and "address" in item
-            ]
 
         self._submit(operation, on_ok, on_err)
 
     def get_status_async(self, on_ok, on_err=None) -> None:
         def operation() -> BackendStatus:
-            raw = str(self._private_call("GetStatus", timeout=10))
-            value = json.loads(raw)
-            return BackendStatus.from_dict(value) if isinstance(value, dict) else BackendStatus()
+            return decode_status(self._private_call(
+                "GetStatus", timeout=STATUS_CALL_TIMEOUT_SEC
+            ))
 
         self._submit(operation, on_ok, on_err)
 
     def clear_history_async(self, on_ok, on_err) -> None:
         self._submit(
-            lambda: self._private_call("ClearHistory", dbus.Boolean(True), timeout=20),
+            lambda: self._private_call(
+                "ClearHistory", dbus.Boolean(True), timeout=CLEAR_CALL_TIMEOUT_SEC
+            ),
             lambda _value: on_ok(),
             on_err,
         )
 
     def set_notification_policy_async(self, policy: str, on_ok, on_err) -> None:
         self._submit(
-            lambda: str(self._private_call("SetNotificationPolicy", policy, timeout=10)),
+            lambda: str(self._private_call(
+                "SetNotificationPolicy", policy, timeout=POLICY_CALL_TIMEOUT_SEC
+            )),
             on_ok,
             on_err,
         )
 
     def set_storage_policy_async(self, policy: str, on_ok, on_err) -> None:
         def operation() -> dict:
-            raw = str(self._private_call("SetStoragePolicy", policy, timeout=30))
-            value = json.loads(raw)
-            return value if isinstance(value, dict) else {}
+            return decode_mapping(self._private_call(
+                "SetStoragePolicy", policy, timeout=STORAGE_CALL_TIMEOUT_SEC
+            ))
 
         self._submit(operation, on_ok, on_err)
 
     def unlock_storage_async(self, on_ok, on_err) -> None:
         def operation() -> dict:
-            raw = str(self._private_call("UnlockStorage", timeout=30))
-            value = json.loads(raw)
-            return value if isinstance(value, dict) else {}
+            return decode_mapping(self._private_call(
+                "UnlockStorage", timeout=STORAGE_CALL_TIMEOUT_SEC
+            ))
 
         self._submit(operation, on_ok, on_err)

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -54,7 +54,9 @@ class IPhonePage(Gtk.Box):
                 "Scan for and select your iPhone here, then choose Pair. On the "
                 "iPhone, open Settings → Bluetooth, find this computer under "
                 '"Other Devices", tap it, and approve the matching codes. Pairing '
-                "may appear idle for up to 15 seconds. System Notification "
+                "may appear idle for up to 15 seconds. While it does, return to "
+                "the Bluetooth device list and reopen this computer's ⓘ page a "
+                "few times; turn on any new toggles that appear. System Notification "
                 "access is also how BlueFerry recognizes group text threads; "
                 "without it, a group text appears as a one-to-one conversation "
                 "with its sender."
@@ -100,7 +102,7 @@ class IPhonePage(Gtk.Box):
 
         pair = Adw.ActionRow(
             title=_("2. Pair the Selected iPhone"),
-            subtitle=_("Confirm the code, then allow up to 15 seconds to finish"),
+            subtitle=_("Confirm the code, then watch the iPhone for new toggles"),
         )
         self._setup_spinner = Gtk.Spinner(valign=Gtk.Align.CENTER)
         pair.add_suffix(self._setup_spinner)
@@ -195,7 +197,11 @@ class IPhonePage(Gtk.Box):
         daemon_group.add(self._daemon_row)
         daemon_group.add(self._map_row)
         self._pbap_row = Adw.ActionRow(title=_("Contacts"))
+        self._pbap_icon = Gtk.Image()
+        self._pbap_row.add_suffix(self._pbap_icon)
         self._ancs_row = Adw.ActionRow(title=_("iPhone Notifications"))
+        self._ancs_icon = Gtk.Image()
+        self._ancs_row.add_suffix(self._ancs_icon)
         daemon_group.add(self._pbap_row)
         daemon_group.add(self._ancs_row)
         page.add(daemon_group)
@@ -449,6 +455,42 @@ class IPhonePage(Gtk.Box):
         if not device:
             self._toast(_("Scan for and select an iPhone first"))
             return
+        configuration = self._configuration
+        if device.paired or configuration is None or not configuration.saved:
+            self._start_pairing(device)
+            return
+
+        dialog = Adw.AlertDialog(
+            heading=_("Replace the Saved iPhone?"),
+            body=_(
+                "Pairing this iPhone will remove BlueFerry's saved phone and "
+                "its local Bluetooth bond. Before continuing, also forget this "
+                "computer in the old iPhone's Bluetooth settings."
+            ),
+        )
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("replace", _("Replace and Pair"))
+        dialog.set_close_response("cancel")
+        dialog.set_response_appearance(
+            "replace", Adw.ResponseAppearance.DESTRUCTIVE
+        )
+
+        def responded(_current, response: str) -> None:
+            if response == "replace":
+                self._start_pairing(
+                    device,
+                    replace_saved_mac=configuration.mac,
+                )
+
+        dialog.connect("response", responded)
+        dialog.present(self.get_root())
+
+    def _start_pairing(
+        self,
+        device: PairedDevice,
+        *,
+        replace_saved_mac: str = "",
+    ) -> None:
         self._toast(_("Activating Bluetooth, then starting secure pairing…"))
 
         def completed(result) -> None:
@@ -529,6 +571,7 @@ class IPhonePage(Gtk.Box):
                 device.mac,
                 confirmation=confirm,
                 display=display,
+                replace_saved_mac=replace_saved_mac,
             ),
             completed,
         )
@@ -609,11 +652,15 @@ class IPhonePage(Gtk.Box):
             "emblem-ok-symbolic" if healthy else "dialog-warning-symbolic"
         )
 
-        for row, key in (
-            (self._pbap_row, "pbap"),
-            (self._ancs_row, "ancs"),
+        for row, icon, key in (
+            (self._pbap_row, self._pbap_icon, "pbap"),
+            (self._ancs_row, self._ancs_icon, "ancs"),
         ):
-            row.set_subtitle(_("Connected") if values.get(key) else _("Unavailable"))
+            connected = bool(values.get(key))
+            row.set_subtitle(_("Connected") if connected else _("Unavailable"))
+            icon.set_from_icon_name(
+                "emblem-ok-symbolic" if connected else "dialog-warning-symbolic"
+            )
         self._contacts_row.set_subtitle(str(status.contacts))
         self._events_row.set_subtitle(str(status.events))
         policy = status.notification_policy

--- a/src/blueferry/ui/status_presenter.py
+++ b/src/blueferry/ui/status_presenter.py
@@ -5,18 +5,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from blueferry.i18n import _
+from blueferry.models import BackendStatus
 
 
 def map_connection_refused(status: Mapping) -> bool:
     """Accept the structured state and the legacy raw server detail."""
-    if str(status.get("connectivity_state", "")) == "map-connection-refused":
-        return True
-    detail = str(status.get("connectivity_detail", "")).casefold()
-    return (
-        "createsession(map)" in detail
-        and "connection refused" in detail
-        and "111" in detail
-    )
+    return BackendStatus.from_dict(status).map_connection_refused
 
 
 def map_connection_refused_message() -> str:

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from blueferry import backend_operations
-from blueferry.backend_operations import BackendOperations
+from blueferry.backend_operations import BackendDependencies, BackendOperations
 from blueferry.errors import (
     ConfirmationRequiredError,
     InvalidArgumentsError,
@@ -29,14 +29,15 @@ class _Sessions:
         pass
 
 
-def _operations() -> BackendOperations:
+def _operations(**dependencies) -> BackendOperations:
     def submit(operation, *, on_success, on_error):
         try:
             on_success(operation())
         except Exception as error:
             on_error(error)
 
-    return BackendOperations(_Sessions(), submit_obex=submit)
+    dependencies.setdefault("submit_obex", submit)
+    return BackendOperations(_Sessions(), BackendDependencies(**dependencies))
 
 
 def _group() -> dict:
@@ -92,8 +93,9 @@ def test_confirmed_group_reply_uses_backend_recipient_set(monkeypatch):
 
 def test_group_reply_records_the_projected_member_roster(monkeypatch):
     recorded = []
-    operations = _operations()
-    operations._on_group_sent = lambda *values: recorded.append(values)
+    operations = _operations(
+        on_group_sent=lambda *values: recorded.append(values)
+    )
     thread = _group()
     _stub_group(operations, thread)
     monkeypatch.setattr(
@@ -142,9 +144,10 @@ def test_notification_policy_is_backend_owned_and_notifies_status() -> None:
             return value
 
     changes = []
-    operations = _operations()
-    operations._notification_policy = Policy()
-    operations._on_notification_policy_changed = lambda: changes.append(True)
+    operations = _operations(
+        notification_policy=Policy(),
+        on_notification_policy_changed=lambda: changes.append(True),
+    )
 
     assert operations.get_notification_policy() == "messages"
     assert operations.set_notification_policy("all") == "all"
@@ -160,8 +163,7 @@ def test_invalid_notification_policy_has_public_invalid_args_error() -> None:
         def set(_value):
             raise ValueError("bad policy")
 
-    operations = _operations()
-    operations._notification_policy = Policy()
+    operations = _operations(notification_policy=Policy())
 
     with pytest.raises(InvalidArgumentsError) as caught:
         operations.set_notification_policy("bad")
@@ -192,7 +194,9 @@ def test_storage_policy_change_clears_data_before_switching(monkeypatch) -> None
     monkeypatch.setattr(
         backend_operations, "clear_contact_cache", lambda: calls.append("contacts")
     )
-    operations = BackendOperations(_Sessions(), storage=Storage())
+    operations = BackendOperations(
+        _Sessions(), BackendDependencies(storage=Storage())
+    )
 
     result = operations.set_storage_policy("plaintext")
 
@@ -203,7 +207,9 @@ def test_storage_policy_change_clears_data_before_switching(monkeypatch) -> None
 def test_invalid_storage_policy_does_not_clear_data(monkeypatch) -> None:
     cleared = []
     storage = SimpleNamespace(status=SimpleNamespace(policy="encrypted"))
-    operations = BackendOperations(_Sessions(), storage=storage)
+    operations = BackendOperations(
+        _Sessions(), BackendDependencies(storage=storage)
+    )
     monkeypatch.setattr(
         backend_operations, "clear_events", lambda: cleared.append("events")
     )
@@ -248,8 +254,7 @@ def test_contact_lookup_stays_behind_backend_boundary() -> None:
             assert query == "Alice"
             return [("Alice Example", "15551234567")]
 
-    operations = _operations()
-    operations._contacts = _Contacts()
+    operations = _operations(contacts=_Contacts())
 
     assert operations.find_contacts("Alice") == [{
         "name": "Alice Example",

--- a/tests/test_cli_pairing.py
+++ b/tests/test_cli_pairing.py
@@ -29,6 +29,9 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
     observed = []
 
     class Setup:
+        def prepare_replacement(self, previous_mac, next_mac):
+            observed.append(("replace", previous_mac, next_mac))
+
         def complete(self, mac, *, confirmation, display):
             observed.append((mac, confirmation(12345)))
             return SimpleNamespace(to_dict=lambda: {"ok": True, "device": {"mac": mac}})
@@ -37,7 +40,13 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
 
     result = CliRunner().invoke(
         cli.app,
-        ["pairing-complete", "02:00:00:00:00:01", "--interactive-agent"],
+        [
+            "pairing-complete",
+            "02:00:00:00:00:01",
+            "--interactive-agent",
+            "--replace-saved-mac",
+            "02:00:00:00:00:02",
+        ],
         input="yes\n",
     )
 
@@ -47,4 +56,7 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
         {"event": "confirmation", "passkey": "012345"},
         {"ok": True, "device": {"mac": "02:00:00:00:00:01"}},
     ]
-    assert observed == [("02:00:00:00:00:01", True)]
+    assert observed == [
+        ("replace", "02:00:00:00:00:02", "02:00:00:00:00:01"),
+        ("02:00:00:00:00:01", True),
+    ]

--- a/tests/test_client_models.py
+++ b/tests/test_client_models.py
@@ -54,3 +54,14 @@ def test_backend_client_rejects_wrong_json_shape(monkeypatch):
 
     with pytest.raises(BackendError, match="expected dict"):
         client.status()
+
+
+def test_status_model_normalizes_legacy_map_refusal_detail() -> None:
+    status = BackendStatus.from_dict({
+        "connectivity_detail": (
+            "CreateSession(MAP) failed: Connection refused (111)"
+        )
+    })
+
+    assert status.map_connection_refused is True
+    assert status.to_dict()["map_connection_refused"] is True

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -1,5 +1,23 @@
 """Connectivity state and bounded backoff contracts."""
-from blueferry.connectivity import Connectivity, ConnectivityState, RetryPolicy
+from blueferry.connectivity import (
+    Connectivity,
+    ConnectivityState,
+    RetryPolicy,
+    is_map_connection_refused,
+)
+
+
+def test_map_refusal_classifier_accepts_state_and_legacy_detail():
+    assert is_map_connection_refused(state="map-connection-refused") is True
+    assert is_map_connection_refused(
+        "CreateSession(MAP) failed: Connection refused (111)"
+    ) is True
+    assert is_map_connection_refused(
+        "CreateSession(PBAP) failed: Connection refused (111)"
+    ) is False
+    assert is_map_connection_refused(
+        "CreateSession(MAP) failed: Connection timed out (110)"
+    ) is False
 
 
 def test_failures_back_off_to_a_bound_and_success_resets_them():

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from blueferry import config, contacts
+from blueferry import config, contact_repository, contacts
 from blueferry.contacts import (
     ContactsResolver,
     _parse_vcard_records,
@@ -260,7 +260,7 @@ def test_find_by_name_returns_phone_and_email_destinations(tmp_path, monkeypatch
     monkeypatch.setattr(config, "STATE_DIR", tmp_path)
     monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
     monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
-    with closing(contacts._open_db()) as database:
+    with closing(contact_repository._open_db()) as database:
         with database:
             cursor = database.execute(
                 "INSERT INTO contacts(full_name, updated_at) VALUES (?, ?)",

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import textwrap
 from contextlib import closing
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from blueferry import config, contacts
 from blueferry.contacts import (
@@ -22,6 +26,34 @@ def test_pbap_filters_use_phonebook_access_names():
     assert set(filters) == {"MaxCount", "Format"}
     assert int(filters["MaxCount"]) == 123
     assert str(filters["Format"]) == "vcard30"
+
+
+def test_phonebook_transfer_uses_runtime_dir_and_cleans_up_on_failure(
+    tmp_path, monkeypatch
+) -> None:
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    target = None
+
+    class _Pbap:
+        def Select(self, *_args, **_kwargs):
+            pass
+
+        def PullAll(self, path, *_args, **_kwargs):
+            nonlocal target
+            target = Path(path)
+            raise RuntimeError("transfer setup failed")
+
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
+    monkeypatch.setattr(contacts, "obex", lambda *_args: _Pbap())
+
+    with pytest.raises(RuntimeError, match="transfer setup failed"):
+        contacts.pull_phonebook(SimpleNamespace(pbap_path="/pbap"))
+
+    assert target is not None
+    assert target.parent.parent == runtime_dir / "blueferry"
+    assert not target.parent.exists()
+    assert (runtime_dir / "blueferry").stat().st_mode & 0o777 == 0o700
 
 
 def test_single_vcard():

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -56,6 +56,50 @@ def test_phonebook_transfer_uses_runtime_dir_and_cleans_up_on_failure(
     assert (runtime_dir / "blueferry").stat().st_mode & 0o777 == 0o700
 
 
+def test_phonebook_transfer_fails_closed_without_runtime_dir(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path / "persistent-state")
+
+    with pytest.raises(RuntimeError, match="requires XDG_RUNTIME_DIR"):
+        contacts.pull_phonebook(SimpleNamespace(pbap_path="/pbap"))
+
+    assert not config.STATE_DIR.exists()
+
+
+def test_phonebook_transfer_wires_idle_and_overall_timeouts(
+    tmp_path, monkeypatch
+) -> None:
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    captured = {}
+
+    class _Pbap:
+        def Select(self, *_args, **_kwargs):
+            pass
+
+        def PullAll(self, *_args, **_kwargs):
+            return "/transfer/phonebook", {"Status": "active", "Size": 0}
+
+    def capture_wait(transfer_path, **kwargs):
+        captured["transfer_path"] = transfer_path
+        captured.update(kwargs)
+        raise RuntimeError("stop after timeout wiring")
+
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
+    monkeypatch.setattr(contacts, "obex", lambda *_args: _Pbap())
+    monkeypatch.setattr(contacts, "wait_for_transfer", capture_wait)
+
+    with pytest.raises(RuntimeError, match="stop after timeout wiring"):
+        contacts.pull_phonebook(SimpleNamespace(pbap_path="/pbap"))
+
+    assert captured["transfer_path"] == "/transfer/phonebook"
+    assert captured["timeout_s"] == 60
+    assert captured["overall_timeout_s"] == 30 * 60
+    assert callable(captured["get_progress"])
+
+
 def test_single_vcard():
     blob = textwrap.dedent("""\
         BEGIN:VCARD

--- a/tests/test_dbus_integration.py
+++ b/tests/test_dbus_integration.py
@@ -12,6 +12,7 @@ import dbus.service
 import pytest
 from gi.repository import GLib
 
+from blueferry.backend_operations import BackendDependencies
 from blueferry.dbus_service import MessagesService
 from blueferry.protocol import BUS_NAME, EVENTS_IFACE, MESSAGES_IFACE, OBJECT_PATH
 
@@ -52,10 +53,12 @@ def public_service():
     service = MessagesService(
         bus_name,
         _Sessions(),
-        submit_obex=submit,
-        status_provider=lambda: {"initializing": False},
-        notification_policy=policy,
-        on_notification_policy_changed=lambda: policy_changes.append(True),
+        BackendDependencies(
+            submit_obex=submit,
+            status_provider=lambda: {"initializing": False},
+            notification_policy=policy,
+            on_notification_policy_changed=lambda: policy_changes.append(True),
+        ),
     )
     try:
         yield name, pending, policy, policy_changes, service

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from datetime import datetime, timedelta, timezone
 
 from blueferry.history import (
@@ -18,7 +19,7 @@ def test_reader_filters_and_ignores_corrupt_payload_rows(tmp_path) -> None:
     path = tmp_path / "events.sqlite"
     append_event({"kind": "sms_received", "body": "one"}, path=path)
     append_event({"kind": "ancs_notification", "body": "two"}, path=path)
-    with sqlite3.connect(path) as database:
+    with closing(sqlite3.connect(path)) as database, database:
         database.execute(
             "INSERT INTO events(kind, payload_json) VALUES (?, ?)",
             ("sms_received", "not json"),

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -81,6 +81,25 @@ def test_arch_check_dependencies_cover_cli_test_imports() -> None:
     assert "'python-textual>=8.0'" in checkdepends
 
 
+def test_arch_bluetooth_dropin_warns_about_other_executable_paths() -> None:
+    dropin = (ROOT / "packaging/arch/blueferry-bluetooth.conf").read_text()
+
+    assert "Arch Linux only" in dropin
+    assert "/usr/lib/bluetooth/bluetoothd" in dropin
+    assert "/usr/libexec/bluetooth/bluetoothd" in dropin
+    assert "prevents Bluetooth from starting" in dropin
+
+
+def test_gtk_client_styles_messages_with_libadwaita_1_5_colors() -> None:
+    app = (ROOT / "src/blueferry/ui/app.py").read_text()
+    pkgbuild = (ROOT / "packaging/arch/PKGBUILD").read_text()
+
+    assert "@accent_bg_color" in app
+    assert "@accent_fg_color" in app
+    assert "var(--accent-bg-color)" not in app
+    assert "'libadwaita>=1.5'" in pkgbuild
+
+
 @pytest.mark.parametrize("suffix", ["Gtk", "Qt", "Quickshell"])
 def test_desktop_and_appstream_ids_match(suffix: str) -> None:
     app_id = f"{BUS_NAME}.{suffix}"

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -235,6 +235,11 @@ def test_quickshell_package_ships_its_quattro_theme_adapter() -> None:
     assert "readonly property int controlRadius" in theme
     assert "color: theme.windowSurface" in shell
     assert "component FerryLabel: Label" in shell
+    assert (
+        "component FerryLabel: Label {\n"
+        "    color: theme.windowText\n"
+        "    textFormat: Text.PlainText"
+    ) in shell
     assert "component FerryButton: Button" in shell
     assert "id: bubble" in shell
     assert "messageTimestamp.implicitWidth" in shell
@@ -256,3 +261,25 @@ def test_quickshell_package_ships_its_quattro_theme_adapter() -> None:
     assert "component FerrySectionLabel: FerryLabel" in shell
     window_declaration = shell.split("FloatingWindow {", 1)[1].split("Pane {", 1)[0]
     assert 'color: "transparent"' not in window_declaration
+
+
+def test_remote_qml_text_is_rendered_as_plain_text() -> None:
+    qt_qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
+    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+
+    assert (
+        "text: contactDelegate.text\n"
+        "                        textFormat: Text.PlainText"
+    ) in qt_qml
+    assert (
+        "text: deviceCombo.displayText\n"
+        "                            textFormat: Text.PlainText"
+    ) in qt_qml
+    assert (
+        "text: threadDelegate.modelData.name\n"
+        "                        textFormat: Text.PlainText"
+    ) in quickshell
+    assert (
+        "text: newContactDelegate.modelData.name\n"
+        "                  textFormat: Text.PlainText"
+    ) in quickshell

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -11,6 +11,13 @@ from blueferry.protocol import BUS_NAME, OBJECT_PATH
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _qml_bundle(directory: Path) -> str:
+    """Return a domain bundle without coupling tests to one root filename."""
+    return "\n".join(
+        path.read_text() for path in sorted(directory.glob("*.qml"))
+    )
+
+
 def test_graphical_commands_follow_client_package_names() -> None:
     project = (ROOT / "pyproject.toml").read_text()
     pkgbuild = (ROOT / "packaging" / "arch" / "PKGBUILD").read_text()
@@ -79,6 +86,16 @@ def test_arch_check_dependencies_cover_cli_test_imports() -> None:
 
     assert "'python-typer>=0.12'" in checkdepends
     assert "'python-textual>=8.0'" in checkdepends
+    assert "'python-coverage'" in checkdepends
+
+
+def test_repository_quality_workflow_runs_hermetic_checks() -> None:
+    workflow = (ROOT / ".github/workflows/quality.yml").read_text()
+
+    assert "dbus-run-session --config-file=tests/dbus-test.conf" in workflow
+    assert "python -m coverage run -m pytest" in workflow
+    assert "mypy src/blueferry" in workflow
+    assert "qmllint src/blueferry/qt/qml/*.qml data/quickshell/*.qml" in workflow
 
 
 def test_arch_bluetooth_dropin_warns_about_other_executable_paths() -> None:
@@ -115,7 +132,7 @@ def test_desktop_and_appstream_ids_match(suffix: str) -> None:
 def test_qt_package_ships_the_kirigami_ui_and_dependencies() -> None:
     project = (ROOT / "pyproject.toml").read_text()
     pkgbuild = (ROOT / "packaging/arch/PKGBUILD").read_text()
-    qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
+    qml = _qml_bundle(ROOT / "src/blueferry/qt/qml")
 
     assert '"blueferry.qt" = ["qml/*.qml"]' in project
     assert "'kirigami'" in pkgbuild
@@ -158,8 +175,8 @@ def test_gui_clients_keep_phone_settings_out_of_primary_navigation() -> None:
 def test_all_gui_clients_offer_contacts_aware_new_messages() -> None:
     gtk = (ROOT / "src/blueferry/ui/conversations.py").read_text()
     qt_controller = (ROOT / "src/blueferry/qt/controller.py").read_text()
-    qt_qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
-    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+    qt_qml = _qml_bundle(ROOT / "src/blueferry/qt/qml")
+    quickshell = _qml_bundle(ROOT / "data/quickshell")
 
     assert 'tooltip_text=_("New Message")' in gtk
     assert "find_contacts_async" in gtk
@@ -171,8 +188,8 @@ def test_all_gui_clients_offer_contacts_aware_new_messages() -> None:
 
 def test_all_gui_clients_explain_phone_side_pairing_step() -> None:
     gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
-    qt = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
-    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
+    quickshell = _qml_bundle(ROOT / "data/quickshell")
 
     for client in (gtk, qt, quickshell):
         assert "find this computer" in client
@@ -186,8 +203,8 @@ def test_all_gui_clients_explain_map_connection_refusal() -> None:
     )
     gtk_messages = (ROOT / "src/blueferry/ui/conversations.py").read_text()
     gtk_settings = (ROOT / "src/blueferry/ui/status.py").read_text()
-    qt = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
-    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
+    quickshell = _qml_bundle(ROOT / "data/quickshell")
 
     assert "map_connection_refused_message" in gtk_messages
     assert "map_connection_refused_message" in gtk_settings
@@ -197,8 +214,8 @@ def test_all_gui_clients_explain_map_connection_refusal() -> None:
 
 def test_all_gui_clients_offer_unencrypted_local_storage() -> None:
     gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
-    qt = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
-    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
+    quickshell = _qml_bundle(ROOT / "data/quickshell")
 
     assert '_("Unencrypted Local Data")' in gtk
     assert '"value": "plaintext"' in qt
@@ -223,7 +240,8 @@ def test_quickshell_package_ships_its_quattro_theme_adapter() -> None:
     theme = (ROOT / "data/quickshell/Theme.qml").read_text()
     shell = (ROOT / "data/quickshell/shell.qml").read_text()
 
-    assert "install -Dm644 data/quickshell/Theme.qml" in pkgbuild
+    assert "install -Dm644 data/quickshell/*.qml" in pkgbuild
+    assert (ROOT / "data/quickshell/OnboardingState.qml").is_file()
     assert "/.local/state/omarchy/current/theme" in theme
     assert "fallbackPalette" in theme
     assert "readonly property color windowSurface" in theme
@@ -241,23 +259,7 @@ def test_quickshell_package_ships_its_quattro_theme_adapter() -> None:
         "    textFormat: Text.PlainText"
     ) in shell
     assert "component FerryButton: Button" in shell
-    assert "id: bubble" in shell
-    assert "messageTimestamp.implicitWidth" in shell
     assert "theme.primarySurface" in shell
-    assert 'text: "BLUEFERRY"' not in shell
-    assert shell.count('text: "⚙"') == 2
-    assert "labelSize: theme.displaySize" in shell
-    assert "bare: true" in shell
-    assert "if (sendMessageButton.enabled) sendMessageButton.clicked()" in shell
-    assert "id: settingsDeck" in shell
-    assert 'text: "← MESSAGES"' not in shell
-    assert "Choose which iPhone events create desktop popups" not in shell
-    assert "After approving “Allow System Notifications,”" in shell
-    assert "I will also forget this computer" not in shell
-    assert "text: root.storageDetail" not in shell
-    assert "Cannot retrieve or send messages - are you connected to another computer?" in shell
-    assert "? root.mapConnectionRefused()" in shell
-    assert 'text: root.phoneSettingsVisible ? "MESSAGES" : "IPHONE"' not in shell
     assert "component FerrySectionLabel: FerryLabel" in shell
     window_declaration = shell.split("FloatingWindow {", 1)[1].split("Pane {", 1)[0]
     assert 'color: "transparent"' not in window_declaration

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -151,6 +151,55 @@ def test_qt_package_ships_the_kirigami_ui_and_dependencies() -> None:
     assert "setQuitOnLastWindowClosed(False)" in qt_app
 
 
+def test_gui_pairing_requires_confirmation_before_replacing_saved_target() -> None:
+    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
+    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
+    quickshell = _qml_bundle(ROOT / "data/quickshell")
+
+    for client in (gtk, qt, quickshell):
+        assert "Replace" in client
+        assert "saved phone" in client
+        assert "old iPhone's Bluetooth settings" in client
+    assert "replaceAndPair" in qt
+    assert "--replace-saved-mac" in quickshell
+
+
+def test_gui_pairing_guidance_tells_users_to_recheck_iphone_toggles() -> None:
+    clients = (
+        (ROOT / "src/blueferry/ui/status.py").read_text(),
+        _qml_bundle(ROOT / "src/blueferry/qt/qml"),
+        _qml_bundle(ROOT / "data/quickshell"),
+    )
+
+    for client in clients:
+        assert "reopen this computer's ⓘ page a" in client
+        assert "few times; turn on any new toggles that appear" in client
+
+
+def test_gtk_connection_rows_all_have_status_icons() -> None:
+    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
+
+    for profile in ("daemon", "map", "pbap", "ancs"):
+        assert f"self._{profile}_icon = Gtk.Image()" in gtk
+        assert f"self._{profile}_row.add_suffix(self._{profile}_icon)" in gtk
+
+
+def test_qt_message_bubbles_do_not_use_full_selection_color() -> None:
+    bubble = (ROOT / "src/blueferry/qt/qml/MessageBubble.qml").read_text()
+
+    assert "backgroundColor.r * 0.78" in bubble
+    assert "highlightColor.r * 0.22" in bubble
+    assert "? Kirigami.Theme.highlightColor" not in bubble
+    assert "Kirigami.Theme.highlightedTextColor" not in bubble
+
+
+def test_quickshell_outgoing_bubbles_match_qt_accent_tint() -> None:
+    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+
+    assert "? theme.selectedSurface : theme.raisedSurface" in quickshell
+    assert "color: theme.windowText" in quickshell
+
+
 def test_qt_messages_toolbar_toggles_dismissible_settings_pane() -> None:
     qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
 

--- a/tests/test_obex_transfer.py
+++ b/tests/test_obex_transfer.py
@@ -58,6 +58,35 @@ def test_transfer_timeout_restarts_when_progress_advances() -> None:
     assert clock.now > 0.2
 
 
+def test_progress_regression_does_not_restart_inactivity_timeout() -> None:
+    clock = _Clock()
+
+    with pytest.raises(TimeoutError, match=r"timed out after 0\.2s"):
+        wait_for_transfer(
+            "/transfer/regressing",
+            timeout_s=0.2,
+            get_status=lambda: "active",
+            get_progress=lambda: 10 if clock.now < 0.1 else 9,
+            monotonic=clock,
+            sleep=clock.sleep,
+        )
+
+
+def test_progress_cannot_extend_overall_timeout() -> None:
+    clock = _Clock()
+
+    with pytest.raises(TimeoutError, match=r"0\.5s overall limit"):
+        wait_for_transfer(
+            "/transfer/slow-loris",
+            timeout_s=0.2,
+            overall_timeout_s=0.5,
+            get_status=lambda: "active",
+            get_progress=lambda: int(clock.now * 100),
+            monotonic=clock,
+            sleep=clock.sleep,
+        )
+
+
 def test_explicit_transfer_error_fails() -> None:
     with pytest.raises(TransferFailed):
         wait_for_transfer(

--- a/tests/test_obex_transfer.py
+++ b/tests/test_obex_transfer.py
@@ -38,6 +38,26 @@ def test_nonterminal_status_at_deadline_is_not_success() -> None:
         )
 
 
+def test_transfer_timeout_restarts_when_progress_advances() -> None:
+    clock = _Clock()
+    polls = 0
+
+    def status() -> str:
+        nonlocal polls
+        polls += 1
+        return "complete" if polls == 8 else "active"
+
+    assert wait_for_transfer(
+        "/transfer/long",
+        timeout_s=0.2,
+        get_status=status,
+        get_progress=lambda: int(clock.now / 0.2),
+        monotonic=clock,
+        sleep=clock.sleep,
+    ) == "complete"
+    assert clock.now > 0.2
+
+
 def test_explicit_transfer_error_fails() -> None:
     with pytest.raises(TransferFailed):
         wait_for_transfer(

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -117,6 +117,39 @@ def test_clear_local_target_preserves_unrelated_preferences(tmp_path, monkeypatc
     assert cleared == [True]
 
 
+def test_replacing_stale_target_keeps_selected_unpaired_scan_result(monkeypatch):
+    device = _device(paired=False)
+    calls = []
+    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac: device)
+    monkeypatch.setattr(
+        pair_setup, "forget_device", lambda _mac: calls.append("forget")
+    )
+    monkeypatch.setattr(
+        pair_setup, "_stop_user_service", lambda: calls.append("stop")
+    )
+    monkeypatch.setattr(
+        pair_setup, "clear_local_target", lambda: calls.append("clear")
+    )
+
+    pair_setup.prepare_target_replacement(device.mac, device.mac)
+
+    assert calls == ["stop", "clear"]
+
+
+def test_replacing_a_different_target_removes_its_bluez_device(monkeypatch):
+    calls = []
+    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac: None)
+    monkeypatch.setattr(
+        pair_setup, "forget_device", lambda mac: calls.append(mac)
+    )
+
+    pair_setup.prepare_target_replacement(
+        "02:00:00:00:00:01", "02:00:00:00:00:02"
+    )
+
+    assert calls == ["02:00:00:00:00:01"]
+
+
 def test_forget_stops_backend_removes_bond_and_clears_target(monkeypatch):
     device = _device(paired=True)
     calls = []

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -1,0 +1,73 @@
+"""Behavioral checks for extracted QML presentation components."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtCore import QUrl
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtQml import QQmlComponent, QQmlEngine
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def qml_engine():
+    application = QGuiApplication.instance() or QGuiApplication([])
+    engine = QQmlEngine()
+    yield engine
+    engine.deleteLater()
+    application.processEvents()
+
+
+def _component(engine: QQmlEngine, relative_path: str) -> QQmlComponent:
+    component = QQmlComponent(
+        engine, QUrl.fromLocalFile(str((ROOT / relative_path).resolve()))
+    )
+    assert not component.isError(), "\n".join(
+        error.toString() for error in component.errors()
+    )
+    return component
+
+
+def test_quickshell_onboarding_state_derives_ready_stage(qml_engine) -> None:
+    component = _component(qml_engine, "data/quickshell/OnboardingState.qml")
+    presenter = component.createWithInitialProperties({
+        "hardwareSupported": True,
+        "notificationsSupported": True,
+        "bluezActive": True,
+        "configured": True,
+        "backendStatus": {
+            "daemon": True,
+            "map": True,
+            "pbap": True,
+            "verified_iphone_setup": [
+                "message-notifications", "contacts", "notification-access",
+            ],
+        },
+    })
+
+    assert presenter is not None
+    assert presenter.property("stage") == "ready"
+    presenter.deleteLater()
+
+
+def test_qt_onboarding_summary_renders_stage_from_properties(qml_engine) -> None:
+    component = _component(
+        qml_engine, "src/blueferry/qt/qml/OnboardingSummary.qml"
+    )
+    summary = component.createWithInitialProperties({
+        "stage": "ready",
+        "compatibility": {"notifications_supported": True},
+        "status": {"verified_iphone_setup": []},
+    })
+
+    assert summary is not None
+    assert "BlueFerry Is Connected" in summary.property("text")
+    summary.deleteLater()

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -242,3 +242,46 @@ def test_pairing_rejects_when_confirmation_is_declined(monkeypatch):
     controller.completePairing("02:00:00:00:00:01")
 
     assert observed == [False]
+
+
+def test_replacing_saved_target_is_forwarded_to_pairing_helper(monkeypatch):
+    observed = []
+
+    class Setup:
+        def complete_isolated(
+            self,
+            mac,
+            *,
+            confirmation,
+            display,
+            replace_saved_mac,
+        ):
+            observed.append((replace_saved_mac, mac))
+            return object()
+
+    controller = BridgeController(
+        backend=_Backend(),
+        setup=Setup(),
+        subscribe=False,
+        autostart=False,
+    )
+    monkeypatch.setattr(
+        controller,
+        "_run",
+        lambda operation, on_done=None, *_args, **_kwargs: (
+            on_done(operation()) if on_done is not None else operation()
+        ),
+    )
+    monkeypatch.setattr(controller, "loadDevices", lambda _scan: None)
+    monkeypatch.setattr(controller, "loadSetupState", lambda: None)
+    monkeypatch.setattr(controller, "refresh", lambda: None)
+
+    controller.replaceAndPair(
+        "02:00:00:00:00:01",
+        "02:00:00:00:00:02",
+    )
+
+    assert observed == [
+        ("02:00:00:00:00:01", "02:00:00:00:00:02")
+    ]
+    assert controller.targetSaved is True

--- a/tests/test_setup_client.py
+++ b/tests/test_setup_client.py
@@ -132,6 +132,7 @@ def test_complete_pairing_decodes_result_and_forget_delegates(monkeypatch):
 
 def test_isolated_pairing_answers_helper_confirmation(monkeypatch):
     device = _device()
+    commands = []
 
     class Input(io.StringIO):
         def flush(self):
@@ -155,12 +156,18 @@ def test_isolated_pairing_answers_helper_confirmation(monkeypatch):
             return 0
 
     process = Process()
-    monkeypatch.setattr(setup_client.subprocess, "Popen", lambda *_args, **_kwargs: process)
+    monkeypatch.setattr(
+        setup_client.subprocess,
+        "Popen",
+        lambda command, **_kwargs: commands.append(command) or process,
+    )
 
     result = setup_client.SetupClient().complete_isolated(
         device.mac,
         confirmation=lambda passkey: passkey == 123456,
+        replace_saved_mac="02:00:00:00:00:02",
     )
 
     assert process.stdin.getvalue() == "yes\n"
     assert result.ancs_ready is True
+    assert commands[0][-2:] == ["--replace-saved-mac", "02:00:00:00:00:02"]

--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -1,8 +1,11 @@
 """Local encryption behavior without contacting a desktop keyring."""
 from __future__ import annotations
 
+import base64
 import json
+import logging
 import sqlite3
+from types import SimpleNamespace
 
 import pytest
 
@@ -12,10 +15,22 @@ from blueferry.history import append_event, prune_events, read_events
 from blueferry.settings_store import SettingsStore
 from blueferry.storage_security import (
     CorruptStorageError,
+    SecretServiceKeyProvider,
     StorageSecurity,
     StorageUnavailableError,
     is_encrypted_value,
 )
+
+
+def _secret_module(*, get_service):
+    return SimpleNamespace(
+        Service=SimpleNamespace(get_sync=get_service),
+        ServiceFlags=SimpleNamespace(LOAD_COLLECTIONS=1, OPEN_SESSION=2),
+        Schema=SimpleNamespace(new=lambda *_args: object()),
+        SchemaFlags=SimpleNamespace(NONE=0),
+        SchemaAttributeType=SimpleNamespace(STRING=0),
+        SearchFlags=SimpleNamespace(ALL=1, LOAD_SECRETS=2, UNLOCK=4),
+    )
 
 
 class _KeyProvider:
@@ -39,6 +54,47 @@ class _LockedProvider:
     def delete(self, *, allow_prompt: bool) -> bool:
         raise StorageUnavailableError("wallet locked")
 
+
+def test_secret_service_does_not_eagerly_load_unrelated_collections(
+    monkeypatch,
+) -> None:
+    calls = []
+    encoded = base64.b64encode(b"K" * 32).decode("ascii")
+    item = SimpleNamespace(
+        get_locked=lambda: False,
+        get_secret=lambda: SimpleNamespace(get_text=lambda: encoded),
+    )
+    service = SimpleNamespace(search_sync=lambda *_args: [item])
+
+    def get_service(flags, cancellable):
+        calls.append((flags, cancellable))
+        if flags & 1:
+            raise RuntimeError("dangling item in an unrelated collection")
+        return service
+
+    provider = SecretServiceKeyProvider()
+    monkeypatch.setattr(
+        provider, "_secret_module", lambda: _secret_module(get_service=get_service)
+    )
+
+    assert provider.get_or_create(allow_prompt=False) == b"K" * 32
+    assert calls == [(2, None)]
+
+
+def test_secret_service_log_includes_the_provider_error(monkeypatch, caplog) -> None:
+    def get_service(_flags, _cancellable):
+        raise RuntimeError("No such secret item at path /collection/login/27")
+
+    provider = SecretServiceKeyProvider()
+    monkeypatch.setattr(
+        provider, "_secret_module", lambda: _secret_module(get_service=get_service)
+    )
+
+    with caplog.at_level(logging.INFO, logger="blueferry.storage_security"):
+        with pytest.raises(StorageUnavailableError):
+            provider.get_or_create(allow_prompt=False)
+
+    assert "No such secret item at path /collection/login/27" in caplog.text
 
 def _storage(tmp_path, provider=None) -> StorageSecurity:
     return StorageSecurity(

--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -5,6 +5,7 @@ import base64
 import json
 import logging
 import sqlite3
+from contextlib import closing
 from types import SimpleNamespace
 
 import pytest
@@ -173,7 +174,7 @@ def test_history_database_contains_ciphertext_and_round_trips(tmp_path) -> None:
 
     append_event(event, path=path, storage=storage)
 
-    with sqlite3.connect(path) as database:
+    with closing(sqlite3.connect(path)) as database:
         kind, occurred_at, payload = database.execute(
             "SELECT kind, occurred_at, payload_json FROM events"
         ).fetchone()
@@ -208,14 +209,14 @@ def test_pruning_reasserts_private_encrypted_metadata(tmp_path) -> None:
         path=path,
         storage=storage,
     )
-    with sqlite3.connect(path) as database:
+    with closing(sqlite3.connect(path)) as database, database:
         database.execute(
             "UPDATE events SET kind = 'sms_received', occurred_at = 123"
         )
 
     prune_events(path=path, storage=storage)
 
-    with sqlite3.connect(path) as database:
+    with closing(sqlite3.connect(path)) as database:
         assert database.execute(
             "SELECT kind, occurred_at FROM events"
         ).fetchone() == ("private", None)
@@ -244,16 +245,15 @@ def test_plaintext_secure_contact_record_fails_closed(
     monkeypatch.setattr(config, "STATE_DIR", tmp_path)
     monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
     monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
-    with contact_repository._open_db() as database:
-        with database:
-            database.execute(
-                "INSERT INTO secure_contacts(payload) VALUES (?)",
-                (json.dumps({
-                    "name": "Alice Example",
-                    "phones": ["15551234567"],
-                    "emails": [],
-                }),),
-            )
+    with closing(contact_repository._open_db()) as database, database:
+        database.execute(
+            "INSERT INTO secure_contacts(payload) VALUES (?)",
+            (json.dumps({
+                "name": "Alice Example",
+                "phones": ["15551234567"],
+                "emails": [],
+            }),),
+        )
     storage = _storage(tmp_path)
 
     resolver = ContactsResolver(storage=storage)
@@ -269,16 +269,15 @@ def test_unencrypted_policy_reads_plaintext_contact_records(
     monkeypatch.setattr(config, "STATE_DIR", tmp_path)
     monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
     monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
-    with contact_repository._open_db() as database:
-        with database:
-            database.execute(
-                "INSERT INTO secure_contacts(payload) VALUES (?)",
-                (json.dumps({
-                    "name": "Alice Example",
-                    "phones": ["15551234567"],
-                    "emails": [],
-                }),),
-            )
+    with closing(contact_repository._open_db()) as database, database:
+        database.execute(
+            "INSERT INTO secure_contacts(payload) VALUES (?)",
+            (json.dumps({
+                "name": "Alice Example",
+                "phones": ["15551234567"],
+                "emails": [],
+            }),),
+        )
     settings = SettingsStore(tmp_path / "settings.json")
     settings.update(local_data="plaintext")
 
@@ -293,21 +292,20 @@ def test_plaintext_contact_tables_are_discarded_in_encrypted_mode(
     monkeypatch.setattr(config, "STATE_DIR", tmp_path)
     monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
     monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
-    with contact_repository._open_db() as database:
-        with database:
-            cursor = database.execute(
-                "INSERT INTO contacts(full_name, updated_at) VALUES (?, ?)",
-                ("Plaintext Alice", 0),
-            )
-            database.execute(
-                "INSERT INTO phones(phone_norm, contact_id) VALUES (?, ?)",
-                ("15551234567", cursor.lastrowid),
-            )
+    with closing(contact_repository._open_db()) as database, database:
+        cursor = database.execute(
+            "INSERT INTO contacts(full_name, updated_at) VALUES (?, ?)",
+            ("Plaintext Alice", 0),
+        )
+        database.execute(
+            "INSERT INTO phones(phone_norm, contact_id) VALUES (?, ?)",
+            ("15551234567", cursor.lastrowid),
+        )
 
     resolver = ContactsResolver(storage=_storage(tmp_path))
 
     assert resolver.resolve("15551234567") is None
-    with sqlite3.connect(config.CONTACTS_DB) as database:
+    with closing(sqlite3.connect(config.CONTACTS_DB)) as database:
         assert database.execute("SELECT COUNT(*) FROM contacts").fetchone()[0] == 0
     assert b"Plaintext Alice" not in config.CONTACTS_DB.read_bytes()
 

--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from blueferry import config, contacts
+from blueferry import config, contact_repository
 from blueferry.contacts import ContactsResolver
 from blueferry.history import append_event, prune_events, read_events
 from blueferry.settings_store import SettingsStore
@@ -244,7 +244,7 @@ def test_plaintext_secure_contact_record_fails_closed(
     monkeypatch.setattr(config, "STATE_DIR", tmp_path)
     monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
     monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
-    with contacts._open_db() as database:
+    with contact_repository._open_db() as database:
         with database:
             database.execute(
                 "INSERT INTO secure_contacts(payload) VALUES (?)",
@@ -269,7 +269,7 @@ def test_unencrypted_policy_reads_plaintext_contact_records(
     monkeypatch.setattr(config, "STATE_DIR", tmp_path)
     monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
     monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
-    with contacts._open_db() as database:
+    with contact_repository._open_db() as database:
         with database:
             database.execute(
                 "INSERT INTO secure_contacts(payload) VALUES (?)",
@@ -293,7 +293,7 @@ def test_plaintext_contact_tables_are_discarded_in_encrypted_mode(
     monkeypatch.setattr(config, "STATE_DIR", tmp_path)
     monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
     monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
-    with contacts._open_db() as database:
+    with contact_repository._open_db() as database:
         with database:
             cursor = database.execute(
                 "INSERT INTO contacts(full_name, updated_at) VALUES (?, ?)",


### PR DESCRIPTION
## Summary

- make the bluetoothd configuration portable across supported distributions and retain an Arch packaging-specific drop-in
- restore sent-message styling on older libadwaita releases
- make Secret Service key access resilient to unrelated dangling keyring items
- allow large PBAP transfers to complete while retaining bounded waits and failure handling
- harden contact storage/transfers and centralize shared backend/client behavior
- add pairing, connection-state, and presentation polish across GTK, Qt, and Quickshell
- expand static analysis, integration, security, wiring-regression, and QML coverage

## Validation

- `ruff check .`
- `bandit -r src/blueferry -q`
- `mypy src/blueferry`
- `444 passed` under the hermetic D-Bus test configuration
- `qmllint` for Qt and Quickshell QML

Closes #3
Closes #4
Closes #5
Closes #6