### PR TITLE
Isolate threaded D-Bus test clients

### DIFF
--- a/tests/test_dbus_integration.py
+++ b/tests/test_dbus_integration.py
@@ -8,6 +8,7 @@ import threading
 import time
 
 import dbus
+import dbus.mainloop
 import dbus.service
 import pytest
 from gi.repository import GLib
@@ -69,7 +70,14 @@ def public_service():
 
 
 def _client(name: str):
-    connection = dbus.SessionBus(private=True)
+    # These clients make synchronous calls from Python worker threads while
+    # the test's main thread dispatches the service's GLib context. Keeping
+    # their private connections off that context avoids concurrent libdbus
+    # dispatch of the same connection.
+    connection = dbus.SessionBus(
+        private=True,
+        mainloop=dbus.mainloop.NULL_MAIN_LOOP,
+    )
     interface = dbus.Interface(
         connection.get_object(name, OBJECT_PATH), MESSAGES_IFACE
     )


### PR DESCRIPTION
## Summary

- keep synchronous integration-test client connections off the service GLib context
- prevent the main test thread and client worker threads from concurrently dispatching libdbus state
- mirror the `NULL_MAIN_LOOP` isolation already used by BlueFerry production worker connections

## Failure analysis

The push and pull-request workflows for the same `cf2d6fb` commit produced different results: the push aborted natively inside the pending-send D-Bus integration test, while the PR workflow passed shortly afterward. The test created private connections on worker threads but left them attached to the process-wide GLib main loop being dispatched by the main test thread.

## Verification

- 25 consecutive hermetic D-Bus stress iterations passed
- exact GitHub Actions D-Bus/coverage command: 469 passed
- Ruff and diff checks pass