### PR TITLE
Smooth client scroll and refresh behavior

### DIFF
--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -375,6 +375,7 @@ ShellRoot {
     onExited: function(code) {
       if (code === 0) {
         composer.text = ""
+        messageList.stickToBottom = true
         root.reload()
       }
     }
@@ -906,11 +907,27 @@ ShellRoot {
 
               ListView {
                 id: messageList
+                property bool stickToBottom: true
+                property string threadKey: conversationPane.thread
+                  ? conversationPane.thread.key : ""
+
+                function scrollToBottom() {
+                  if (stickToBottom && count > 0) positionViewAtEnd()
+                }
+
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 clip: true
                 spacing: theme.scaled(8)
                 model: conversationPane.thread ? conversationPane.thread.messages : []
+                onThreadKeyChanged: {
+                  stickToBottom = true
+                  Qt.callLater(scrollToBottom)
+                }
+                onCountChanged: Qt.callLater(scrollToBottom)
+                onContentHeightChanged: Qt.callLater(scrollToBottom)
+                onMovementStarted: stickToBottom = false
+                onMovementEnded: stickToBottom = atYEnd
                 delegate: Item {
                   id: messageRow
                   required property var modelData

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -614,7 +614,7 @@ class BlueFerryApp(App[None]):
         except Exception:
             self._monitor = None
         self.set_interval(_SIGNAL_PUMP_SECONDS, self._pump_events)
-        self.set_interval(_REFRESH_SECONDS, self.action_refresh)
+        self.set_interval(_REFRESH_SECONDS, self._load_data)
         self._update_responsive(self.size.width)
         self._load_data()
 
@@ -669,15 +669,25 @@ class BlueFerryApp(App[None]):
         )
 
     async def _apply_snapshot(self, snapshot: TuiSnapshot) -> None:
+        previous_status = self.state.status
+        previous_threads = tuple(self.state.threads)
+        previous_selection = self.state.selected_key
+        previous_error = self.state.error
         self.state.apply_snapshot(snapshot)
         if self._pending_open_handle and self.state.select_message(self._pending_open_handle):
             self._pending_open_handle = None
             self.query_one("#workspace").add_class("chat-open")
-        await self._populate_threads()
-        await self._render_conversation()
-        self._update_status()
-        self._update_notice()
-        self._warn_about_roster_changes()
+        threads_changed = tuple(self.state.threads) != previous_threads
+        selection_changed = self.state.selected_key != previous_selection
+        if threads_changed or selection_changed:
+            await self._populate_threads()
+            await self._render_conversation()
+        if self.state.status != previous_status:
+            self._update_status()
+        if self.state.error != previous_error:
+            self._update_notice()
+        if threads_changed:
+            self._warn_about_roster_changes()
 
     def _warn_about_roster_changes(self) -> None:
         for thread in self.state.threads:

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -387,3 +387,13 @@ def test_remote_qml_text_is_rendered_as_plain_text() -> None:
         "text: newContactDelegate.modelData.name\n"
         "                  textFormat: Text.PlainText"
     ) in quickshell
+
+
+def test_quickshell_message_timeline_stays_at_the_latest_message() -> None:
+    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+
+    assert "property bool stickToBottom: true" in quickshell
+    assert "positionViewAtEnd()" in quickshell
+    assert "onThreadKeyChanged" in quickshell
+    assert "onMovementStarted: stickToBottom = false" in quickshell
+    assert "messageList.stickToBottom = true" in quickshell

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -265,6 +265,26 @@ def test_textual_app_renders_status_threads_and_messages() -> None:
     _run_headless(scenario())
 
 
+def test_unchanged_poll_does_not_rebuild_the_terminal_view() -> None:
+    async def scenario() -> None:
+        state = TuiState(_Backend())
+        app = BlueFerryApp(state, monitor_factory=lambda: None)
+
+        async with app.run_test(size=(120, 36)) as pilot:
+            await _wait_for_threads(app, pilot, 2)
+            thread_items = tuple(app.query_one("#thread-list", ListView).children)
+            message_items = tuple(
+                app.query_one("#message-timeline").children
+            )
+
+            await app._apply_snapshot(state.fetch_snapshot())
+
+            assert tuple(app.query_one("#thread-list", ListView).children) == thread_items
+            assert tuple(app.query_one("#message-timeline").children) == message_items
+
+    _run_headless(scenario())
+
+
 def test_textual_warns_once_when_saved_group_roster_changes() -> None:
     async def scenario() -> None:
         backend = _Backend()


### PR DESCRIPTION
## Summary

- keep the Quickshell message timeline pinned to the newest message when opening a thread or completing a send
- stop automatic bottom-pinning when the user deliberately scrolls upward
- make the TUI periodic backend poll silent
- skip conversation-list and message-timeline reconstruction when a TUI snapshot is unchanged

## Stack

This PR is intentionally based on #10 and is independent of security PR #11. It can be retargeted to main after #10 merges.

## Verification

- 468 passed, 3 skipped
- Ruff, Bandit, mypy, QML lint, Python compilation, and diff checks pass
- regressions verify Quickshell bottom-pinning hooks and that identical TUI snapshots preserve existing widget instances