### PR TITLE
Land security hardening and client refresh fixes

### DIFF
--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -375,6 +375,7 @@ ShellRoot {
     onExited: function(code) {
       if (code === 0) {
         composer.text = ""
+        messageList.stickToBottom = true
         root.reload()
       }
     }
@@ -906,11 +907,27 @@ ShellRoot {
 
               ListView {
                 id: messageList
+                property bool stickToBottom: true
+                property string threadKey: conversationPane.thread
+                  ? conversationPane.thread.key : ""
+
+                function scrollToBottom() {
+                  if (stickToBottom && count > 0) positionViewAtEnd()
+                }
+
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 clip: true
                 spacing: theme.scaled(8)
                 model: conversationPane.thread ? conversationPane.thread.messages : []
+                onThreadKeyChanged: {
+                  stickToBottom = true
+                  Qt.callLater(scrollToBottom)
+                }
+                onCountChanged: Qt.callLater(scrollToBottom)
+                onContentHeightChanged: Qt.callLater(scrollToBottom)
+                onMovementStarted: stickToBottom = false
+                onMovementEnded: stickToBottom = atYEnd
                 delegate: Item {
                   id: messageRow
                   required property var modelData

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -1104,6 +1104,8 @@ ShellRoot {
                       if (thread.is_group) args.push("--confirm-group")
                       sendProcess.command = args
                       sendProcess.running = true
+                      if (thread.group_origin === "named")
+                        root.confirmedGroupSignature = ""
                     }
                   }
                 }

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -225,14 +225,19 @@ class BackendOperations:
                 raise NotReadyError("group thread must have 2 to 20 recipients")
             if len(set(group_recipients)) != len(group_recipients):
                 raise NotReadyError("group thread contains duplicate recipients")
-            if thread_key not in self._confirmed_group_keys and not confirm_group:
+            named_group = thread.get("group_origin") == "named"
+            if (
+                (named_group or thread_key not in self._confirmed_group_keys)
+                and not confirm_group
+            ):
                 raise ConfirmationRequiredError(
-                    "confirm the displayed participant list before the first reply "
+                    "confirm the displayed participant list before replying "
                     "to this group"
                 )
 
             def succeeded(transfer: str) -> None:
-                self._confirmed_group_keys.add(thread_key)
+                if not named_group:
+                    self._confirmed_group_keys.add(thread_key)
                 if self.dependencies.on_group_sent is not None:
                     try:
                         self.dependencies.on_group_sent(

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -19,14 +19,16 @@ from blueferry.backend_operations import BackendDependencies
 from blueferry.bearer_supervisor import BearerSupervisor
 from blueferry.bus import get_system_bus, main_loop
 from blueferry.connectivity import Connectivity
-from blueferry.contacts import ContactsResolver, pull_phonebook
+from blueferry.contacts import ContactsResolver, clear_contact_cache, pull_phonebook
 from blueferry.dbus_service import MessagesService, claim_bus_name
 from blueferry.event_dispatcher import EventDispatcher
 from blueferry.history import (
+    clear_events,
     history_count,
     minimize_ancs_history,
     prune_events,
     read_events,
+    scrub_unprotected_events,
 )
 from blueferry.notification_policy import (
     ALL_NOTIFICATIONS,
@@ -44,7 +46,7 @@ from blueferry.setup_verification import (
     NOTIFICATION_ACCESS,
     SetupVerification,
 )
-from blueferry.storage_security import StorageSecurity
+from blueferry.storage_security import NO_STORAGE, StorageSecurity
 
 log = logging.getLogger(__name__)
 
@@ -185,9 +187,16 @@ class Daemon:
 
     def _initialize_storage(self) -> None:
         status = self.storage.refresh(allow_prompt=False)
+        if status.policy == NO_STORAGE:
+            clear_events()
+            clear_contact_cache()
+            return
         if not status.can_read:
             log.info("private storage unavailable: %s", status.detail)
             return
+        scrubbed = scrub_unprotected_events(storage=self.storage)
+        if scrubbed:
+            log.info("scrubbed %d unprotected history events", scrubbed)
         prune_events(storage=self.storage)
         discarded, minimized = minimize_ancs_history(storage=self.storage)
         if discarded or minimized:

--- a/src/blueferry/grouping.py
+++ b/src/blueferry/grouping.py
@@ -233,6 +233,8 @@ def _reconcile_group_identities(
         key = "group:addresses:" + "|".join(verified_signature)
         name = str(source.get("group_name") or "")
         for event in grouped:
+            if event.get("group_sender_verified") is False:
+                continue
             event["group_key"] = key
             event["group_name"] = name
             event["group_recipients"] = recipients
@@ -338,6 +340,11 @@ def correlate_group_events(events: list[dict], resolver=None) -> list[dict]:
 
         sender_title = str(event.get("title") or "").strip()
         trusted_sender_name = str(sms.get("contact_name") or "").strip()
+        sender_name_verified = bool(
+            sender_title
+            and trusted_sender_name
+            and sender_title.casefold() == trusted_sender_name.casefold()
+        )
         if (sender_title and trusted_sender_name
                 and sender_title.casefold() != trusted_sender_name.casefold()):
             # The notification title should name the MAP sender. A mismatch
@@ -345,7 +352,7 @@ def correlate_group_events(events: list[dict], resolver=None) -> list[dict]:
             matched.remove(sms_index)
             continue
         sender_address = _safe_address(sms)
-        if sender_title and sender_address:
+        if sender_name_verified and sender_address:
             addresses_by_name.setdefault(sender_title.casefold(), set()).add(
                 sender_address
             )
@@ -411,18 +418,33 @@ def correlate_group_events(events: list[dict], resolver=None) -> list[dict]:
         recipients: list[str] = []
         unresolved = False
         for member in members:
-            known = addresses_by_name.get(member.casefold(), set())
-            if len(known) == 1:
-                address = next(iter(known))
+            if sender_title and member.casefold() == sender_title.casefold():
+                # ANCS display names are remote, unauthenticated metadata. Do
+                # not let a claimed title redirect the live MAP sender to a
+                # contact with that name.
+                address = sender_address if sender_name_verified else None
             else:
-                address = _contact_address(resolver, member)
+                known = addresses_by_name.get(member.casefold(), set())
+                if len(known) == 1:
+                    address = next(iter(known))
+                else:
+                    address = _contact_address(resolver, member)
             if not address:
                 unresolved = True
                 continue
             if address not in recipients:
                 recipients.append(address)
 
-        reply_ready = not unresolved and len(recipients) >= 2
+        sender_identity = canonical_address(sender_address)
+        recipient_identities = {
+            canonical_address(address) for address in recipients
+        }
+        reply_ready = (
+            not unresolved
+            and len(recipients) >= 2
+            and sender_identity is not None
+            and sender_identity in recipient_identities
+        )
         key, name = _group_identity(
             members, recipients, reply_ready=reply_ready
         )
@@ -434,6 +456,7 @@ def correlate_group_events(events: list[dict], resolver=None) -> list[dict]:
             "group_recipients": recipients,
             "group_reply_ready": reply_ready,
             "group_observed_sender": sender_title,
+            "group_sender_verified": sender_name_verified,
         })
 
     _reconcile_group_identities(out, addresses_by_name, resolver)

--- a/src/blueferry/history.py
+++ b/src/blueferry/history.py
@@ -10,7 +10,11 @@ from typing import TYPE_CHECKING, Any
 
 from blueferry import config
 from blueferry.ancs.constants import MESSAGES_APP_ID
-from blueferry.storage_security import CorruptStorageError
+from blueferry.storage_security import (
+    ENCRYPTED_STORAGE,
+    CorruptStorageError,
+    is_encrypted_value,
+)
 
 if TYPE_CHECKING:
     from blueferry.storage_security import StorageSecurity
@@ -293,6 +297,40 @@ def clear_events(*, path: Path | None = None) -> None:
         with database:
             database.execute("DELETE FROM events")
         database.execute("VACUUM")
+
+
+def scrub_unprotected_events(
+    *, path: Path | None = None, storage: StorageSecurity
+) -> int:
+    """Remove legacy plaintext rows before encrypted history is read.
+
+    Ciphertext with a valid BlueFerry frame is retained even if its key no
+    longer works. That distinction avoids turning a keyring problem into data
+    loss while ensuring plaintext left by an older policy is erased.
+    """
+    if (
+        storage.status.policy != ENCRYPTED_STORAGE
+        or not storage.status.can_read
+    ):
+        return 0
+    with closing(_open_database(path)) as database:
+        plaintext_ids = [
+            int(event_id)
+            for event_id, payload in database.execute(
+                "SELECT id, payload_json FROM events"
+            )
+            if not is_encrypted_value(str(payload))
+        ]
+        if not plaintext_ids:
+            return 0
+        database.execute("PRAGMA secure_delete = ON")
+        with database:
+            database.executemany(
+                "DELETE FROM events WHERE id = ?",
+                ((event_id,) for event_id in plaintext_ids),
+            )
+        database.execute("VACUUM")
+    return len(plaintext_ids)
 
 
 _ANCS_CORRELATION_FIELDS = (

--- a/src/blueferry/storage_security.py
+++ b/src/blueferry/storage_security.py
@@ -87,20 +87,53 @@ class SecretServiceKeyProvider:
                 {"purpose": Secret.SchemaAttributeType.STRING,
                  "version": Secret.SchemaAttributeType.STRING},
             )
-            flags = Secret.SearchFlags.ALL | Secret.SearchFlags.LOAD_SECRETS
-            if allow_prompt:
-                flags |= Secret.SearchFlags.UNLOCK
-            items = service.search_sync(schema, _ATTRIBUTES, flags, None)
-            locked_match = False
-            for item in items:
+
+            def search(*, load_secrets: bool = False):
+                flags = Secret.SearchFlags.ALL
+                if load_secrets:
+                    flags |= Secret.SearchFlags.LOAD_SECRETS
+                return list(service.search_sync(schema, _ATTRIBUTES, flags, None))
+
+            def load_existing(items) -> bytes:
+                if not items:
+                    raise StorageUnavailableError(
+                        "the BlueFerry storage key disappeared from the desktop keyring"
+                    )
+                if len(items) > 1:
+                    raise StorageUnavailableError(
+                        "multiple BlueFerry storage keys exist in the desktop keyring"
+                    )
+                item = items[0]
                 if item.get_locked():
-                    locked_match = True
-                    continue
+                    if not allow_prompt:
+                        raise StorageUnavailableError("the desktop keyring is locked")
+                    service.unlock_sync([item], None)
+                loaded = search(load_secrets=True)
+                if len(loaded) != 1:
+                    if len(loaded) > 1:
+                        raise StorageUnavailableError(
+                            "multiple BlueFerry storage keys exist in the desktop keyring"
+                        )
+                    raise StorageUnavailableError(
+                        "the BlueFerry storage key disappeared from the desktop keyring"
+                    )
+                item = loaded[0]
+                if item.get_locked():
+                    raise StorageUnavailableError("the desktop keyring is locked")
                 secret = item.get_secret()
-                if secret is not None:
-                    return self._decode_key(secret.get_text())
-            if locked_match:
-                raise StorageUnavailableError("the desktop keyring is locked")
+                if secret is None:
+                    raise StorageUnavailableError(
+                        "the desktop keyring did not return the BlueFerry key"
+                    )
+                return self._decode_key(secret.get_text())
+
+            items = search()
+            if len(items) > 1:
+                raise StorageUnavailableError(
+                    "multiple BlueFerry storage keys exist in the desktop keyring"
+                )
+            if items:
+                return load_existing(items)
             if not allow_prompt:
                 raise StorageUnavailableError(
                     "Encrypted storage needs one-time keyring setup"
@@ -114,8 +147,21 @@ class SecretServiceKeyProvider:
             )
             if collection is None:
                 raise StorageUnavailableError("no default keyring is configured")
-            if collection.get_locked() and not allow_prompt:
-                raise StorageUnavailableError("the desktop keyring is locked")
+            if collection.get_locked():
+                service.unlock_sync([collection], None)
+                if collection.get_locked():
+                    raise StorageUnavailableError("the desktop keyring is locked")
+
+            # Unlocking a collection can reveal an item that was not returned
+            # by a non-conforming Secret Service implementation. It also
+            # narrows the race between the first lookup and key creation.
+            items = search()
+            if len(items) > 1:
+                raise StorageUnavailableError(
+                    "multiple BlueFerry storage keys exist in the desktop keyring"
+                )
+            if items:
+                return load_existing(items)
 
             key = os.urandom(_KEY_BYTES)
             encoded = base64.b64encode(key).decode("ascii")
@@ -129,7 +175,9 @@ class SecretServiceKeyProvider:
                 None,
             ):
                 raise StorageUnavailableError("the desktop keyring rejected the key")
-            return key
+            # Return what the service actually retained, and fail closed if a
+            # concurrent creator produced a duplicate item.
+            return load_existing(search())
         except StorageUnavailableError:
             raise
         except Exception as error:
@@ -310,5 +358,5 @@ class StorageSecurity:
 
 
 def is_encrypted_value(value: str) -> bool:
-    """Introspection helper used by tests."""
+    """Return whether a stored value has BlueFerry's ciphertext frame."""
     return value.startswith(_PREFIX)

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -183,7 +183,10 @@ class TuiState:
             return False
         if (
             thread.is_group
-            and thread.key not in self.confirmed_groups
+            and (
+                thread.extra.get("group_origin") == "named"
+                or thread.key not in self.confirmed_groups
+            )
             and not confirm_group
         ):
             self.error = "Group reply requires participant confirmation"
@@ -197,7 +200,11 @@ class TuiState:
         except BackendError as error:
             self.error = str(error)
             return False
-        if thread.is_group and confirm_group:
+        if (
+            thread.is_group
+            and confirm_group
+            and thread.extra.get("group_origin") != "named"
+        ):
             self.confirmed_groups.add(thread.key)
         self.selected_key = thread.key
         self.error = ""
@@ -306,7 +313,9 @@ class ConversationItem(ListItem):
 class MessageRow(Horizontal):
     def __init__(self, message: ThreadMessage, fallback_name: str) -> None:
         direction = "outgoing" if message.outgoing else "incoming"
-        sender = "You" if message.outgoing else (message.sender or fallback_name)
+        sender = _one_line(
+            "You" if message.outgoing else (message.sender or fallback_name)
+        )
         meta = f"{sender}  ·  {_short_timestamp(message.timestamp)}"
         bubble = Vertical(
             Static(Text(meta), classes="message-meta"),
@@ -951,7 +960,10 @@ class BlueFerryApp(App[None]):
         if len(body) > _MAX_INPUT:
             self.notify(f"Messages are limited to {_MAX_INPUT} characters", severity="error")
             return
-        if thread.is_group and thread.key not in self.state.confirmed_groups:
+        if thread.is_group and (
+            thread.extra.get("group_origin") == "named"
+            or thread.key not in self.state.confirmed_groups
+        ):
             self.push_screen(
                 GroupConfirmScreen(thread),
                 lambda confirmed: self._group_reply_ready(confirmed, thread.key, body),

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -614,7 +614,7 @@ class BlueFerryApp(App[None]):
         except Exception:
             self._monitor = None
         self.set_interval(_SIGNAL_PUMP_SECONDS, self._pump_events)
-        self.set_interval(_REFRESH_SECONDS, self.action_refresh)
+        self.set_interval(_REFRESH_SECONDS, self._load_data)
         self._update_responsive(self.size.width)
         self._load_data()
 
@@ -669,15 +669,25 @@ class BlueFerryApp(App[None]):
         )
 
     async def _apply_snapshot(self, snapshot: TuiSnapshot) -> None:
+        previous_status = self.state.status
+        previous_threads = tuple(self.state.threads)
+        previous_selection = self.state.selected_key
+        previous_error = self.state.error
         self.state.apply_snapshot(snapshot)
         if self._pending_open_handle and self.state.select_message(self._pending_open_handle):
             self._pending_open_handle = None
             self.query_one("#workspace").add_class("chat-open")
-        await self._populate_threads()
-        await self._render_conversation()
-        self._update_status()
-        self._update_notice()
-        self._warn_about_roster_changes()
+        threads_changed = tuple(self.state.threads) != previous_threads
+        selection_changed = self.state.selected_key != previous_selection
+        if threads_changed or selection_changed:
+            await self._populate_threads()
+            await self._render_conversation()
+        if self.state.status != previous_status:
+            self._update_status()
+        if self.state.error != previous_error:
+            self._update_notice()
+        if threads_changed:
+            self._warn_about_roster_changes()
 
     def _warn_about_roster_changes(self) -> None:
         for thread in self.state.threads:

--- a/src/blueferry/ui/conversations.py
+++ b/src/blueferry/ui/conversations.py
@@ -752,7 +752,10 @@ class ConversationsPage(Gtk.Box):
         if not body or self._current is None:
             return
         thread = self._threads[self._current]
-        if thread.get("is_group") and thread["key"] not in self._confirmed_groups:
+        if thread.get("is_group") and (
+            thread.get("group_origin") == "named"
+            or thread["key"] not in self._confirmed_groups
+        ):
             self._confirm_group_send(thread, body)
             return
         self._dispatch_send(thread, body, confirm_group=False)
@@ -773,7 +776,8 @@ class ConversationsPage(Gtk.Box):
 
         def responded(_dialog, response: str) -> None:
             if response == "send":
-                self._confirmed_groups.add(thread["key"])
+                if thread.get("group_origin") != "named":
+                    self._confirmed_groups.add(thread["key"])
                 self._dispatch_send(thread, body, confirm_group=True)
 
         dialog.connect("response", responded)

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -68,11 +68,13 @@ class IPhonePage(Gtk.Box):
             title=_("Found iPhone"),
             subtitle=_("Choose the phone to pair"),
             model=self._device_model,
+            use_markup=False,
         )
         self._device_row.connect("notify::selected", lambda *_args: self._selection_changed())
         self._hardware_row = Adw.ActionRow(
             title=_("Bluetooth Controller"),
             subtitle=_("Checking compatibility…"),
+            use_markup=False,
         )
         self._bluez_row = Adw.ActionRow(
             title=_("Bluetooth Support"),
@@ -133,6 +135,7 @@ class IPhonePage(Gtk.Box):
         self._paired_row = Adw.ActionRow(
             title=_("Paired iPhone"),
             subtitle=_("Checking device name…"),
+            use_markup=False,
         )
         self._unpair_button = Gtk.Button(
             label=_("Unpair"),
@@ -592,6 +595,8 @@ class IPhonePage(Gtk.Box):
             body=_(
                 "For a clean re-pair, also forget this computer in the iPhone's Bluetooth settings."
             ),
+            heading_use_markup=False,
+            body_use_markup=False,
         )
         dialog.add_response("cancel", _("Cancel"))
         dialog.add_response("forget", _("Unpair"))

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -93,6 +93,31 @@ def test_confirmed_group_reply_uses_backend_recipient_set(monkeypatch):
     assert thread["key"] in operations._confirmed_group_keys
 
 
+def test_named_group_requires_confirmation_for_every_reply(monkeypatch):
+    operations = _operations()
+    thread = {**_group(), "group_origin": "named"}
+    _stub_group(operations, thread)
+    monkeypatch.setattr(
+        backend_operations,
+        "send_group_message",
+        lambda *_args: "/transfer/named",
+    )
+
+    operations.send_to_thread(
+        thread["key"], "first", True,
+        lambda _result: None,
+        lambda error: pytest.fail(str(error)),
+    )
+
+    assert thread["key"] not in operations._confirmed_group_keys
+    with pytest.raises(ConfirmationRequiredError):
+        operations.send_to_thread(
+            thread["key"], "second", False,
+            lambda _result: pytest.fail("unexpected successful reply"),
+            lambda error: pytest.fail(str(error)),
+        )
+
+
 def test_group_reply_records_the_projected_member_roster(monkeypatch):
     recorded = []
     operations = _operations(

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -87,6 +87,28 @@ def test_start_publishes_dbus_before_scheduling_bluetooth(monkeypatch):
     assert instance._initializing is False
 
 
+def test_no_storage_policy_reasserts_empty_local_data(monkeypatch):
+    instance = _bare_daemon()
+    status = SimpleNamespace(
+        policy="none", state="disabled", detail="", can_read=False
+    )
+    instance.storage = SimpleNamespace(
+        status=status,
+        refresh=lambda **_kwargs: status,
+    )
+    cleared = []
+    monkeypatch.setattr(
+        daemon_mod, "clear_events", lambda: cleared.append("events")
+    )
+    monkeypatch.setattr(
+        daemon_mod, "clear_contact_cache", lambda: cleared.append("contacts")
+    )
+
+    instance._initialize_storage()
+
+    assert cleared == ["events", "contacts"]
+
+
 def test_failed_hardware_initialization_leaves_control_service_alive(monkeypatch):
     instance = _bare_daemon()
     scheduled = []

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -32,7 +32,7 @@ def _ancs(title: str, subtitle: str, body: str, seen_at: str) -> dict:
     }
 
 
-def test_captured_group_notification_correlates_with_map_sender() -> None:
+def test_unnamed_group_without_trusted_map_sender_name_is_read_only() -> None:
     events = [
         # Earlier 1:1 history teaches the resolver Alice's address.
         _sms("+15551111111", "Alice Example", "earlier",
@@ -46,10 +46,47 @@ def test_captured_group_notification_correlates_with_map_sender() -> None:
     correlated = correlate_group_events(events)
     group_sms = correlated[1]
     assert group_sms["group_name"] == "Alice Example, Bob Example"
-    assert group_sms["group_recipients"] == [
-        "+15551111111", "bob@icloud.com"
+    assert group_sms["group_recipients"] == ["+15551111111"]
+    assert group_sms["group_reply_ready"] is False
+
+
+def test_ancs_title_cannot_replace_an_unverified_map_sender() -> None:
+    events = [
+        _sms("+15551111111", "Alice", "earlier",
+             "2026-08-08T16:20:00+00:00"),
+        _sms("+15552222222", "Bob", "earlier too",
+             "2026-08-08T16:20:05+00:00"),
+        _sms("mallory@example.com", None, "attack",
+             "2026-08-08T16:21:20+00:00"),
+        _ancs("Alice", "To you & Bob", "attack",
+              "2026-08-08T16:21:22+00:00"),
     ]
-    assert group_sms["group_reply_ready"] is True
+
+    message = correlate_group_events(events)[2]
+
+    assert message["group_reply_ready"] is False
+    assert "mallory@example.com" not in message["group_recipients"]
+
+
+def test_verified_history_cannot_upgrade_an_unverified_group_sender() -> None:
+    events = [
+        _sms("+15552222222", "Bob", "earlier",
+             "2026-08-08T16:19:00+00:00"),
+        _sms("+15551111111", "Alice", "legitimate",
+             "2026-08-08T16:20:00+00:00"),
+        _ancs("Alice", "To you & Bob", "legitimate",
+              "2026-08-08T16:20:02+00:00"),
+        _sms("mallory@example.com", None, "attack",
+             "2026-08-08T16:21:20+00:00"),
+        _ancs("Alice", "To you & Bob", "attack",
+              "2026-08-08T16:21:22+00:00"),
+    ]
+
+    correlated = correlate_group_events(events)
+
+    assert correlated[1]["group_reply_ready"] is True
+    assert correlated[3]["group_reply_ready"] is False
+    assert correlated[3]["group_sender_verified"] is False
 
 
 def test_group_key_is_stable_when_a_different_member_speaks() -> None:

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -387,3 +387,13 @@ def test_remote_qml_text_is_rendered_as_plain_text() -> None:
         "text: newContactDelegate.modelData.name\n"
         "                  textFormat: Text.PlainText"
     ) in quickshell
+
+
+def test_quickshell_message_timeline_stays_at_the_latest_message() -> None:
+    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+
+    assert "property bool stickToBottom: true" in quickshell
+    assert "positionViewAtEnd()" in quickshell
+    assert "onThreadKeyChanged" in quickshell
+    assert "onMovementStarted: stickToBottom = false" in quickshell
+    assert "messageList.stickToBottom = true" in quickshell

--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -12,7 +12,12 @@ import pytest
 
 from blueferry import config, contact_repository
 from blueferry.contacts import ContactsResolver
-from blueferry.history import append_event, prune_events, read_events
+from blueferry.history import (
+    append_event,
+    prune_events,
+    read_events,
+    scrub_unprotected_events,
+)
 from blueferry.settings_store import SettingsStore
 from blueferry.storage_security import (
     CorruptStorageError,
@@ -96,6 +101,108 @@ def test_secret_service_log_includes_the_provider_error(monkeypatch, caplog) -> 
             provider.get_or_create(allow_prompt=False)
 
     assert "No such secret item at path /collection/login/27" in caplog.text
+
+
+def test_secret_service_rejects_duplicate_matching_keys(monkeypatch) -> None:
+    item = SimpleNamespace(get_locked=lambda: False)
+    service = SimpleNamespace(search_sync=lambda *_args: [item, item])
+    provider = SecretServiceKeyProvider()
+    monkeypatch.setattr(
+        provider,
+        "_secret_module",
+        lambda: _secret_module(get_service=lambda *_args: service),
+    )
+
+    with pytest.raises(StorageUnavailableError, match="multiple BlueFerry"):
+        provider.get_or_create(allow_prompt=False)
+
+
+def test_locked_matching_key_is_never_replaced(monkeypatch) -> None:
+    item = SimpleNamespace(get_locked=lambda: True)
+    stored = []
+    service = SimpleNamespace(
+        search_sync=lambda *_args: [item],
+        unlock_sync=lambda *_args: None,
+        store_sync=lambda *_args: stored.append(True),
+    )
+    provider = SecretServiceKeyProvider()
+    monkeypatch.setattr(
+        provider,
+        "_secret_module",
+        lambda: _secret_module(get_service=lambda *_args: service),
+    )
+
+    with pytest.raises(StorageUnavailableError, match="keyring is locked"):
+        provider.get_or_create(allow_prompt=True)
+
+    assert stored == []
+
+
+def test_secret_service_creates_and_reloads_exactly_one_key(monkeypatch) -> None:
+    retained = []
+    collection = SimpleNamespace(get_locked=lambda: False)
+
+    def item_for(value):
+        return SimpleNamespace(
+            get_locked=lambda: False,
+            get_secret=lambda: SimpleNamespace(get_text=lambda: value),
+        )
+
+    service = SimpleNamespace()
+    service.search_sync = lambda *_args: [item_for(retained[0])] if retained else []
+    service.store_sync = lambda *_args: retained.append(_args[4]) or True
+    secret = _secret_module(get_service=lambda *_args: service)
+    secret.Collection = SimpleNamespace(
+        for_alias_sync=lambda *_args: collection,
+    )
+    secret.CollectionFlags = SimpleNamespace(NONE=0)
+    secret.COLLECTION_DEFAULT = "default"
+    secret.Value = SimpleNamespace(new=lambda text, *_args: text)
+    provider = SecretServiceKeyProvider()
+    monkeypatch.setattr(provider, "_secret_module", lambda: secret)
+
+    key = provider.get_or_create(allow_prompt=True)
+
+    assert len(retained) == 1
+    assert key == base64.b64decode(retained[0])
+
+
+def test_secret_service_rechecks_after_collection_unlock(monkeypatch) -> None:
+    encoded = base64.b64encode(b"R" * 32).decode("ascii")
+    unlocked = False
+    search_count = 0
+    stored = []
+    item = SimpleNamespace(
+        get_locked=lambda: False,
+        get_secret=lambda: SimpleNamespace(get_text=lambda: encoded),
+    )
+    collection = SimpleNamespace(get_locked=lambda: not unlocked)
+
+    def search(*_args):
+        nonlocal search_count
+        search_count += 1
+        return [] if search_count == 1 else [item]
+
+    def unlock(*_args):
+        nonlocal unlocked
+        unlocked = True
+
+    service = SimpleNamespace(
+        search_sync=search,
+        unlock_sync=unlock,
+        store_sync=lambda *_args: stored.append(True),
+    )
+    secret = _secret_module(get_service=lambda *_args: service)
+    secret.Collection = SimpleNamespace(
+        for_alias_sync=lambda *_args: collection,
+    )
+    secret.CollectionFlags = SimpleNamespace(NONE=0)
+    secret.COLLECTION_DEFAULT = "default"
+    provider = SecretServiceKeyProvider()
+    monkeypatch.setattr(provider, "_secret_module", lambda: secret)
+
+    assert provider.get_or_create(allow_prompt=True) == b"R" * 32
+    assert stored == []
 
 def _storage(tmp_path, provider=None) -> StorageSecurity:
     return StorageSecurity(
@@ -186,15 +293,36 @@ def test_history_database_contains_ciphertext_and_round_trips(tmp_path) -> None:
     assert read_events(path=path, storage=storage) == [event]
 
 
-def test_plaintext_history_is_rejected_in_encrypted_mode(tmp_path) -> None:
+def test_plaintext_history_is_scrubbed_in_encrypted_mode(tmp_path) -> None:
     path = tmp_path / "events.sqlite"
     event = {"kind": "sms_received", "body": "old plaintext"}
     append_event(event, path=path)
     storage = _storage(tmp_path)
 
+    assert scrub_unprotected_events(path=path, storage=storage) == 1
     assert read_events(path=path, storage=storage) == []
-    assert storage.status.state == "error"
-    assert b"old plaintext" in path.read_bytes()
+    assert storage.status.state == "ready"
+    assert b"old plaintext" not in path.read_bytes()
+
+
+def test_plaintext_scrub_preserves_framed_ciphertext(tmp_path) -> None:
+    path = tmp_path / "events.sqlite"
+    storage = _storage(tmp_path)
+    append_event(
+        {"kind": "sms_received", "body": "encrypted"},
+        path=path,
+        storage=storage,
+    )
+    append_event(
+        {"kind": "sms_received", "body": "legacy plaintext"},
+        path=path,
+    )
+
+    assert scrub_unprotected_events(path=path, storage=storage) == 1
+    assert read_events(path=path, storage=storage) == [
+        {"kind": "sms_received", "body": "encrypted"}
+    ]
+    assert b"legacy plaintext" not in path.read_bytes()
 
 
 def test_pruning_reasserts_private_encrypted_metadata(tmp_path) -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -265,6 +265,26 @@ def test_textual_app_renders_status_threads_and_messages() -> None:
     _run_headless(scenario())
 
 
+def test_unchanged_poll_does_not_rebuild_the_terminal_view() -> None:
+    async def scenario() -> None:
+        state = TuiState(_Backend())
+        app = BlueFerryApp(state, monitor_factory=lambda: None)
+
+        async with app.run_test(size=(120, 36)) as pilot:
+            await _wait_for_threads(app, pilot, 2)
+            thread_items = tuple(app.query_one("#thread-list", ListView).children)
+            message_items = tuple(
+                app.query_one("#message-timeline").children
+            )
+
+            await app._apply_snapshot(state.fetch_snapshot())
+
+            assert tuple(app.query_one("#thread-list", ListView).children) == thread_items
+            assert tuple(app.query_one("#message-timeline").children) == message_items
+
+    _run_headless(scenario())
+
+
 def test_textual_warns_once_when_saved_group_roster_changes() -> None:
     async def scenario() -> None:
         backend = _Backend()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -154,7 +154,30 @@ def test_replies_use_opaque_thread_key_and_explicit_group_confirmation() -> None
     assert state.send_reply("hello all", confirm_group=True) is True
 
     assert backend.sent == [("group", "hello all", True)]
-    assert state.confirmed_groups == {"group"}
+    assert state.confirmed_groups == set()
+    assert state.send_reply("not without another confirmation") is False
+
+
+def test_message_sender_metadata_is_sanitized() -> None:
+    async def scenario() -> None:
+        backend = _Backend()
+        unsafe = replace(
+            backend.loaded[1].messages[0],
+            sender="Beau\x1b[31m\u202e\nforged",
+        )
+        backend.loaded[1] = replace(backend.loaded[1], messages=(unsafe,))
+        state = TuiState(backend)
+        state.selected_key = "group"
+        app = BlueFerryApp(state, monitor_factory=lambda: None)
+
+        async with app.run_test(size=(120, 36)) as pilot:
+            await _wait_for_threads(app, pilot, 2)
+            app.action_next_thread()
+            await pilot.pause(0.1)
+            meta = app.query_one(MessageRow).query_one(".message-meta", Static)
+            assert meta.render().plain.startswith("Beau�[31m� forged  ·  ")
+
+    _run_headless(scenario())
 
 
 def test_read_only_thread_cannot_send() -> None:


### PR DESCRIPTION
## Summary

This follow-up brings the changes from the already-reviewed stacked PRs into `main`. PR #10 was merged before its stacked PRs, so GitHub merged #11 and #12 into `feature/named-group-threads` after that branch had already landed.

Included changes:

- #11: group-routing and local-storage security hardening
- #12: Quickshell bottom-pinning and TUI redraw prevention

The diff contains only commits `77f4bac` and `25772f5` plus their merge commits; the named-group implementation from #10 is already present on `main`.