### PR TITLE
Write scrubbed pairing reports for adapter and ANCS failures

### DIFF
--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -35,6 +35,7 @@ ShellRoot {
   property bool pairingConfirmationPending: false
   property string pairingPasskey: ""
   property bool pairingResultReceived: false
+  property string pairingIssueReport: ""
   property var pendingPairingDevice: null
   property string adapterName: ""
   property string onboardingStage: onboarding.stage
@@ -231,12 +232,14 @@ ShellRoot {
       if (!parsed.ok) {
         root.pairingResultReceived = true
         root.pairingStatus = parsed.error || "Pairing failed; it is safe to retry."
+        root.pairingIssueReport = parsed.report_path || parsed.quirks_report || ""
         return
       }
       root.pairingResultReceived = true
       root.pairingStatus = parsed.ancs_ready || !root.notificationsSupported
         ? "Linux pairing complete. On the iPhone enable Show Message Notifications and Sync Contacts."
         : "Pairing is complete. Notification access is still settling; keep the iPhone Bluetooth settings open."
+      root.pairingIssueReport = parsed.quirks_report || parsed.report_path || ""
       root.configured = true
       root.targetSaved = true
       root.targetBonded = true
@@ -316,6 +319,8 @@ ShellRoot {
           root.bondStateKnown = typeof parsed.bonded === "boolean"
           root.targetBonded = parsed.bonded === true
           root.configuredMac = root.targetSaved ? (parsed.mac || "") : ""
+          if (typeof parsed.pairing_issue_report === "string")
+            root.pairingIssueReport = parsed.pairing_issue_report
           if (root.targetSaved && root.bondStateKnown && !root.targetBonded)
             root.pairingStatus = "This phone is no longer paired in BlueZ. Clear the saved phone, then scan and pair again."
           if (!root.configured) root.phoneSettingsVisible = true
@@ -566,6 +571,18 @@ ShellRoot {
       root.pairingPasskey = ""
       if (code !== 0 && !root.pairingResultReceived)
         root.pairingStatus = "Pairing did not complete; unlock the iPhone and try again."
+    }
+  }
+
+  Process {
+    id: pairingIssueUrlProcess
+    command: ["/usr/bin/blueferry", "pairing-issue", "--print-url"]
+    stdout: StdioCollector {
+      onStreamFinished: {
+        var url = text.trim().split("\n").pop()
+        if (url.indexOf("https://") === 0)
+          Qt.openUrlExternally(url)
+      }
     }
   }
 
@@ -1246,6 +1263,11 @@ ShellRoot {
               } else root.startPairing(device, false)
             }
           }
+          FerryButton {
+            visible: root.pairingIssueReport !== ""
+            text: "Report Pairing Issue"
+            onClicked: pairingIssuePopup.open()
+          }
           FerryLabel {
             text: root.pairingPasskey === "" ? "Pairing confirmation" : root.pairingPasskey
             font.bold: true
@@ -1465,6 +1487,59 @@ ShellRoot {
                 var device = root.pendingPairingDevice
                 replaceTargetPopup.close()
                 if (device !== null) root.startPairing(device, true)
+              }
+            }
+          }
+        }
+      }
+
+      Popup {
+        id: pairingIssuePopup
+        parent: applicationSurface
+        x: Math.max(0, (applicationSurface.width - width) / 2)
+        y: Math.max(0, (applicationSurface.height - height) / 2)
+        width: Math.min(theme.scaled(440), applicationSurface.width - theme.scaled(24))
+        modal: true
+        focus: true
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        padding: theme.scaled(18)
+
+        background: Rectangle {
+          color: theme.cardSurface
+          border.color: theme.divider
+          radius: theme.panelRadius
+        }
+
+        Overlay.modal: Rectangle {
+          color: Qt.rgba(theme.windowSurface.r, theme.windowSurface.g,
+                         theme.windowSurface.b, 0.72)
+        }
+
+        contentItem: ColumnLayout {
+          spacing: theme.scaled(12)
+          FerryLabel {
+            text: "Report pairing issue"
+            font.bold: true
+            font.pixelSize: theme.headingSize
+          }
+          FerryLabel {
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            text: "A pairing report was saved at " + root.pairingIssueReport
+              + ". Attach that file to a GitHub issue and include the iPhone model and iOS version."
+          }
+          RowLayout {
+            Layout.alignment: Qt.AlignRight
+            FerryButton {
+              text: "Cancel"
+              onClicked: pairingIssuePopup.close()
+            }
+            FerryButton {
+              text: "Open GitHub"
+              highlighted: true
+              onClicked: {
+                pairingIssuePopup.close()
+                pairingIssueUrlProcess.running = true
               }
             }
           }

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -175,11 +175,21 @@ class AncsClient:
             self._on_iface_added(path, ifaces)
 
     @property
+    def subscribed(self) -> bool:
+        """GATT Notification Source/Data Source subscriptions are active."""
+        return self._notify_started
+
+    @property
+    def authorized(self) -> bool:
+        """iOS accepted a content-free Control Point probe."""
+        return self._authorized
+
+    @property
     def connected(self) -> bool:
         # StartNotify only proves that BlueZ subscribed to the GATT
         # characteristics. iOS notification access is usable only after an
         # authorized Control Point round trip succeeds.
-        return self._notify_started and self._authorized
+        return self.subscribed and self.authorized
 
     def stop(self) -> None:
         log.info("ANCS client stopping")

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -26,6 +26,17 @@ _INTERFACES = {
     "le": "org.bluez.Bearer.LE1",
 }
 
+def _connect_error_parts(error: Exception) -> tuple[str, str]:
+    """Split a connect failure into D-Bus name and message."""
+    if isinstance(error, dbus.exceptions.DBusException):
+        name = error.get_dbus_name() or type(error).__name__
+        message = error.get_dbus_message() or ""
+    else:
+        name = type(error).__name__
+        message = str(error)
+    return name[:256], message[:256]
+
+
 ReadConnected = Callable[[str], bool | None]
 Connect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
 Prefer = Callable[[str], None]
@@ -70,7 +81,7 @@ class BearerSupervisor:
         self._le_settle_id: int | None = None
         self._running = False
         self._connecting: set[str] = set()
-        self._last_errors: dict[str, str] = {}
+        self._last_errors: dict[str, tuple[str, str]] = {}
         self._states: dict[str, bool | None] = {"bredr": None, "le": None}
         self._failures: dict[str, int] = {"bredr": 0, "le": 0}
         self._next_attempt: dict[str, float] = {"bredr": 0.0, "le": 0.0}
@@ -120,10 +131,13 @@ class BearerSupervisor:
                 log.debug("could not remove bearer health timer", exc_info=True)
             self._timer_id = None
 
-    def snapshot(self) -> dict[str, bool]:
+    def snapshot(self) -> dict[str, object]:
+        name, message = self._last_errors.get("le", ("", ""))
         return {
             "bredr": self.bredr_connected,
             "le": self.le_connected,
+            "last_le_error": name,
+            "last_le_error_message": message,
         }
 
     def _tick(self) -> bool:
@@ -237,11 +251,7 @@ class BearerSupervisor:
 
     def _connect_failed(self, kind: str, error: Exception) -> None:
         self._connecting.discard(kind)
-        name = (
-            error.get_dbus_name()
-            if isinstance(error, dbus.exceptions.DBusException)
-            else type(error).__name__
-        ) or str(error)
+        name, message = _connect_error_parts(error)
         if name in {
             "org.bluez.Error.AlreadyConnected",
             "org.bluez.Error.InProgress",
@@ -254,14 +264,15 @@ class BearerSupervisor:
             BACKOFF_CAP_SECONDS,
         )
         self._next_attempt[kind] = self._clock() + delay
-        if self._last_errors.get(kind) != name:
+        if self._last_errors.get(kind) != (name, message):
+            detail = f"{name}: {message}" if message else name
             log.warning(
                 "could not connect iPhone %s bearer: %s (next attempt in %ds)",
                 kind.upper(),
-                name,
+                detail,
                 delay,
             )
-            self._last_errors[kind] = name
+            self._last_errors[kind] = (name, message)
 
     def _read_bluez_connected(self, kind: str) -> bool | None:
         obj = get_system_bus().get_object("org.bluez", self.device_path)

--- a/src/blueferry/bluetooth_capabilities.py
+++ b/src/blueferry/bluetooth_capabilities.py
@@ -1,6 +1,7 @@
 """Bluetooth controller capability probing and packaged BlueZ activation."""
 from __future__ import annotations
 
+import re
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -8,36 +9,296 @@ from typing import Protocol
 
 import dbus
 
+from blueferry.config import is_valid_adapter
 from blueferry.errors import CommandError, PairingError
 
 
 class CommandResult(Protocol):
     returncode: int
     stdout: str
+    stderr: str
 
 
 RunCommand = Callable[..., CommandResult]
 
+# Bluetooth SIG company identifiers seen on common Linux adapters.
+_BT_COMPANIES = {
+    2: "Intel",
+    10: "Qualcomm",
+    15: "Broadcom",
+    29: "Qualcomm",
+    70: "MediaTek",
+    93: "Realtek",
+    305: "Cypress",
+}
 
-def controller_settings(
-    adapter: str, *, run_command: RunCommand,
-) -> tuple[bool, set[str], set[str], str]:
-    index = adapter.removeprefix("hci")
-    try:
-        result = run_command(
-            ["/usr/bin/btmgmt", "--index", index, "info"], timeout=15, check=False,
-        )
-    except CommandError as error:
-        return False, set(), set(), str(error)
+# USB/PCI IDs whose sysfs product string is generic (e.g. Wireless_Device).
+_CHIPSETS = {
+    "0bda:8771": "RTL8761BU",
+    "0bda:8852": "RTL8852AE",
+    "0bda:b85b": "RTL8852BE",
+    "0bda:b85c": "RTL8852BE",
+    "0bda:c852": "RTL8852CE",
+    "0bda:c85a": "RTL8852CE",
+    "0e8d:7922": "MT7922",
+    "0e8d:7961": "MT7921",
+    "10ec:8852": "RTL8852AE",
+    "10ec:b852": "RTL8852BE",
+    "10ec:c852": "RTL8852CE",
+    "13d3:3563": "MT7922",
+    "13d3:3585": "MT7922",
+    "14c3:0608": "MT7921",
+    "14c3:0616": "MT7922",
+    "14c3:0717": "MT7925",
+    "14c3:7922": "MT7922",
+    "14c3:7961": "MT7921",
+    "8086:2723": "AX200",
+    "8086:2725": "AX210",
+    "8086:51f0": "AX211",
+    "8086:54f0": "AX211",
+    "8086:7e40": "AX211",
+    "8086:7e70": "AX211",
+}
+_DRIVER_CHIPSETS = {
+    "mt7921e": "MT7921",
+    "mt7921u": "MT7921",
+    "mt7925e": "MT7925",
+    "rtw89_8852ae": "RTL8852AE",
+    "rtw89_8852be": "RTL8852BE",
+    "rtw89_8852ce": "RTL8852CE",
+}
+_GENERIC_PRODUCTS = {
+    "bluetooth",
+    "bluetooth adapter",
+    "bluetooth device",
+    "bluetooth radio",
+    "generic",
+    "usb",
+    "wireless",
+    "wireless device",
+}
+
+# USB/PCI vendor IDs. Values are lowercase hex without 0x.
+_BUS_VENDORS = {
+    "8086": "Intel",
+    "8087": "Intel",
+    "0bda": "Realtek",
+    "10ec": "Realtek",
+    "14c3": "MediaTek",
+    "0e8d": "MediaTek",
+    "0a5c": "Broadcom",
+    "14e4": "Broadcom",
+    "0cf3": "Qualcomm",
+    "168c": "Qualcomm",
+    "17cb": "Qualcomm",
+    "13d3": "AzureWave",
+    "04ca": "Lite-On",
+}
+
+_BTMGMT_IDENTITY = re.compile(
+    r"\bversion\s+(?P<version>\d+)\s+manufacturer\s+(?P<manufacturer>\d+)\b",
+    re.IGNORECASE,
+)
+_MAC_IN_TEXT = re.compile(r"(?i)(?:[0-9a-f]{2}:){5}[0-9a-f]{2}")
+
+
+def _parse_btmgmt_info(stdout: str) -> tuple[set[str], set[str], dict[str, int]]:
     supported: set[str] = set()
     current: set[str] = set()
-    for raw in result.stdout.splitlines():
+    for raw in stdout.splitlines():
         line = raw.strip().casefold()
         if line.startswith("supported settings:"):
             supported.update(line.partition(":")[2].split())
         elif line.startswith("current settings:"):
             current.update(line.partition(":")[2].split())
-    return result.returncode == 0 and bool(supported), supported, current, ""
+    identity: dict[str, int] = {}
+    match = _BTMGMT_IDENTITY.search(stdout)
+    if match is not None:
+        identity["hci_version"] = int(match.group("version"))
+        identity["manufacturer_id"] = int(match.group("manufacturer"))
+    return supported, current, identity
+
+
+def controller_settings(
+    adapter: str, *, run_command: RunCommand, timeout: float = 15,
+) -> tuple[bool, set[str], set[str], str, dict[str, int]]:
+    index = adapter.removeprefix("hci")
+    try:
+        result = run_command(
+            ["/usr/bin/btmgmt", "--index", index, "info"], timeout=timeout, check=False,
+        )
+    except CommandError as error:
+        return False, set(), set(), str(error), {}
+    supported, current, identity = _parse_btmgmt_info(result.stdout)
+    return result.returncode == 0 and bool(supported), supported, current, "", identity
+
+
+def controller_hardware(
+    adapter: str,
+    *,
+    run_command: RunCommand | None = None,
+    sys_root: Path = Path("/sys"),
+) -> dict[str, object]:
+    """Describe the local controller without using the adapter address."""
+    identity: dict[str, object] = {"name": adapter}
+    if not is_valid_adapter(adapter):
+        return identity
+    if run_command is not None:
+        _apply_btmgmt_identity(identity, adapter, run_command)
+    identity.update(_sysfs_identity(adapter, sys_root=sys_root))
+    apply_chipset(identity)
+    manufacturer_id = identity.get("manufacturer_id")
+    if isinstance(manufacturer_id, int):
+        apply_company_id(identity, manufacturer_id)
+    else:
+        identity["summary"] = _hardware_summary(identity)
+    return identity
+
+
+def apply_company_id(identity: dict[str, object], manufacturer_id: int) -> None:
+    """Fill vendor/summary from a Bluetooth SIG company identifier."""
+    identity["manufacturer_id"] = manufacturer_id
+    company = _BT_COMPANIES.get(manufacturer_id)
+    if company and not identity.get("vendor"):
+        identity["vendor"] = company
+    apply_chipset(identity)
+    identity["summary"] = _hardware_summary(identity)
+
+
+def _normalized_product(value: str) -> str:
+    return " ".join(value.casefold().replace("_", " ").replace("-", " ").split())
+
+
+def is_generic_product(value: str) -> bool:
+    folded = _normalized_product(value)
+    return not folded or folded in _GENERIC_PRODUCTS
+
+
+def chipset_name(
+    *,
+    usb_id: str = "",
+    pci_id: str = "",
+    driver: str = "",
+    product: str = "",
+) -> str:
+    """Return a chip name when the USB product string is not useful."""
+    for raw in (usb_id, pci_id):
+        chip = _CHIPSETS.get(str(raw).casefold())
+        if chip:
+            return chip
+    chip = _DRIVER_CHIPSETS.get(str(driver).casefold())
+    if chip:
+        return chip
+    if product and not is_generic_product(product):
+        return product.strip()
+    return ""
+
+
+def apply_chipset(identity: dict[str, object]) -> None:
+    """Replace a generic USB product string with a known chipset name."""
+    product = str(identity.get("product") or "")
+    chip = chipset_name(
+        usb_id=str(identity.get("usb_id") or ""),
+        pci_id=str(identity.get("pci_id") or ""),
+        driver=str(identity.get("driver") or ""),
+        product=product,
+    )
+    if chip and (not product or is_generic_product(product)):
+        identity["product"] = chip
+
+
+def _apply_btmgmt_identity(
+    identity: dict[str, object], adapter: str, run_command: RunCommand,
+) -> None:
+    _available, _supported, _current, _error, parsed = controller_settings(
+        adapter, run_command=run_command,
+    )
+    identity.update(parsed)
+
+
+def _sysfs_identity(adapter: str, *, sys_root: Path) -> dict[str, object]:
+    node = sys_root / "class" / "bluetooth" / adapter / "device"
+    if not node.exists():
+        return {}
+    try:
+        resolved = node.resolve()
+    except OSError:
+        resolved = node
+    identity: dict[str, object] = {}
+    vendor = _sysfs_hex(resolved / "vendor")
+    device = _sysfs_hex(resolved / "device")
+    if vendor and device:
+        identity["bus"] = "pci"
+        identity["pci_id"] = f"{vendor}:{device}"
+        name = _BUS_VENDORS.get(vendor)
+        if name:
+            identity["vendor"] = name
+    driver = resolved / "driver"
+    if driver.is_symlink() or driver.exists():
+        try:
+            identity["driver"] = driver.resolve().name
+        except OSError:
+            pass
+    for current in (resolved, *list(resolved.parents)[:6]):
+        id_vendor = _sysfs_text(current / "idVendor")
+        id_product = _sysfs_text(current / "idProduct")
+        if not id_vendor or not id_product:
+            continue
+        identity["bus"] = "usb"
+        identity["usb_id"] = f"{id_vendor}:{id_product}"
+        name = _BUS_VENDORS.get(id_vendor.casefold())
+        if name:
+            identity["vendor"] = name
+        product = _safe_model(_sysfs_text(current / "product"))
+        manufacturer = _safe_model(_sysfs_text(current / "manufacturer"))
+        if product:
+            identity["product"] = product
+        if manufacturer:
+            identity["usb_manufacturer"] = manufacturer
+        break
+    return identity
+
+
+def _sysfs_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return ""
+
+
+def _sysfs_hex(path: Path) -> str:
+    raw = _sysfs_text(path).casefold()
+    if raw.startswith("0x"):
+        raw = raw[2:]
+    return raw if re.fullmatch(r"[0-9a-f]{4}", raw) else ""
+
+
+def _safe_model(value: str) -> str:
+    cleaned = " ".join(value.split())
+    if not cleaned or len(cleaned) > 80 or _MAC_IN_TEXT.search(cleaned):
+        return ""
+    return cleaned
+
+
+def _hardware_summary(identity: dict[str, object]) -> str:
+    vendor = str(identity.get("vendor") or "")
+    product = str(identity.get("product") or "")
+    chip = " ".join(part for part in (vendor, product) if part) or str(
+        identity.get("name") or "unknown"
+    )
+    bus_id = str(identity.get("usb_id") or identity.get("pci_id") or "")
+    bus = str(identity.get("bus") or "")
+    driver = str(identity.get("driver") or "")
+    details = []
+    if bus and bus_id:
+        details.append(f"{bus} {bus_id}")
+    elif bus_id:
+        details.append(bus_id)
+    if driver:
+        details.append(driver)
+    if details:
+        return f"{chip} ({', '.join(details)})"
+    return chip
 
 
 def bluez_support_status(*, run_command: RunCommand) -> dict:
@@ -60,6 +321,45 @@ def bluez_support_status(*, run_command: RunCommand) -> dict:
         "packaged_drop_in": drop_in.exists(),
         "exec_start": command,
     }
+
+
+_BLUEZ_DAEMONS = (
+    "/usr/lib/bluetooth/bluetoothd",
+    "/usr/libexec/bluetooth/bluetoothd",
+    "/usr/sbin/bluetoothd",
+)
+_BLUEZ_VERSION = re.compile(r"(\d+\.\d+(?:\.\d+)?)")
+
+
+def bluez_stack(
+    *,
+    run_command: RunCommand,
+    experimental: bool | None = None,
+    timeout: float = 10,
+) -> dict[str, object]:
+    """Return the running BlueZ version and whether ``-E`` is enabled."""
+    version = ""
+    candidates = [["bluetoothctl", "--version"]]
+    candidates.extend([path, "--version"] for path in _BLUEZ_DAEMONS if Path(path).is_file())
+    for argv in candidates:
+        try:
+            result = run_command(argv, timeout=timeout, check=False)
+        except CommandError:
+            continue
+        text = f"{result.stdout} {result.stderr}"
+        match = _BLUEZ_VERSION.search(text)
+        if match:
+            version = match.group(1)
+            break
+    if experimental is None:
+        try:
+            experimental = bool(bluez_support_status(run_command=run_command)["active"])
+        except PairingError:
+            experimental = False
+    stack: dict[str, object] = {"experimental": bool(experimental)}
+    if version:
+        stack["bluez_version"] = version
+    return stack
 
 
 def compatibility(
@@ -94,14 +394,16 @@ def compatibility(
         )
         if fallback is None:
             fallback = inspected
-        _name, available, settings, _current, _error = inspected
+        _name, available, settings, _current, _error, _identity = inspected
         classic = bool({"br/edr", "bredr"} & settings)
         secure = bool({"ssp", "secure-conn"} & settings)
         if available and classic and secure:
             selected = inspected
             break
-    adapter, available, supported, current, command_error = (
-        selected or fallback or (requested, False, set(), set(), "No adapter found")
+    adapter, available, supported, current, command_error, identity = (
+        selected
+        or fallback
+        or (requested, False, set(), set(), "No adapter found", {})
     )
     classic = bool({"br/edr", "bredr"} & supported)
     low_energy = "le" in supported
@@ -129,7 +431,7 @@ def compatibility(
         issue = "Messages and contacts are supported; per-app notifications are not"
     else:
         issue = ""
-    return {
+    result: dict[str, object] = {
         "adapter": adapter,
         "available": available,
         "powered": "powered" in current,
@@ -137,6 +439,7 @@ def compatibility(
         "low_energy": low_energy,
         "advertising": advertising,
         "secure_pairing": secure_pairing,
+        "secure_conn": "secure-conn" in current,
         "hardware_supported": messages_supported,
         "messages_supported": messages_supported,
         "notifications_supported": notifications_supported,
@@ -146,7 +449,13 @@ def compatibility(
         ),
         "issue": issue,
         "supported_settings": sorted(supported),
+        "current_settings": sorted(current),
     }
+    if "manufacturer_id" in identity:
+        result["manufacturer_id"] = identity["manufacturer_id"]
+    if "hci_version" in identity:
+        result["hci_version"] = identity["hci_version"]
+    return result
 
 
 def activate_bluez_support(

--- a/src/blueferry/cli.py
+++ b/src/blueferry/cli.py
@@ -265,8 +265,45 @@ def pairing_complete(
         )
         emit(result.to_dict())
     except PairingError as error:
-        typer.echo(json.dumps({"ok": False, "error": str(error)}))
+        payload = {"ok": False, "error": str(error)}
+        if error.report_path:
+            payload["report_path"] = error.report_path
+        typer.echo(json.dumps(payload))
         raise typer.Exit(code=2) from None
+
+
+@app.command("pairing-issue")
+def pairing_issue(
+    no_open: bool = typer.Option(
+        False,
+        "--no-open",
+        help="Print the GitHub URL without opening a browser",
+    ),
+    print_url: bool = typer.Option(
+        False,
+        "--print-url",
+        hidden=True,
+        help="Print only the GitHub new-issue URL",
+    ),
+) -> None:
+    """File a GitHub issue using the latest pairing report."""
+    from blueferry import quirks_report
+
+    path = quirks_report.latest_report()
+    if path is None:
+        typer.echo("No pairing report found. Pair an iPhone first.")
+        raise typer.Exit(code=1)
+    url = quirks_report.issue_url(path)
+    if print_url:
+        typer.echo(url)
+        return
+    typer.echo(f"Pairing report: {path}")
+    typer.echo(quirks_report.issue_instructions(path))
+    typer.echo(url)
+    if no_open:
+        return
+    if not quirks_report.open_issue_page(url):
+        typer.echo("Open that URL in a browser to file the issue.")
 
 
 @app.command("pairing-forget", hidden=True)

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -371,10 +371,13 @@ class Daemon:
             self._mark_setup_task(CONTACTS)
         if self.ancs and self.ancs.connected:
             self._mark_setup_task(NOTIFICATION_ACCESS)
+        ancs = self.ancs
         return {
             "backend_release": self._running_release,
             "initializing": self._initializing,
-            "ancs": bool(self.ancs and self.ancs.connected),
+            "ancs": bool(ancs and ancs.connected),
+            "ancs_subscribed": bool(ancs and ancs.subscribed),
+            "ancs_authorized": bool(ancs and ancs.authorized),
             **self.bearers.snapshot(),
             "contacts": self.contacts.count(),
             "events": history_count(storage=self.storage),

--- a/src/blueferry/errors.py
+++ b/src/blueferry/errors.py
@@ -31,6 +31,10 @@ class BluetoothError(BlueFerryError):
 class PairingError(BluetoothError):
     dbus_suffix = "PairingFailed"
 
+    def __init__(self, *args: object, report_path: str | None = None) -> None:
+        super().__init__(*args)
+        self.report_path = report_path
+
 
 class ObexError(BlueFerryError):
     dbus_suffix = "ObexFailed"

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -13,7 +13,7 @@ import dbus.exceptions
 from gi.repository import GLib
 
 from blueferry import bluetooth_capabilities as capabilities
-from blueferry import config
+from blueferry import config, quirks_report
 from blueferry.bluetooth_devices import PairedDevice
 from blueferry.bus import get_session_bus, get_system_bus
 from blueferry.commands import run_command
@@ -24,6 +24,14 @@ from blueferry.setup_verification import clear_setup_verification
 log = logging.getLogger(__name__)
 
 LOCAL_ENV_PATH = config.LOCAL_ENV_PATH
+_SESSION_BLUETOOTH_NAMES = (
+    "org.blueman.Applet",
+    "org.kde.BlueDevil.Client",
+    "org.kde.BlueDevil.Service",
+    "org.kde.kded5",
+    "org.kde.kded6",
+    "org.gnome.SettingsDaemon.Rfkill",
+)
 CLASSIC_SETTLE_SECONDS = 3.0
 
 ConfirmationCallback = Callable[[int | None], bool]
@@ -252,6 +260,7 @@ def _wait_for_classic_settled(
     *,
     timeout: float = 45.0,
     settle_seconds: float = CLASSIC_SETTLE_SECONDS,
+    attempt: dict | None = None,
 ) -> None:
     """Require an observably stable Classic connection before starting LE."""
     props = dbus.Interface(
@@ -283,11 +292,14 @@ def _wait_for_classic_settled(
                 "connected" if connected else "disconnected",
             )
             previous_connected = connected
+            if connected:
+                quirks_report.mark(attempt, "classic_connected")
         if connected:
             if connected_since is None:
                 connected_since = now
             if now - connected_since >= settle_seconds:
                 log.info("Classic connection is settled")
+                quirks_report.mark(attempt, "classic_settled")
                 return
         else:
             connected_since = None
@@ -304,9 +316,11 @@ def _connect_classic(
     *,
     timeout: float = 45.0,
     settle: bool = True,
+    attempt: dict | None = None,
 ) -> None:
     """Connect the Classic bearer without blocking agent dispatch."""
     log.info("sending Device1.Connect for Classic bearer: %s", device_path)
+    quirks_report.mark(attempt, "classic_connect_sent")
     interface = dbus.Interface(
         get_system_bus().get_object("org.bluez", device_path),
         "org.bluez.Device1",
@@ -323,15 +337,24 @@ def _connect_classic(
         "org.bluez.Error.AlreadyConnected",
         "org.bluez.Error.InProgress",
     }:
+        quirks_report.mark(
+            attempt, "classic_connect_failed",
+            error=error.get_dbus_name() or "failed",
+        )
         raise PairingError(
             error.get_dbus_message() or error.get_dbus_name() or str(error)
         ) from error
     if error is None:
         log.debug("Device1.Connect completed successfully")
+        quirks_report.mark(attempt, "classic_connect_replied")
     else:
         log.debug("Device1.Connect reports %s", error.get_dbus_name())
+        quirks_report.mark(
+            attempt, "classic_connect_replied",
+            result=error.get_dbus_name() or "error",
+        )
     if settle:
-        _wait_for_classic_settled(device_path, timeout=timeout)
+        _wait_for_classic_settled(device_path, timeout=timeout, attempt=attempt)
 
 
 def _prefer_bredr(device_path: str) -> None:
@@ -379,24 +402,36 @@ def _activate_obex_mns() -> None:
     log.info("BlueZ OBEX/MNS service is available during pairing")
 
 
-def _wait_for_daemon_transports(*, timeout: float = 45.0) -> tuple[bool, bool, bool]:
+def _wait_for_daemon_transports(
+    *, timeout: float = 45.0, attempt: dict | None = None,
+) -> tuple[bool, bool, bool]:
     """Observe the daemon while the pairing advert and agent remain active."""
     from blueferry.client import BackendClient, BackendError
 
     deadline = time.monotonic() + timeout
     previous: tuple[bool, bool, bool] | None = None
+    quirks_report.mark(attempt, "waiting_for_transports")
     while time.monotonic() < deadline:
         try:
             status = BackendClient().status()
         except BackendError:
             time.sleep(0.5)
             continue
+        _remember_daemon_status(attempt, status)
         current = (status.map, status.pbap, status.ancs)
         if current != previous:
             log.debug(
                 "daemon transport state: MAP=%s PBAP=%s ANCS=%s",
                 *current,
             )
+            if attempt is not None:
+                was = previous or (False, False, False)
+                if current[0] and not was[0]:
+                    quirks_report.mark(attempt, "map_ready")
+                if current[1] and not was[1]:
+                    quirks_report.mark(attempt, "pbap_ready")
+                if current[2] and not was[2]:
+                    quirks_report.mark(attempt, "ancs_ready")
             previous = current
         if status.ancs:
             return current
@@ -523,6 +558,307 @@ def complete_pairing(
     display: DisplayCallback | None = None,
 ) -> dict:
     """Pair if needed and finish every Linux-side BlueFerry setup step."""
+    attempt = quirks_report.start_attempt(interactive=confirmation is not None)
+    try:
+        result = _execute_pairing(
+            mac, confirmation=confirmation, display=display, attempt=attempt,
+        )
+    except PairingError as error:
+        path = _record_pairing_report(attempt, error=error)
+        if path is not None:
+            error.report_path = str(path)
+        raise
+    except Exception as error:
+        path = _record_pairing_report(attempt, error=error)
+        raise PairingError(
+            str(error) or type(error).__name__,
+            report_path=str(path) if path is not None else None,
+        ) from error
+    path = _record_pairing_report(
+        attempt, transports=result.pop("_report_transports", None),
+    )
+    if path is not None:
+        result["quirks_report"] = str(path)
+    return result
+
+
+def _adapter_identity(adapter: str, compatibility: dict | None = None) -> dict:
+    """Build controller identity without repeating the pairing ``btmgmt`` probe."""
+    extras = compatibility if isinstance(compatibility, dict) else {}
+    identity = capabilities.controller_hardware(adapter)
+    manufacturer_id = extras.get("manufacturer_id", identity.get("manufacturer_id"))
+    if isinstance(manufacturer_id, int):
+        capabilities.apply_company_id(identity, manufacturer_id)
+    elif "manufacturer_id" not in identity:
+        try:
+            props = dbus.Interface(
+                get_system_bus().get_object("org.bluez", f"/org/bluez/{adapter}"),
+                "org.freedesktop.DBus.Properties",
+            )
+            capabilities.apply_company_id(
+                identity,
+                int(props.Get("org.bluez.Adapter1", "Manufacturer", timeout=5.0)),
+            )
+        except Exception:
+            log.debug("could not read adapter manufacturer", exc_info=True)
+    hci_version = extras.get("hci_version")
+    if isinstance(hci_version, int):
+        identity["hci_version"] = hci_version
+    return identity
+
+
+def _le_bearer_snapshot(device_path: str) -> dict[str, object]:
+    snapshot: dict[str, object] = {
+        "present": False,
+        "paired": False,
+        "bonded": False,
+        "connected": False,
+    }
+    try:
+        objects = _object_manager().GetManagedObjects()
+        interfaces = objects.get(
+            dbus.ObjectPath(device_path), objects.get(device_path, {}),
+        )
+        bearer = interfaces.get("org.bluez.Bearer.LE1") if interfaces else None
+        if bearer is None:
+            return snapshot
+        snapshot["present"] = True
+        snapshot["paired"] = bool(bearer.get("Paired", False))
+        snapshot["bonded"] = bool(bearer.get("Bonded", False))
+        snapshot["connected"] = bool(bearer.get("Connected", False))
+    except Exception:
+        log.debug("could not inspect LE bearer", exc_info=True)
+    return snapshot
+
+
+_COMPATIBILITY_REPORT_KEYS = (
+    "available",
+    "powered",
+    "classic",
+    "low_energy",
+    "advertising",
+    "secure_pairing",
+    "secure_conn",
+    "hardware_supported",
+    "messages_supported",
+    "notifications_supported",
+    "bearer_api_active",
+    "supported_settings",
+    "current_settings",
+    "manufacturer_id",
+    "hci_version",
+)
+
+
+def _compatibility_fields(compatibility: dict) -> dict:
+    return {
+        key: compatibility[key]
+        for key in _COMPATIBILITY_REPORT_KEYS
+        if key in compatibility
+    }
+
+
+def _controller_snapshot(adapter: str, compatibility: dict) -> dict:
+    controller = _adapter_identity(adapter, compatibility)
+    controller.update(_compatibility_fields(compatibility))
+    try:
+        controller.update(
+            capabilities.bluez_stack(
+                run_command=run_command,
+                experimental=compatibility.get("bearer_api_active"),
+                timeout=2,
+            )
+        )
+    except Exception:
+        log.debug("could not inspect the BlueZ stack", exc_info=True)
+    return controller
+
+
+def _bluetooth_session_owners() -> list[str]:
+    """Return claimed session-bus names of desktop Bluetooth UIs."""
+    try:
+        bus = get_session_bus()
+        daemon = dbus.Interface(
+            bus.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus"),
+            "org.freedesktop.DBus",
+        )
+    except Exception:
+        log.debug("session bus unavailable for Bluetooth owner probe", exc_info=True)
+        return []
+    owners: list[str] = []
+    for name in _SESSION_BLUETOOTH_NAMES:
+        try:
+            owned = bool(daemon.NameHasOwner(name))
+        except dbus.exceptions.DBusException:
+            log.debug("could not query session bus name %s", name, exc_info=True)
+            owned = False
+        if owned:
+            owners.append(name)
+    return owners
+
+
+def _remember_daemon_status(attempt: dict | None, status: object) -> None:
+    if attempt is None:
+        return
+    extra = getattr(status, "extra", {}) or {}
+    if not isinstance(extra, dict):
+        extra = {}
+    subscribed = bool(extra.get("ancs_subscribed"))
+    authorized = bool(extra.get("ancs_authorized"))
+    last_le_error = str(extra.get("last_le_error") or "")[:256]
+    last_le_message = str(extra.get("last_le_error_message") or "")[:256]
+    previous = attempt.get("daemon")
+    if (
+        not last_le_error
+        and extra.get("le") is not True
+        and isinstance(previous, dict)
+    ):
+        last_le_error = str(previous.get("last_le_error") or "")[:256]
+        if not last_le_message:
+            last_le_message = str(previous.get("last_le_error_message") or "")[:256]
+    daemon = {
+        "ancs_subscribed": subscribed,
+        "ancs_authorized": authorized,
+        "bredr": extra.get("bredr"),
+        "le": extra.get("le"),
+    }
+    if last_le_error:
+        daemon["last_le_error"] = last_le_error
+        if last_le_message:
+            daemon["last_le_error_message"] = last_le_message
+    attempt["daemon"] = daemon
+    phone = attempt.get("phone")
+    if isinstance(phone, dict) and last_le_error:
+        bearer = phone.setdefault("le_bearer", {})
+        if isinstance(bearer, dict):
+            bearer["last_error"] = last_le_error
+            if last_le_message:
+                bearer["last_error_message"] = last_le_message
+    seen = {
+        item.get("event")
+        for item in attempt.get("timeline", ())
+        if isinstance(item, dict)
+    }
+    if subscribed and "ancs_subscribed" not in seen:
+        quirks_report.mark(attempt, "ancs_subscribed")
+    if authorized and "ancs_authorized" not in seen:
+        quirks_report.mark(attempt, "ancs_authorized")
+    if last_le_error and "le_connect_failed" not in seen:
+        fields: dict[str, str] = {"error": last_le_error}
+        if last_le_message:
+            fields["message"] = last_le_message
+        quirks_report.mark(attempt, "le_connect_failed", **fields)
+
+
+def _snapshot_phone(attempt: dict, device: PairedDevice) -> None:
+    phone = quirks_report.public_device(device)
+    phone["le_bearer"] = _le_bearer_snapshot(device.device_path)
+    previous = attempt.get("phone")
+    if isinstance(previous, dict):
+        previous_bearer = previous.get("le_bearer")
+        if isinstance(previous_bearer, dict) and previous_bearer.get("last_error"):
+            phone["le_bearer"]["last_error"] = previous_bearer["last_error"]
+            if previous_bearer.get("last_error_message"):
+                phone["le_bearer"]["last_error_message"] = previous_bearer[
+                    "last_error_message"
+                ]
+    attempt["phone"] = phone
+
+
+def _record_pairing_report(
+    attempt: dict,
+    *,
+    transports: tuple[bool, bool, bool] | None = None,
+    error: Exception | None = None,
+):
+    if transports is not None:
+        map_ready, pbap_ready, ancs_ready = transports
+        attempt["preferred_bearer"] = "bredr"
+        seen = {
+            item.get("event")
+            for item in attempt.get("timeline", ())
+            if isinstance(item, dict)
+        }
+        if map_ready and "map_ready" not in seen:
+            quirks_report.mark(attempt, "map_ready")
+        if pbap_ready and "pbap_ready" not in seen:
+            quirks_report.mark(attempt, "pbap_ready")
+        if ancs_ready and "ancs_ready" not in seen:
+            quirks_report.mark(attempt, "ancs_ready")
+    attempt["outcome"] = _pairing_outcome(attempt, transports, error)
+    if error is not None:
+        quirks_report.mark(attempt, "failed")
+    elif transports is not None:
+        quirks_report.mark(attempt, "finished")
+    else:
+        quirks_report.mark(attempt, "failed")
+    return quirks_report.save_report(attempt)
+
+
+def _device_bonded(attempt: dict) -> bool:
+    """True once Device1.Paired is observed, even if later setup fails."""
+    phone = attempt.get("phone")
+    if isinstance(phone, dict) and phone.get("paired") is True:
+        return True
+    for item in attempt.get("timeline", ()):
+        if not isinstance(item, dict):
+            continue
+        if item.get("event") == "paired":
+            return True
+        if item.get("event") == "device_loaded" and item.get("already_paired"):
+            return True
+    return False
+
+
+def _pairing_outcome(
+    attempt: dict,
+    transports: tuple[bool, bool, bool] | None,
+    error: Exception | None,
+) -> dict[str, object]:
+    """Record each profile separately; MAP-only is not a single 'degraded' bit."""
+    outcome: dict[str, object] = {
+        "bonded": _device_bonded(attempt),
+        "setup_complete": error is None and transports is not None,
+        "map": None,
+        "pbap": None,
+        "ancs": None,
+    }
+    daemon = attempt.get("daemon")
+    if isinstance(daemon, dict):
+        if "ancs_subscribed" in daemon:
+            outcome["ancs_subscribed"] = daemon["ancs_subscribed"]
+        if "ancs_authorized" in daemon:
+            outcome["ancs_authorized"] = daemon["ancs_authorized"]
+        if daemon.get("last_le_error"):
+            outcome["last_le_error"] = daemon["last_le_error"]
+        if daemon.get("last_le_error_message"):
+            outcome["last_le_error_message"] = daemon["last_le_error_message"]
+    if transports is not None:
+        outcome["map"], outcome["pbap"], outcome["ancs"] = transports
+    else:
+        events = {
+            item.get("event")
+            for item in attempt.get("timeline", ())
+            if isinstance(item, dict)
+        }
+        if "map_ready" in events:
+            outcome["map"] = True
+        if "pbap_ready" in events:
+            outcome["pbap"] = True
+        if "ancs_ready" in events:
+            outcome["ancs"] = True
+    if error is not None:
+        outcome["error"] = str(error)[:1024]
+    return outcome
+
+
+def _execute_pairing(
+    mac: str,
+    *,
+    confirmation: ConfirmationCallback | None = None,
+    display: DisplayCallback | None = None,
+    attempt: dict,
+) -> dict:
     from blueferry import bluez_setup
 
     device = _device(mac)
@@ -535,7 +871,14 @@ def complete_pairing(
         device.connected,
     )
     adapter = device.adapter_path.rsplit("/", 1)[-1]
+    session = attempt.setdefault("session", quirks_report.session_environment())
+    if isinstance(session, dict):
+        session["bluetooth_owners"] = _bluetooth_session_owners()
+    quirks_report.mark(attempt, "device_loaded", already_paired=device.paired)
+    _snapshot_phone(attempt, device)
     compatibility = bluetooth_compatibility(adapter)
+    attempt["controller"] = _controller_snapshot(adapter, compatibility)
+    quirks_report.mark(attempt, "compatibility_ready")
     if not compatibility["hardware_supported"]:
         raise PairingError(compatibility["issue"] or "Bluetooth controller is incompatible")
     notifications_supported = compatibility["notifications_supported"]
@@ -549,14 +892,19 @@ def complete_pairing(
     # No LE advertisement during pairing: iOS would connect the unbonded
     # advert as a separate accessory and keep two device records. The advert
     # is registered only after the bond exists.
+    quirks_report.mark(attempt, "prepare_classic_sent")
     if not bluez_setup.prepare_classic(adapter=adapter, authorize=True):
         raise PairingError(
             "Could not prepare the Bluetooth adapter; check that "
             "blueferry-backend is installed and run doctor."
         )
+    quirks_report.mark(attempt, "prepare_classic_done")
     _activate_obex_mns()
+    quirks_report.mark(attempt, "obex_mns_ready")
 
     pairing_agents = ExitStack()
+    advert_registered = False
+    agent_registered = False
     try:
         if not device.paired:
             try:
@@ -565,12 +913,31 @@ def complete_pairing(
                     # the Classic bearer. Controllers whose Classic pairing
                     # derives LE keys (CTKD) get the dual bond this way too.
                     log.info("sending Device1.Pair using the headless pairing path")
+                    quirks_report.mark(attempt, "pair_sent")
                     dbus.Interface(
                         get_system_bus().get_object("org.bluez", device.device_path),
                         "org.bluez.Device1",
                     ).Pair(timeout=120.0)
+                    quirks_report.mark(attempt, "pair_replied")
                 else:
                     from blueferry.pairing_agent import RegisteredPairingAgent
+
+                    def timed_confirmation(passkey: int | None) -> bool:
+                        quirks_report.mark(
+                            attempt, "pairing_confirmation_requested",
+                            has_passkey=passkey is not None,
+                        )
+                        accepted = confirmation(passkey)
+                        quirks_report.mark(
+                            attempt, "pairing_confirmation_answered",
+                            accepted=accepted,
+                        )
+                        return accepted
+
+                    def timed_display(passkey: int) -> None:
+                        quirks_report.mark(attempt, "pairing_passkey_displayed")
+                        if display is not None:
+                            display(passkey)
 
                     # Connecting the unpaired ACL makes iOS initiate pairing,
                     # and the authentication initiator is the side that derives
@@ -581,14 +948,17 @@ def complete_pairing(
                     registered = pairing_agents.enter_context(
                         RegisteredPairingAgent(
                             device.device_path,
-                            confirmation,
-                            display,
+                            timed_confirmation,
+                            timed_display,
                         )
                     )
+                    agent_registered = True
+                    quirks_report.mark(attempt, "agent_registered")
                     _connect_classic(
                         device.device_path,
                         timeout=60.0,
                         settle=False,
+                        attempt=attempt,
                     )
                     registered.wait_for_pair(timeout=120.0)
             except dbus.exceptions.DBusException as error:
@@ -598,6 +968,7 @@ def complete_pairing(
                     "org.bluez.Error.InProgress",
                 }:
                     # The iPhone initiated pairing on its own; settle below.
+                    quirks_report.mark(attempt, "peer_pairing_in_progress")
                     pass
                 else:
                     detail = error.get_dbus_message() or name or str(error)
@@ -609,30 +980,41 @@ def complete_pairing(
                         detail = f"Bluetooth confirmation did not complete: {detail}"
                     raise PairingError(detail) from error
             device = _wait_for_paired_device(mac)
+            quirks_report.mark(attempt, "paired")
+            _snapshot_phone(attempt, device)
         log.debug("setting Device1.Trusted=true for %s", device.device_path)
         trust_device(device.mac, device.adapter_path)
+        quirks_report.mark(attempt, "trusted")
 
         _prefer_bredr(device.device_path)
+        quirks_report.mark(attempt, "preferred_bearer_bredr")
         # The pairing transaction already established the Classic ACL.  A
         # second generic Device1.Connect can wander into LE and hangs on the
         # observed iOS 18 path, so only require that existing ACL to settle.
-        _wait_for_classic_settled(device.device_path)
+        _wait_for_classic_settled(device.device_path, attempt=attempt)
 
         # Keep ANCS solicitation active because iOS 26 testing found that it
         # surfaced the MAP/PBAP permission toggles.  It is a pairing signal,
         # not a prerequisite connection: the daemon below attempts MAP/PBAP
         # before it is allowed to connect the LE bearer.
         log.debug("registering ANCS solicitation advertisement on %s", adapter)
+        quirks_report.mark(attempt, "advert_register_sent")
         if not bluez_setup.register_advert(adapter, settle_for_pairing=True):
             raise PairingError("The ANCS advertisement did not activate")
+        advert_registered = True
+        quirks_report.mark(attempt, "advert_ready")
 
         # Start the long-lived owner while both the advert and temporary
         # pairing agent are still present.  Its first operation is a Classic
         # MAP/PBAP open; only when that attempt completes does it enable LE.
         write_local_env(device.mac, device.adapter_path.rsplit("/", 1)[-1])
         log.debug("saved paired target %s; restarting user service", device.mac)
+        quirks_report.mark(attempt, "daemon_restart_sent")
         _restart_user_service()
-        map_ready, pbap_ready, ancs_ready = _wait_for_daemon_transports()
+        quirks_report.mark(attempt, "daemon_restarted")
+        map_ready, pbap_ready, ancs_ready = _wait_for_daemon_transports(
+            attempt=attempt,
+        )
         ancs = "connected" if ancs_ready else "daemon connecting"
         log.info(
             "pairing-window result: MAP=%s PBAP=%s ANCS=%s",
@@ -648,10 +1030,15 @@ def complete_pairing(
         try:
             log.debug("removing ANCS solicitation advertisement from %s", adapter)
             bluez_setup.unregister_advert(adapter)
+            if advert_registered:
+                quirks_report.mark(attempt, "advert_removed")
         finally:
             pairing_agents.close()
+            if agent_registered:
+                quirks_report.mark(attempt, "agent_released")
 
     device = _device(mac)
+    _snapshot_phone(attempt, device)
     return {
         "ok": True,
         "device": device.to_dict(),
@@ -665,6 +1052,7 @@ def complete_pairing(
             "Toggle on Show Message Notifications and Sync Contacts",
             "You may need to back out and tap ⓘ again to make these toggles appear",
         ],
+        "_report_transports": (map_ready, pbap_ready, ancs_ready),
     }
 
 

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -10,6 +10,7 @@ from blueferry.backend_lifecycle import ensure_backend_current
 from blueferry.bluetooth_devices import iphone_candidates
 from blueferry.client import BackendClient, BackendError
 from blueferry.errors import PairingError
+from blueferry.quirks_report import cli_issue_hint
 from blueferry.setup_client import SetupClient
 from blueferry.setup_verification import (
     NOTIFICATION_ACCESS,
@@ -169,8 +170,12 @@ def run_wizard(*, verify_after: bool = True) -> int:
         )
     except PairingError as error:
         typer.echo(typer.style(str(error), fg=typer.colors.RED))
+        if getattr(error, "report_path", None):
+            typer.echo(cli_issue_hint())
         return 1
     typer.echo(typer.style("✓ Linux-side setup complete", fg=typer.colors.GREEN))
+    if getattr(result, "quirks_report", "") and not result.ancs_ready:
+        typer.echo(cli_issue_hint())
     try:
         verified = BackendClient().status().verified_iphone_setup
     except BackendError:

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -24,6 +24,7 @@ from blueferry.i18n import _
 from blueferry.onboarding import derive_stage
 from blueferry.protocol import BUS_NAME, EVENTS_IFACE, OBJECT_PATH
 from blueferry.qt.tasks import Task
+from blueferry.quirks_report import issue_report, issue_url
 from blueferry.setup_client import SetupClient
 
 
@@ -40,6 +41,7 @@ class BridgeController(QObject):
     setupLoadedChanged = Signal()
     onboardingStageChanged = Signal()
     pairingConfirmationRequested = Signal(str)
+    pairingIssueReportChanged = Signal()
     messageOpenRequested = Signal(str)
 
     def __init__(
@@ -68,6 +70,7 @@ class BridgeController(QObject):
         self._bluetooth_active = False
         self._busy_count = 0
         self._error_text = ""
+        self._pairing_issue_report = ""
         self._compatibility: dict = {}
         self._configured = False
         self._target_saved = False
@@ -124,6 +127,10 @@ class BridgeController(QObject):
     def errorText(self) -> str:
         return self._error_text
 
+    @Property(str, notify=pairingIssueReportChanged)
+    def pairingIssueReport(self) -> str:
+        return self._pairing_issue_report
+
     @Property("QVariantMap", notify=compatibilityChanged)
     def compatibility(self):
         return self._compatibility
@@ -171,6 +178,24 @@ class BridgeController(QObject):
             return
         self._error_text = message
         self.errorTextChanged.emit()
+
+    def _set_pairing_issue_report(self, path: str) -> None:
+        value = str(path or "").strip()
+        if value == self._pairing_issue_report:
+            return
+        self._pairing_issue_report = value
+        self.pairingIssueReportChanged.emit()
+
+    def _refresh_pairing_issue_report(self) -> None:
+        found = issue_report()
+        self._set_pairing_issue_report(str(found) if found is not None else "")
+
+    @Slot()
+    def filePairingIssue(self) -> None:
+        from PySide6.QtCore import QUrl
+        from PySide6.QtGui import QDesktopServices
+
+        QDesktopServices.openUrl(QUrl(issue_url(self._pairing_issue_report or None)))
 
     def _set_busy(self, delta: int) -> None:
         was_busy = self.busy
@@ -299,6 +324,7 @@ class BridgeController(QObject):
             self.setupLoadedChanged.emit()
             self.bluetoothChanged.emit()
             self._update_onboarding_stage()
+            self._set_pairing_issue_report(configuration.pairing_issue_report)
             if self._devices:
                 self.loadDevices(False)
 
@@ -336,6 +362,7 @@ class BridgeController(QObject):
             self.statusChanged.emit()
             self._maybe_unlock_storage()
             self._update_onboarding_stage()
+            self._refresh_pairing_issue_report()
             if self._status.get("daemon"):
                 self._set_error("")
 
@@ -543,7 +570,7 @@ class BridgeController(QObject):
         self._start_pairing(mac, replace_saved_mac=previous_mac)
 
     def _start_pairing(self, mac: str, *, replace_saved_mac: str = "") -> None:
-        def completed(_value: object) -> None:
+        def completed(value: object) -> None:
             self._configured = True
             self._target_saved = True
             self._configured_mac = mac
@@ -552,6 +579,7 @@ class BridgeController(QObject):
             self.loadDevices(False)
             self.loadSetupState()
             self.refresh()
+            self._refresh_pairing_issue_report()
 
         def confirm(passkey: int | None) -> bool:
             event = threading.Event()
@@ -592,6 +620,7 @@ class BridgeController(QObject):
 
         def failed(message: str) -> None:
             self._operation_failed(message)
+            self._refresh_pairing_issue_report()
             if replace_saved_mac:
                 self.loadSetupState()
                 self.loadDevices(False)

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -429,6 +429,21 @@ Kirigami.ApplicationWindow {
     }
 
     Kirigami.PromptDialog {
+        id: pairingIssueDialog
+        title: qsTr("Report Pairing Issue")
+        subtitle: qsTr("A pairing report was saved at %1. Attach that file to a GitHub issue and include the iPhone model and iOS version.").arg(root.bridge.pairingIssueReport)
+        standardButtons: Kirigami.Dialog.Cancel
+        customFooterActions: [Kirigami.Action {
+            text: qsTr("Open GitHub")
+            icon.name: "internet-web-browser"
+            onTriggered: {
+                root.bridge.filePairingIssue()
+                pairingIssueDialog.close()
+            }
+        }]
+    }
+
+    Kirigami.PromptDialog {
         id: replaceTargetDialog
         property string mac: ""
         title: qsTr("Replace the Saved iPhone?")
@@ -1044,6 +1059,13 @@ Kirigami.ApplicationWindow {
                             forgetDialog.open()
                         }
                     }
+                }
+
+                Controls.Button {
+                    visible: root.bridge.pairingIssueReport !== ""
+                    text: qsTr("Report Pairing Issue")
+                    icon.name: "help-about"
+                    onClicked: pairingIssueDialog.open()
                 }
 
                 RowLayout {

--- a/src/blueferry/quirks_report.py
+++ b/src/blueferry/quirks_report.py
@@ -1,0 +1,388 @@
+"""Scrubbed pairing/adapter reports kept next to local history."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import stat
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+from blueferry import config
+from blueferry.bluetooth_capabilities import chipset_name, is_generic_product
+from blueferry.private_files import atomic_write_private_text, ensure_private_directory
+
+log = logging.getLogger(__name__)
+
+REPORT_PREFIX = "quirks-"
+REPORT_SUFFIX = ".json"
+MAX_REPORTS = 10
+MAX_REPORT_BYTES = 64 * 1024
+MAX_ISSUE_URL_CHARS = 8000
+GITHUB_ISSUE_NEW = "https://github.com/erikwb/blueferry/issues/new"
+GITHUB_ISSUE_LABEL = "pairing-issue"
+
+_MAC_COLON = re.compile(r"(?i)\b(?:[0-9a-f]{2}:){5}[0-9a-f]{2}\b")
+_MAC_PATH = re.compile(r"(?i)dev_(?:[0-9a-f]{2}_){5}[0-9a-f]{2}")
+
+
+def _home_path() -> Path | None:
+    try:
+        home = Path.home()
+    except RuntimeError:
+        return None
+    if len(str(home)) < 2 or str(home) == "/":
+        return None
+    return home
+
+
+def _redaction_prefixes() -> list[tuple[str, str]]:
+    """Longest-first home and XDG prefixes to strip from diagnostic text."""
+    home = _home_path()
+    pairs: list[tuple[str, str]] = []
+
+    def add(raw: str | Path | None, token: str) -> None:
+        if raw is None:
+            return
+        text = str(Path(str(raw).strip()).expanduser()).rstrip("/")
+        if len(text) < 2 or text == "/":
+            return
+        pairs.append((text, token))
+
+    add(os.environ.get("XDG_CONFIG_HOME") or (home / ".config" if home else None),
+        "$XDG_CONFIG_HOME")
+    add(os.environ.get("XDG_STATE_HOME") or (home / ".local/state" if home else None),
+        "$XDG_STATE_HOME")
+    add(os.environ.get("XDG_CACHE_HOME") or (home / ".cache" if home else None),
+        "$XDG_CACHE_HOME")
+    add(os.environ.get("XDG_DATA_HOME") or (home / ".local/share" if home else None),
+        "$XDG_DATA_HOME")
+    add(home, "$HOME")
+    add(os.environ.get("HOME"), "$HOME")
+    unique: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for prefix, token in sorted(pairs, key=lambda item: len(item[0]), reverse=True):
+        if prefix in seen:
+            continue
+        seen.add(prefix)
+        unique.append((prefix, token))
+    return unique
+
+
+def _replace_path_prefix(text: str, prefix: str, token: str) -> str:
+    pattern = re.compile(
+        r"(?<![\w.-])" + re.escape(prefix) + r"(?=/|$|\"|'|\s|:)",
+    )
+    return pattern.sub(token, text)
+
+
+def scrub_text(value: str) -> str:
+    """Remove Bluetooth addresses and home/XDG path prefixes from text."""
+    text = str(value)
+    for prefix, token in _redaction_prefixes():
+        text = _replace_path_prefix(text, prefix, token)
+    text = _MAC_COLON.sub("xx:xx:xx:xx:xx:xx", text)
+    return _MAC_PATH.sub("dev_REDACTED", text)
+
+
+def scrub_value(value: Any) -> Any:
+    """Recursively redact Bluetooth addresses from a JSON-compatible value."""
+    if isinstance(value, str):
+        return scrub_text(value)
+    if isinstance(value, list):
+        return [scrub_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): scrub_value(item) for key, item in value.items()}
+    return value
+
+
+def public_device(device: Any) -> dict[str, Any]:
+    """Project a paired device without names, addresses, or object paths."""
+    return {
+        "likely_iphone": bool(getattr(device, "likely_iphone", False)),
+        "paired": bool(getattr(device, "paired", False)),
+        "trusted": bool(getattr(device, "trusted", False)),
+        "connected": bool(getattr(device, "connected", False)),
+        "services_resolved": bool(getattr(device, "services_resolved", False)),
+        "ancs_uuid": bool(getattr(device, "ancs_bonded", False)),
+    }
+
+
+def session_environment() -> dict[str, str]:
+    """Desktop session fields that are not personal identifiers."""
+    return {
+        "desktop": os.environ.get("XDG_CURRENT_DESKTOP", ""),
+        "session_type": os.environ.get("XDG_SESSION_TYPE", ""),
+    }
+
+
+def start_attempt(*, interactive: bool) -> dict[str, Any]:
+    from blueferry import __version__
+
+    attempt: dict[str, Any] = {
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "blueferry": __version__,
+        "pairing_path": "interactive" if interactive else "headless",
+        "session": session_environment(),
+        "_t0": time.monotonic(),
+        "timeline": [],
+    }
+    mark(attempt, "start")
+    return attempt
+
+
+def mark(attempt: dict[str, Any] | None, event: str, **fields: Any) -> None:
+    """Append one timeline entry. ``t`` is seconds since pairing started."""
+    if attempt is None:
+        return
+    origin = attempt.get("_t0")
+    if not isinstance(origin, (int, float)):
+        origin = time.monotonic()
+        attempt["_t0"] = origin
+    entry = {"t": round(time.monotonic() - origin, 3), "event": event}
+    entry.update(fields)
+    attempt.setdefault("timeline", []).append(entry)
+
+
+def save_report(report: dict[str, Any], *, directory: Path | None = None) -> Path | None:
+    """Write one scrubbed report beside the history database and keep ten."""
+    try:
+        target_dir = directory if directory is not None else config.STATE_DIR
+        if directory is None:
+            config.ensure_dirs()
+        else:
+            ensure_private_directory(target_dir)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        sequence = 1
+        path = target_dir / f"{REPORT_PREFIX}{stamp}-{sequence:04d}{REPORT_SUFFIX}"
+        while path.exists():
+            sequence += 1
+            path = target_dir / f"{REPORT_PREFIX}{stamp}-{sequence:04d}{REPORT_SUFFIX}"
+        prepared = dict(report)
+        origin = prepared.pop("_t0", None)
+        timeline = prepared.get("timeline")
+        if isinstance(origin, (int, float)):
+            prepared["duration_s"] = round(time.monotonic() - origin, 3)
+        elif isinstance(timeline, list) and timeline:
+            last = timeline[-1]
+            if isinstance(last, dict) and isinstance(last.get("t"), (int, float)):
+                prepared["duration_s"] = last["t"]
+        payload = json.dumps(
+            scrub_value(prepared),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        ) + "\n"
+        atomic_write_private_text(path, payload, maximum_bytes=MAX_REPORT_BYTES)
+        _prune_reports(target_dir)
+        log.info("saved pairing report: %s", path)
+        return path
+    except Exception:
+        log.warning("could not save pairing report", exc_info=True)
+        return None
+
+
+def list_reports(directory: Path | None = None) -> list[Path]:
+    """Return pairing reports oldest-first."""
+    target = directory if directory is not None else config.STATE_DIR
+    try:
+        if not target.is_dir():
+            return []
+        candidates = list(target.glob(f"{REPORT_PREFIX}*{REPORT_SUFFIX}"))
+    except OSError:
+        return []
+    found: list[tuple[int, str, Path]] = []
+    for path in candidates:
+        try:
+            info = path.lstat()
+        except OSError:
+            continue
+        if not stat.S_ISREG(info.st_mode):
+            continue
+        found.append((info.st_mtime_ns, path.name, path))
+    found.sort()
+    return [path for _mtime, _name, path in found]
+
+
+def latest_report(directory: Path | None = None) -> Path | None:
+    reports = list_reports(directory)
+    return reports[-1] if reports else None
+
+
+def issue_report(directory: Path | None = None) -> Path | None:
+    """Return the latest pairing report, including a successful setup."""
+    return latest_report(directory)
+
+
+def _prune_reports(directory: Path) -> None:
+    extra = list_reports(directory)[:-MAX_REPORTS]
+    for path in extra:
+        try:
+            path.unlink()
+        except OSError:
+            log.debug("could not remove old pairing report %s", path, exc_info=True)
+
+
+def issue_instructions(report_path: Path | str) -> str:
+    return (
+        f"Attach this pairing report to the GitHub issue and include the "
+        f"iPhone model and iOS version:\n{report_path}"
+    )
+
+
+def cli_issue_hint() -> str:
+    return (
+        "Run `blueferry pairing-issue` if you'd like to file an issue about pairing."
+    )
+
+
+def _read_report(path: Path | str | None) -> dict[str, Any]:
+    target = Path(path) if path is not None else latest_report()
+    if target is None:
+        return {}
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _adapter_title(controller: Any) -> str:
+    if not isinstance(controller, dict):
+        return "unknown adapter"
+    vendor = str(controller.get("vendor") or "").strip()
+    product = str(controller.get("product") or "").strip()
+    bus_id = str(controller.get("usb_id") or controller.get("pci_id") or "").strip()
+    chip = chipset_name(
+        usb_id=str(controller.get("usb_id") or ""),
+        pci_id=str(controller.get("pci_id") or ""),
+        driver=str(controller.get("driver") or ""),
+        product=product,
+    )
+    label = chip or (product if product and not is_generic_product(product) else "")
+    if vendor and label:
+        if vendor.casefold() in label.casefold():
+            return label
+        return f"{vendor} {label}"
+    if label:
+        return label
+    if vendor and bus_id:
+        return f"{vendor} {bus_id}"
+    return vendor or bus_id or "unknown adapter"
+
+
+def _profile_word(value: Any) -> str | None:
+    if value is True:
+        return "success"
+    if value is False:
+        return "fail"
+    return None
+
+
+def _outcome_title(outcome: Any) -> str:
+    if not isinstance(outcome, dict):
+        return "status unknown"
+    map_state = _profile_word(outcome.get("map"))
+    pbap_state = _profile_word(outcome.get("pbap"))
+    ancs_state = _profile_word(outcome.get("ancs"))
+    parts: list[str] = []
+    if map_state and map_state == pbap_state:
+        parts.append(f"MAP/PBAP {map_state}")
+    else:
+        if map_state:
+            parts.append(f"MAP {map_state}")
+        if pbap_state:
+            parts.append(f"PBAP {pbap_state}")
+    if ancs_state:
+        parts.append(f"ANCS {ancs_state}")
+    if parts:
+        return ", ".join(parts)
+    if outcome.get("bonded") is True and outcome.get("setup_complete") is False:
+        return "bonded, setup failed"
+    if outcome.get("setup_complete") is False or outcome.get("bonded") is False:
+        return "pairing failed"
+    return "status unknown"
+
+
+def issue_title(report: dict[str, Any] | Path | str | None = None) -> str:
+    payload = report if isinstance(report, dict) else _read_report(report)
+    title = (
+        f"Pairing issue: {_adapter_title(payload.get('controller'))} — "
+        f"{_outcome_title(payload.get('outcome'))}"
+    )
+    return title[:256]
+
+
+def issue_body(report: dict[str, Any] | Path | str | None = None) -> str:
+    payload = report if isinstance(report, dict) else _read_report(report)
+    return _issue_body_with_json(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+    )
+
+
+def _issue_body_with_json(report_json: str) -> str:
+    return (
+        "iPhone model:\n"
+        "iOS version:\n\n"
+        "```json\n"
+        f"{report_json}\n"
+        "```\n"
+    )
+
+
+def issue_url(report: dict[str, Any] | Path | str | None = None) -> str:
+    """GitHub new-issue URL with label, chipset title, and report JSON body."""
+    payload = report if isinstance(report, dict) else _read_report(report)
+    title = issue_title(payload)
+    candidates = [
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True),
+    ]
+    slim = dict(payload)
+    slim.pop("timeline", None)
+    candidates.append(
+        json.dumps(slim, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    )
+    for report_json in candidates:
+        url = (
+            f"{GITHUB_ISSUE_NEW}?"
+            + urlencode(
+                {
+                    "labels": GITHUB_ISSUE_LABEL,
+                    "title": title,
+                    "body": _issue_body_with_json(report_json),
+                }
+            )
+        )
+        if len(url) <= MAX_ISSUE_URL_CHARS:
+            return url
+    return (
+        f"{GITHUB_ISSUE_NEW}?"
+        + urlencode(
+            {
+                "labels": GITHUB_ISSUE_LABEL,
+                "title": title,
+                "body": (
+                    "iPhone model:\n"
+                    "iOS version:\n\n"
+                    "The pairing report was too large to embed. Attach the "
+                    "local quirks-*.json file from BlueFerry's state directory.\n"
+                ),
+            }
+        )
+    )
+
+
+def open_issue_page(url: str | None = None) -> bool:
+    """Open the new-issue page in the default browser when possible."""
+    import webbrowser
+
+    try:
+        return bool(webbrowser.open(url or issue_url()))
+    except Exception:
+        log.debug("could not open the GitHub issue page", exc_info=True)
+        return False

--- a/src/blueferry/setup_client.py
+++ b/src/blueferry/setup_client.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from blueferry import pair_setup
+from blueferry import pair_setup, quirks_report
 from blueferry.bluetooth_devices import PairedDevice
 from blueferry.errors import PairingError
 
@@ -90,6 +90,7 @@ class ConfigurationState:
     path: str
     saved: bool = False
     bonded: bool | None = None
+    pairing_issue_report: str = ""
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> ConfigurationState:
@@ -104,6 +105,7 @@ class ConfigurationState:
                 if isinstance(value.get("bonded"), bool)
                 else None
             ),
+            pairing_issue_report=str(value.get("pairing_issue_report", "")),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -114,6 +116,7 @@ class ConfigurationState:
             "path": self.path,
             "saved": self.saved,
             "bonded": self.bonded,
+            "pairing_issue_report": self.pairing_issue_report,
         }
 
 
@@ -126,6 +129,7 @@ class PairingResult:
     ancs: str
     ancs_ready: bool
     iphone_steps: tuple[str, ...]
+    quirks_report: str = ""
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> PairingResult:
@@ -142,6 +146,7 @@ class PairingResult:
             ancs_ready=bool(value.get("ancs_ready", False)),
             iphone_steps=tuple(str(item) for item in raw_steps)
             if isinstance(raw_steps, list | tuple) else (),
+            quirks_report=str(value.get("quirks_report", "")),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -153,6 +158,7 @@ class PairingResult:
             "ancs": self.ancs,
             "ancs_ready": self.ancs_ready,
             "iphone_steps": list(self.iphone_steps),
+            "quirks_report": self.quirks_report,
         }
 
 
@@ -168,7 +174,10 @@ class SetupClient:
         )
 
     def configuration(self) -> ConfigurationState:
-        return ConfigurationState.from_dict(pair_setup.configuration_status())
+        value = dict(pair_setup.configuration_status())
+        report = quirks_report.issue_report()
+        value["pairing_issue_report"] = str(report) if report is not None else ""
+        return ConfigurationState.from_dict(value)
 
     def activate_bluez(self) -> BluezSupport:
         return BluezSupport.from_dict(pair_setup.activate_bluez_support())
@@ -243,7 +252,11 @@ class SetupClient:
                     process.wait()
                     return PairingResult.from_dict(event)
                 elif event.get("ok") is False:
-                    raise PairingError(str(event.get("error", "Pairing failed")))
+                    path = str(event.get("report_path") or "").strip()
+                    raise PairingError(
+                        str(event.get("error", "Pairing failed")),
+                        report_path=path or None,
+                    )
             raise PairingError("Pairing helper exited without a result")
         finally:
             if process.poll() is None:

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import threading
 
-from gi.repository import Adw, GLib, Gtk
+from gi.repository import Adw, Gio, GLib, Gtk
 
 from blueferry.bluetooth_devices import PairedDevice, iphone_candidates
 from blueferry.i18n import _
 from blueferry.models import BackendStatus
 from blueferry.onboarding import OnboardingStage, derive_stage
+from blueferry.quirks_report import issue_report, issue_url
 from blueferry.setup_client import (
     BluetoothCompatibility,
     ConfigurationState,
@@ -44,6 +45,7 @@ class IPhonePage(Gtk.Box):
         self._applying_notification_policy = False
         self._applying_storage_policy = False
         self._storage_unlock_attempted = False
+        self._pairing_issue_report = ""
 
         page = Adw.PreferencesPage()
         self.append(page)
@@ -130,6 +132,22 @@ class IPhonePage(Gtk.Box):
         forget.add_suffix(self._forget_button)
         self._pairing_group.add(forget)
         page.add(self._pairing_group)
+
+        self._issue_group = Adw.PreferencesGroup()
+        self._issue_row = Adw.ActionRow(
+            title=_("Pairing Report"),
+            subtitle=_("Attach the last pairing report if notifications stay unavailable"),
+            use_markup=False,
+        )
+        self._issue_button = Gtk.Button(
+            label=_("Report Pairing Issue"),
+            valign=Gtk.Align.CENTER,
+        )
+        self._issue_button.connect("clicked", self._file_pairing_issue)
+        self._issue_row.add_suffix(self._issue_button)
+        self._issue_group.add(self._issue_row)
+        self._issue_group.set_visible(False)
+        page.add(self._issue_group)
 
         self._paired_group = Adw.PreferencesGroup(title=_("Paired Phone"))
         self._paired_row = Adw.ActionRow(
@@ -340,8 +358,46 @@ class IPhonePage(Gtk.Box):
             self._setup_failed,
         )
 
+    def _refresh_issue_offer(self, report_path: str = "") -> None:
+        path = report_path.strip()
+        if not path:
+            found = issue_report()
+            path = str(found) if found is not None else ""
+        self._pairing_issue_report = path
+        self._issue_group.set_visible(bool(path))
+
+    def _file_pairing_issue(self, _button) -> None:
+        path = self._pairing_issue_report
+        if not path:
+            return
+        dialog = Adw.AlertDialog(
+            heading=_("Report Pairing Issue"),
+            body=_(
+                "A pairing report was saved at {path}. Attach that file to a "
+                "GitHub issue and include the iPhone model and iOS version."
+            ).format(path=path),
+            heading_use_markup=False,
+            body_use_markup=False,
+        )
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("open", _("Open GitHub"))
+        dialog.set_close_response("cancel")
+        dialog.set_response_appearance("open", Adw.ResponseAppearance.SUGGESTED)
+
+        def responded(_current, response: str) -> None:
+            if response != "open":
+                return
+            try:
+                Gio.AppInfo.launch_default_for_uri(issue_url(path), None)
+            except Exception:
+                self._toast(_("Could not open GitHub. The report is at {path}.").format(path=path))
+
+        dialog.connect("response", responded)
+        dialog.present(self.get_root())
+
     def _setup_failed(self, message: str) -> bool:
         self._set_pairing_busy(False)
+        self._refresh_issue_offer()
         self._toast(_("Setup failed: {error}").format(error=message))
         return False
 
@@ -384,6 +440,7 @@ class IPhonePage(Gtk.Box):
             self._set_pairing_busy(False)
             self._update_phone_controls()
             self._update_onboarding()
+            self._refresh_issue_offer(configuration.pairing_issue_report)
             if scan_after or not self._devices:
                 self._load_devices(scan=scan_after)
 
@@ -515,6 +572,7 @@ class IPhonePage(Gtk.Box):
             else:
                 message = _("Linux setup is complete; finish the two iPhone settings")
             self._toast(message)
+            self._refresh_issue_offer()
             self._load_devices(scan=False)
             self._update_onboarding()
             self._refresh()
@@ -614,6 +672,7 @@ class IPhonePage(Gtk.Box):
                         path="",
                     )
                     self._apply_status(BackendStatus())
+                    self._refresh_issue_offer()
                     self._load_devices(scan=False)
                     self._update_phone_controls()
 
@@ -689,6 +748,7 @@ class IPhonePage(Gtk.Box):
             self._unlock_storage()
         self._update_iphone_setup_tasks()
         self._update_onboarding()
+        self._refresh_issue_offer()
         return False
 
     def _notification_policy_changed(self, _row, _property) -> None:

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -302,15 +302,21 @@ def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
 
     client._try_subscribe()
 
+    assert client.subscribed is False
+    assert client.authorized is False
     assert client.connected is False
     assert len(scheduled) == 1
     assert scheduled[0][0] == client_module.SUBSCRIBE_RETRY_SECONDS
 
     scheduled[0][1]()
 
+    assert client.subscribed is True
+    assert client.authorized is False
     assert client.connected is False
     assert len(writes) == 1
     _complete_authorization_probe(client)
+    assert client.subscribed is True
+    assert client.authorized is True
     assert client.connected is True
     assert ns.start_calls == 2
     assert ds.start_calls == 1
@@ -354,6 +360,8 @@ def test_control_point_failure_keeps_ancs_unready_and_retries(
 
     client._queue_authorization_probe()
 
+    assert client.subscribed is True
+    assert client.authorized is False
     assert client.connected is False
     assert scheduled[0][0] == client_module.AUTHORIZATION_RETRY_SECONDS
     assert "org.bluez.Error.Failed: Insufficient authorization" in caplog.text
@@ -361,4 +369,5 @@ def test_control_point_failure_keeps_ancs_unready_and_retries(
     scheduled[0][1]()
     assert client.connected is False
     _complete_authorization_probe(client)
+    assert client.authorized is True
     assert client.connected is True

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -38,11 +38,49 @@ def test_connects_classic_before_le(caplog) -> None:
 
     state["le"] = True
     scheduled[0][1]()
-    assert supervisor.snapshot() == {"bredr": True, "le": True}
+    assert supervisor.snapshot() == {
+        "bredr": True,
+        "le": True,
+        "last_le_error": "",
+        "last_le_error_message": "",
+    }
     assert "probing iPhone BR/EDR and LE bearer state" in caplog.text
     assert "iPhone BREDR bearer state: disconnected" in caplog.text
     assert "iPhone BREDR bearer state: connected" in caplog.text
     assert "iPhone LE bearer state: connected" in caplog.text
+
+
+def test_snapshot_includes_the_last_le_connect_error() -> None:
+    import dbus
+
+    state = {"bredr": True, "le": False}
+
+    def connect(kind, on_success, on_error):
+        if kind == "le":
+            on_error(
+                dbus.exceptions.DBusException(
+                    "le-connection-abort-by-local",
+                    name="org.bluez.Error.Failed",
+                )
+            )
+            return
+        on_success()
+
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=connect,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    supervisor.start()
+    scheduled[0][1]()
+    assert supervisor.snapshot() == {
+        "bredr": True,
+        "le": False,
+        "last_le_error": "org.bluez.Error.Failed",
+        "last_le_error_message": "le-connection-abort-by-local",
+    }
 
 
 def test_le_is_not_connected_if_classic_drops_during_settling() -> None:

--- a/tests/test_cli_pairing.py
+++ b/tests/test_cli_pairing.py
@@ -60,3 +60,78 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
         ("replace", "02:00:00:00:00:02", "02:00:00:00:00:01"),
         ("02:00:00:00:00:01", True),
     ]
+
+
+def test_pairing_complete_failure_includes_report_path(monkeypatch):
+    from blueferry.errors import PairingError
+
+    class Setup:
+        @staticmethod
+        def complete(*_args, **_kwargs):
+            raise PairingError(
+                "adapter setup failed",
+                report_path="/tmp/quirks-fail.json",
+            )
+
+    monkeypatch.setattr(setup_client, "SetupClient", Setup)
+
+    result = CliRunner().invoke(
+        cli.app, ["pairing-complete", "02:00:00:00:00:01"],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"] == "adapter setup failed"
+    assert payload["report_path"] == "/tmp/quirks-fail.json"
+
+
+def test_pairing_issue_prints_the_latest_report_without_opening(tmp_path, monkeypatch):
+    from blueferry import config, quirks_report
+
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
+    opened = []
+    path = quirks_report.save_report({"outcome": {"setup_complete": False}}, directory=tmp_path)
+    monkeypatch.setattr(quirks_report, "open_issue_page", lambda: opened.append(True) or True)
+
+    result = CliRunner().invoke(cli.app, ["pairing-issue", "--no-open"])
+
+    assert result.exit_code == 0
+    assert str(path) in result.stdout
+    assert "iPhone model" in result.stdout
+    assert "labels=pairing-issue" in result.stdout
+    assert "title=" in result.stdout
+    assert "body=" in result.stdout
+    assert opened == []
+
+
+def test_pairing_issue_print_url_is_only_the_github_link(tmp_path, monkeypatch):
+    from blueferry import config, quirks_report
+
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
+    quirks_report.save_report(
+        {
+            "controller": {"name": "hci1", "vendor": "Intel"},
+            "outcome": {"map": True, "pbap": False, "ancs": False},
+        },
+        directory=tmp_path,
+    )
+    opened = []
+    monkeypatch.setattr(quirks_report, "open_issue_page", lambda *_args: opened.append(True))
+
+    result = CliRunner().invoke(cli.app, ["pairing-issue", "--print-url"])
+
+    assert result.exit_code == 0
+    url = result.stdout.strip()
+    assert url.startswith("https://github.com/erikwb/blueferry/issues/new?")
+    assert "labels=pairing-issue" in url
+    assert opened == []
+
+
+def test_pairing_issue_without_a_report_exits_nonzero(tmp_path, monkeypatch):
+    from blueferry import config
+
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
+    result = CliRunner().invoke(cli.app, ["pairing-issue", "--no-open"])
+    assert result.exit_code == 1
+    assert "No pairing report" in result.stdout

--- a/tests/test_controller_hardware.py
+++ b/tests/test_controller_hardware.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from blueferry.bluetooth_capabilities import bluez_stack, controller_hardware
+
+
+def _btmgmt(stdout: str):
+    return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+
+
+def test_controller_hardware_describes_a_realtek_usb_stick(tmp_path) -> None:
+    usb = tmp_path / "bus" / "usb" / "1-4"
+    iface = usb / "1-4:1.0"
+    iface.mkdir(parents=True)
+    usb.joinpath("idVendor").write_text("0bda\n")
+    usb.joinpath("idProduct").write_text("c852\n")
+    usb.joinpath("manufacturer").write_text("Realtek\n")
+    usb.joinpath("product").write_text("RTL8852CE\n")
+    drivers = tmp_path / "bus" / "usb" / "drivers" / "btusb"
+    drivers.mkdir(parents=True)
+    iface.joinpath("driver").symlink_to(drivers)
+    hci = tmp_path / "class" / "bluetooth" / "hci0"
+    hci.mkdir(parents=True)
+    hci.joinpath("device").symlink_to(iface)
+
+    identity = controller_hardware(
+        "hci0",
+        run_command=lambda *_args, **_kwargs: _btmgmt(
+            "hci0: Primary controller\n"
+            "\taddr 02:00:AA:BB:CC:DD version 11 manufacturer 93 class 0x7c0408\n"
+        ),
+        sys_root=tmp_path,
+    )
+
+    assert identity["vendor"] == "Realtek"
+    assert identity["product"] == "RTL8852CE"
+    assert identity["usb_id"] == "0bda:c852"
+    assert identity["bus"] == "usb"
+    assert identity["driver"] == "btusb"
+    assert identity["manufacturer_id"] == 93
+    assert identity["hci_version"] == 11
+    assert "RTL8852CE" in str(identity["summary"])
+    assert "0bda:c852" in str(identity["summary"])
+    assert "02:00:AA:BB:CC:DD" not in str(identity)
+
+
+def test_controller_hardware_describes_an_intel_pci_card(tmp_path) -> None:
+    pci = tmp_path / "bus" / "pci" / "0000:00:14.3"
+    pci.mkdir(parents=True)
+    pci.joinpath("vendor").write_text("0x8086\n")
+    pci.joinpath("device").write_text("0x2723\n")
+    drivers = tmp_path / "bus" / "pci" / "drivers" / "iwlwifi"
+    drivers.mkdir(parents=True)
+    pci.joinpath("driver").symlink_to(drivers)
+    hci = tmp_path / "class" / "bluetooth" / "hci1"
+    hci.mkdir(parents=True)
+    hci.joinpath("device").symlink_to(pci)
+
+    identity = controller_hardware(
+        "hci1",
+        run_command=lambda *_args, **_kwargs: _btmgmt(
+            "addr 11:22:33:44:55:66 version 10 manufacturer 2 class 0x7c0408\n"
+        ),
+        sys_root=tmp_path,
+    )
+
+    assert identity["vendor"] == "Intel"
+    assert identity["pci_id"] == "8086:2723"
+    assert identity["bus"] == "pci"
+    assert identity["driver"] == "iwlwifi"
+    assert "Intel" in str(identity["summary"])
+    assert "11:22:33:44:55:66" not in str(identity)
+
+
+def test_bluez_stack_reports_version_and_experimental_flag() -> None:
+    commands = []
+
+    def run_command(argv, **_kwargs):
+        commands.append(list(argv))
+        if argv[0] == "bluetoothctl":
+            return _btmgmt("bluetoothctl: 5.87\n")
+        return _btmgmt(
+            "{ path=/usr/lib/bluetooth/bluetoothd ; argv[]=/usr/lib/bluetooth/bluetoothd -E ; }\n"
+        )
+
+    stack = bluez_stack(run_command=run_command)
+    assert stack["bluez_version"] == "5.87"
+    assert stack["experimental"] is True
+    assert commands[0] == ["bluetoothctl", "--version"]
+
+
+def test_bluez_stack_reuses_a_known_experimental_flag() -> None:
+    commands = []
+
+    def run_command(argv, **kwargs):
+        commands.append((list(argv), kwargs.get("timeout")))
+        return _btmgmt("bluetoothctl: 5.87\n")
+
+    stack = bluez_stack(run_command=run_command, experimental=True, timeout=2)
+    assert stack == {"experimental": True, "bluez_version": "5.87"}
+    assert commands == [(["bluetoothctl", "--version"], 2)]
+
+
+def test_controller_hardware_replaces_a_generic_usb_product(tmp_path) -> None:
+    usb = tmp_path / "bus" / "usb" / "1-3"
+    iface = usb / "1-3:1.0"
+    iface.mkdir(parents=True)
+    usb.joinpath("idVendor").write_text("0e8d\n")
+    usb.joinpath("idProduct").write_text("7961\n")
+    usb.joinpath("manufacturer").write_text("MediaTek\n")
+    usb.joinpath("product").write_text("Wireless_Device\n")
+    drivers = tmp_path / "bus" / "usb" / "drivers" / "btusb"
+    drivers.mkdir(parents=True)
+    iface.joinpath("driver").symlink_to(drivers)
+    hci = tmp_path / "class" / "bluetooth" / "hci0"
+    hci.mkdir(parents=True)
+    hci.joinpath("device").symlink_to(iface)
+
+    identity = controller_hardware(
+        "hci0",
+        run_command=lambda *_args, **_kwargs: _btmgmt(""),
+        sys_root=tmp_path,
+    )
+
+    assert identity["vendor"] == "MediaTek"
+    assert identity["product"] == "MT7921"
+    assert identity["usb_id"] == "0e8d:7961"
+    assert "Wireless_Device" not in str(identity["summary"])
+    assert "MT7921" in str(identity["summary"])
+
+
+def test_controller_hardware_ignores_invalid_adapter_names(tmp_path) -> None:
+    identity = controller_hardware(
+        "../etc",
+        run_command=lambda *_args, **_kwargs: _btmgmt(""),
+        sys_root=tmp_path,
+    )
+    assert identity == {"name": "../etc"}

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -109,6 +109,34 @@ def test_no_storage_policy_reasserts_empty_local_data(monkeypatch):
     assert cleared == ["events", "contacts"]
 
 
+def test_status_exposes_split_ancs_and_last_le_error(monkeypatch):
+    instance = _bare_daemon()
+    instance.contacts = SimpleNamespace(count=lambda: 0)
+    instance.ancs = SimpleNamespace(
+        connected=False, subscribed=True, authorized=False,
+    )
+    instance.bearers = SimpleNamespace(
+        snapshot=lambda: {
+            "bredr": True,
+            "le": False,
+            "last_le_error": "org.bluez.Error.Failed",
+            "last_le_error_message": "le-connection-abort-by-local",
+        }
+    )
+    instance.setup_verification = SimpleNamespace(verified=())
+    monkeypatch.setattr(daemon_mod, "history_count", lambda **_kwargs: 0)
+
+    status = instance._status()
+
+    assert status["ancs"] is False
+    assert status["ancs_subscribed"] is True
+    assert status["ancs_authorized"] is False
+    assert status["bredr"] is True
+    assert status["le"] is False
+    assert status["last_le_error"] == "org.bluez.Error.Failed"
+    assert status["last_le_error_message"] == "le-connection-abort-by-local"
+
+
 def test_failed_hardware_initialization_leaves_control_service_alive(monkeypatch):
     instance = _bare_daemon()
     scheduled = []

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -288,6 +288,20 @@ def test_all_gui_clients_offer_contacts_aware_new_messages() -> None:
     assert '"contacts-json"' in quickshell
 
 
+def test_all_gui_clients_offer_a_pairing_issue_button() -> None:
+    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
+    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
+    quickshell = _qml_bundle(ROOT / "data/quickshell")
+
+    for client in (gtk, qt, quickshell):
+        assert "Report Pairing Issue" in client
+        assert "iPhone model" in client
+        assert "iOS version" in client
+    assert "blueferry pairing-issue" in (ROOT / "src/blueferry/quirks_report.py").read_text()
+    assert '"pairing-issue"' in quickshell
+    assert '"--print-url"' in quickshell
+
+
 def test_all_gui_clients_explain_phone_side_pairing_step() -> None:
     gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
     qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -11,6 +11,22 @@ from blueferry import bluez_setup, config, pair_setup
 from blueferry.bluetooth_devices import iphone_candidates
 
 
+@pytest.fixture(autouse=True)
+def _pairing_reports_in_tmp(tmp_path, monkeypatch):
+    state = tmp_path / "blueferry-state"
+    monkeypatch.setattr(config, "STATE_DIR", state)
+    monkeypatch.setattr(config, "EVENTS_DB", state / "events.sqlite")
+    monkeypatch.setattr(config, "CONTACTS_DB", state / "contacts.sqlite")
+    monkeypatch.setattr(pair_setup, "_adapter_identity", lambda adapter, *_args, **_kwargs: {"name": adapter})
+    monkeypatch.setattr(
+        pair_setup,
+        "_le_bearer_snapshot",
+        lambda _path: {
+            "present": False, "paired": False, "bonded": False, "connected": False,
+        },
+    )
+
+
 def _device(*, paired: bool) -> pair_setup.PairedDevice:
     return pair_setup.PairedDevice(
         mac="02:00:00:00:00:01",
@@ -373,6 +389,11 @@ def test_compatibility_is_based_on_controller_features_not_vendor(monkeypatch):
     assert status["adapter"] == "hci7"
     assert status["hardware_supported"] is True
     assert status["pairing_ready"] is True
+    assert status["secure_conn"] is False
+    assert "secure-conn" in status["supported_settings"]
+    assert status["current_settings"] == [
+        "advertising", "br/edr", "le", "powered",
+    ]
 
 
 def test_compatibility_explains_missing_classic_transport(monkeypatch):
@@ -436,6 +457,48 @@ def test_classic_only_controller_supports_core_without_ancs(monkeypatch):
     assert status["pairing_ready"] is True
 
 
+def test_controller_snapshot_does_not_repeat_btmgmt_or_systemctl(monkeypatch):
+    calls = []
+
+    def run_command(argv, **_kwargs):
+        calls.append(list(argv))
+        return type(
+            "Result",
+            (),
+            {"returncode": 0, "stdout": "bluetoothctl: 5.87\n", "stderr": ""},
+        )()
+
+    monkeypatch.setattr(pair_setup, "run_command", run_command)
+    snapshot = pair_setup._controller_snapshot(
+        "hci0",
+        {
+            "available": True,
+            "powered": True,
+            "classic": True,
+            "low_energy": True,
+            "advertising": True,
+            "secure_pairing": True,
+            "secure_conn": True,
+            "hardware_supported": True,
+            "messages_supported": True,
+            "notifications_supported": True,
+            "bearer_api_active": True,
+            "manufacturer_id": 93,
+            "hci_version": 11,
+            "supported_settings": ["advertising", "br/edr", "le", "powered", "secure-conn"],
+            "current_settings": ["br/edr", "le", "powered", "secure-conn"],
+        },
+    )
+
+    assert calls == [["bluetoothctl", "--version"]]
+    assert snapshot["secure_conn"] is True
+    assert snapshot["current_settings"] == ["br/edr", "le", "powered", "secure-conn"]
+    assert snapshot["manufacturer_id"] == 93
+    assert snapshot["hci_version"] == 11
+    assert snapshot["experimental"] is True
+    assert snapshot["bluez_version"] == "5.87"
+
+
 def test_backend_restart_does_not_create_per_user_enablement(monkeypatch):
     calls = []
     monkeypatch.setattr(
@@ -464,11 +527,11 @@ def _compatible(monkeypatch, *, notifications: bool = True) -> None:
     )
     monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
     monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
-    monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path: None)
+    monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path, **_kwargs: None)
     monkeypatch.setattr(
         pair_setup,
         "_wait_for_daemon_transports",
-        lambda: (True, True, True),
+        lambda **_kwargs: (True, True, True),
     )
 
 
@@ -502,7 +565,7 @@ def test_complete_pairing_starts_profiles_while_pairing_advert_is_active(monkeyp
     monkeypatch.setattr(
         pair_setup,
         "_wait_for_classic_settled",
-        lambda path: calls.append(("classic-settled", path)),
+        lambda path, **_kwargs: calls.append(("classic-settled", path)),
     )
     monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: calls.append("restart"))
 
@@ -762,7 +825,7 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
     monkeypatch.setattr(
         pair_setup,
         "_wait_for_classic_settled",
-        lambda path: calls.append(("classic-settled", path)),
+        lambda path, **_kwargs: calls.append(("classic-settled", path)),
     )
     monkeypatch.setattr(
         pair_setup,
@@ -795,8 +858,11 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
     # LE keys); there must be no competing Linux-side Device1.Pair() call.
     # Keep our agent default while the daemon makes the first MAP/PBAP attempt
     # and only then enables LE.
-    assert calls == [
-        ("agent", unpaired.device_path, confirmation, display),
+    assert calls[0][0] == "agent"
+    assert calls[0][1] == unpaired.device_path
+    assert calls[0][2] is not confirmation
+    assert calls[0][2](12) is True
+    assert calls[1:] == [
         "agent-enter",
         ("connect", unpaired.device_path, 60.0),
         ("wait", 120.0),
@@ -862,7 +928,7 @@ def test_pairing_starts_daemon_even_when_ancs_is_still_missing(monkeypatch):
     monkeypatch.setattr(
         pair_setup,
         "_wait_for_daemon_transports",
-        lambda: (True, True, False),
+        lambda **_kwargs: (True, True, False),
     )
     monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: restarted.append(True))
 
@@ -885,7 +951,7 @@ def test_pairing_does_not_gate_map_on_inbound_ancs(monkeypatch):
     monkeypatch.setattr(
         pair_setup,
         "_wait_for_daemon_transports",
-        lambda: (False, False, False),
+        lambda **_kwargs: (False, False, False),
     )
     saved = []
     monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: saved.append(True))

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -160,4 +160,65 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> No
         ("\nUse this device?", {"default": True}),
         ("Do both devices show Bluetooth code 012345?", {"default": False}),
     ]
-    assert "Bluetooth pairing code: 012345" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "Bluetooth pairing code: 012345" in output
+    assert "pairing-issue" not in output
+
+
+def test_cli_wizard_points_at_pairing_issue_when_ancs_stays_down(
+    monkeypatch, capsys,
+) -> None:
+    device = PairedDevice(
+        mac="02:00:00:00:00:01",
+        name="iPhone",
+        icon="phone",
+        trusted=True,
+        connected=True,
+        paired=True,
+        adapter_path="/org/bluez/hci0",
+        device_path="/org/bluez/hci0/dev_02_00_00_00_00_01",
+        uuids=frozenset(),
+    )
+    compatibility = SimpleNamespace(
+        adapter="hci0",
+        hardware_supported=True,
+        issue="",
+        notifications_supported=True,
+        bearer_api_active=True,
+    )
+
+    class Setup:
+        @staticmethod
+        def compatibility():
+            return compatibility
+
+        @staticmethod
+        def devices(*, scan_seconds):
+            return [device]
+
+        @staticmethod
+        def configuration():
+            return SimpleNamespace(saved=False, mac="")
+
+        @staticmethod
+        def complete(mac, *, confirmation, display):
+            return SimpleNamespace(
+                device=device,
+                ancs_ready=False,
+                quirks_report="/tmp/quirks-test.json",
+            )
+
+    class Backend:
+        @staticmethod
+        def status():
+            return SimpleNamespace(verified_iphone_setup=())
+
+    monkeypatch.setattr(pairing_cli, "SetupClient", Setup)
+    monkeypatch.setattr(pairing_cli, "BackendClient", Backend)
+    monkeypatch.setattr(pairing_cli.typer, "confirm", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(pairing_cli, "_print_iphone_steps", lambda *_args, **_kwargs: None)
+
+    assert pairing_cli.run_wizard(verify_after=False) == 0
+    output = capsys.readouterr().out
+    assert "blueferry pairing-issue" in output
+    assert "GitHub issue" not in output

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -315,3 +315,24 @@ def test_replacing_saved_target_is_forwarded_to_pairing_helper(monkeypatch):
         ("02:00:00:00:00:01", "02:00:00:00:00:02")
     ]
     assert controller.targetSaved is True
+
+
+def test_pairing_issue_offer_stays_when_ancs_connects(monkeypatch, tmp_path) -> None:
+    from blueferry import config, quirks_report
+
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
+    path = quirks_report.save_report(
+        {"outcome": {"setup_complete": True, "ancs": True}},
+        directory=tmp_path,
+    )
+    controller = BridgeController(
+        backend=_Backend(),
+        setup=object(),
+        subscribe=False,
+        autostart=False,
+    )
+    controller._status = {"ancs": True}
+
+    controller._refresh_pairing_issue_report()
+
+    assert controller.pairingIssueReport == str(path)

--- a/tests/test_quirks_report.py
+++ b/tests/test_quirks_report.py
@@ -1,0 +1,620 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from blueferry import bluez_setup, config, pair_setup, quirks_report
+from blueferry.quirks_report import MAX_REPORTS
+
+
+@pytest.fixture
+def report_dir(tmp_path, monkeypatch):
+    state = tmp_path / "blueferry-state"
+    monkeypatch.setattr(config, "STATE_DIR", state)
+    monkeypatch.setattr(config, "EVENTS_DB", state / "events.sqlite")
+    monkeypatch.setattr(config, "CONTACTS_DB", state / "contacts.sqlite")
+    return state
+
+
+def test_pairing_outcome_separates_bond_from_later_setup_failure() -> None:
+    attempt = {
+        "phone": {"paired": True},
+        "timeline": [{"event": "paired"}],
+    }
+    outcome = pair_setup._pairing_outcome(
+        attempt, None, pair_setup.PairingError("advert failed"),
+    )
+    assert outcome["bonded"] is True
+    assert outcome["setup_complete"] is False
+    assert "pairing" not in outcome
+
+
+def test_issue_instructions_ask_for_iphone_model_and_ios_version() -> None:
+    text = quirks_report.issue_instructions("/tmp/quirks-test.json")
+    assert "/tmp/quirks-test.json" in text
+    assert "iPhone model" in text
+    assert "iOS version" in text
+    assert "blueferry pairing-issue" in quirks_report.cli_issue_hint()
+
+
+def test_issue_url_labels_a_pairing_issue_with_adapter_and_outcome() -> None:
+    url = quirks_report.issue_url(
+        {
+            "controller": {
+                "name": "hci0",
+                "vendor": "Realtek",
+                "product": "RTL8852CE",
+            },
+            "outcome": {"map": True, "pbap": True, "ancs": False},
+        }
+    )
+    assert "labels=pairing-issue" in url
+    title = parse_qs(urlparse(url).query)["title"][0]
+    assert title == "Pairing issue: Realtek RTL8852CE — MAP/PBAP success, ANCS fail"
+    assert "```json" in parse_qs(urlparse(url).query)["body"][0]
+    assert '"ancs": false' in parse_qs(urlparse(url).query)["body"][0]
+    assert quirks_report.issue_title(
+        {"controller": {"name": "hci0"}, "outcome": {"bonded": True, "setup_complete": False}}
+    ) == "Pairing issue: unknown adapter — bonded, setup failed"
+    assert quirks_report.issue_title(
+        {
+            "controller": {
+                "name": "hci0",
+                "vendor": "MediaTek",
+                "product": "Wireless_Device",
+                "usb_id": "0e8d:7961",
+            },
+            "outcome": {"map": True, "pbap": True, "ancs": False},
+        }
+    ) == "Pairing issue: MediaTek MT7921 — MAP/PBAP success, ANCS fail"
+
+
+def test_issue_report_keeps_a_successful_ancs_setup(tmp_path) -> None:
+    failed = quirks_report.save_report(
+        {"outcome": {"setup_complete": True, "ancs": False}},
+        directory=tmp_path,
+    )
+    assert quirks_report.issue_report(tmp_path) == failed
+    succeeded = quirks_report.save_report(
+        {"outcome": {"setup_complete": True, "ancs": True}},
+        directory=tmp_path,
+    )
+    assert quirks_report.issue_report(tmp_path) == succeeded
+
+
+def test_session_environment_reads_xdg(monkeypatch) -> None:
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "KDE")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    assert quirks_report.session_environment() == {
+        "desktop": "KDE",
+        "session_type": "wayland",
+    }
+
+
+def test_remember_daemon_status_splits_ancs_and_le_error() -> None:
+    attempt = {"phone": {"le_bearer": {}}, "timeline": []}
+    status = SimpleNamespace(
+        extra={
+            "ancs_subscribed": True,
+            "ancs_authorized": False,
+            "bredr": True,
+            "le": False,
+            "last_le_error": "org.bluez.Error.Failed",
+            "last_le_error_message": "le-connection-abort-by-local",
+        }
+    )
+    pair_setup._remember_daemon_status(attempt, status)
+    assert attempt["daemon"]["ancs_subscribed"] is True
+    assert attempt["daemon"]["ancs_authorized"] is False
+    assert attempt["phone"]["le_bearer"]["last_error"] == "org.bluez.Error.Failed"
+    assert (
+        attempt["phone"]["le_bearer"]["last_error_message"]
+        == "le-connection-abort-by-local"
+    )
+    assert [item["event"] for item in attempt["timeline"]] == [
+        "ancs_subscribed",
+        "le_connect_failed",
+    ]
+    assert attempt["timeline"][1]["error"] == "org.bluez.Error.Failed"
+    assert attempt["timeline"][1]["message"] == "le-connection-abort-by-local"
+
+
+def test_bluetooth_session_owners_lists_claimed_well_known_names(monkeypatch) -> None:
+    claimed = {"org.blueman.Applet", "org.kde.kded6"}
+
+    class Daemon:
+        @staticmethod
+        def NameHasOwner(name):
+            return name in claimed
+
+    class Bus:
+        @staticmethod
+        def get_object(service, path):
+            assert service == "org.freedesktop.DBus"
+            assert path == "/org/freedesktop/DBus"
+            return object()
+
+    monkeypatch.setattr(pair_setup, "get_session_bus", lambda: Bus())
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args, **_kwargs: Daemon())
+    assert pair_setup._bluetooth_session_owners() == [
+        "org.blueman.Applet",
+        "org.kde.kded6",
+    ]
+
+
+def test_wait_for_daemon_transports_records_split_ancs(monkeypatch) -> None:
+    from blueferry.models import BackendStatus
+
+    statuses = [
+        BackendStatus.from_dict(
+            {
+                "map": True,
+                "pbap": True,
+                "ancs": False,
+                "ancs_subscribed": True,
+                "ancs_authorized": False,
+                "bredr": True,
+                "le": False,
+                "last_le_error": "org.bluez.Error.Failed",
+                "last_le_error_message": "le-connection-abort-by-local",
+            }
+        ),
+        BackendStatus.from_dict(
+            {
+                "map": True,
+                "pbap": True,
+                "ancs": True,
+                "ancs_subscribed": True,
+                "ancs_authorized": True,
+                "bredr": True,
+                "le": True,
+            }
+        ),
+    ]
+
+    class FakeClient:
+        @staticmethod
+        def status():
+            return statuses.pop(0)
+
+    monkeypatch.setattr("blueferry.client.BackendClient", FakeClient)
+    monkeypatch.setattr(pair_setup.time, "sleep", lambda _seconds: None)
+    attempt = {"timeline": [], "phone": {"le_bearer": {}}}
+
+    result = pair_setup._wait_for_daemon_transports(timeout=5, attempt=attempt)
+
+    assert result == (True, True, True)
+    assert attempt["daemon"]["ancs_subscribed"] is True
+    assert attempt["daemon"]["ancs_authorized"] is True
+    assert "last_le_error" not in attempt["daemon"]
+    assert attempt["phone"]["le_bearer"]["last_error"] == "org.bluez.Error.Failed"
+    assert (
+        attempt["phone"]["le_bearer"]["last_error_message"]
+        == "le-connection-abort-by-local"
+    )
+    events = [item["event"] for item in attempt["timeline"]]
+    assert events[:4] == [
+        "waiting_for_transports",
+        "ancs_subscribed",
+        "le_connect_failed",
+        "map_ready",
+    ]
+    assert "ancs_authorized" in events
+    assert "ancs_ready" in events
+
+
+def test_scrub_text_removes_mac_addresses_and_bluez_paths() -> None:
+    raw = (
+        "paired 02:00:AA:BB:CC:DD at "
+        "/org/bluez/hci0/dev_02_00_AA_BB_CC_DD"
+    )
+    cleaned = quirks_report.scrub_text(raw)
+    assert "02:00" not in cleaned
+    assert "AA:BB:CC:DD" not in cleaned
+    assert "dev_02_00" not in cleaned
+    assert "xx:xx:xx:xx:xx:xx" in cleaned
+    assert "dev_REDACTED" in cleaned
+
+
+def test_scrub_text_replaces_home_and_xdg_prefixes(monkeypatch, tmp_path) -> None:
+    home = tmp_path / "alice"
+    home.mkdir()
+    state = home / ".local" / "state"
+    state.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("XDG_STATE_HOME", str(state))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    raw = (
+        f"could not write {home / '.config/blueferry/local.env'}; "
+        f"state={state / 'blueferry/events.sqlite'}"
+    )
+    cleaned = quirks_report.scrub_text(raw)
+    assert "alice" not in cleaned
+    assert str(home) not in cleaned
+    assert "$XDG_CONFIG_HOME/blueferry/local.env" in cleaned
+    assert "$XDG_STATE_HOME/blueferry/events.sqlite" in cleaned
+
+
+def test_save_report_scrubs_home_paths_from_error_text(monkeypatch, tmp_path) -> None:
+    home = tmp_path / "alice"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    path = quirks_report.save_report(
+        {"outcome": {"error": f"could not clear {home / '.config/blueferry/local.env'}"}},
+        directory=tmp_path / "reports",
+    )
+    assert path is not None
+    body = path.read_text()
+    assert "alice" not in body
+    assert "$XDG_CONFIG_HOME/blueferry/local.env" in body
+
+
+def test_list_reports_ignores_files_removed_during_scan(tmp_path, monkeypatch) -> None:
+    first = tmp_path / "quirks-a.json"
+    second = tmp_path / "quirks-b.json"
+    first.write_text("{}\n")
+    second.write_text("{}\n")
+    original = Path.lstat
+
+    def flaky(self, *args, **kwargs):
+        if self == first:
+            raise FileNotFoundError(self)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "lstat", flaky)
+    assert quirks_report.list_reports(tmp_path) == [second]
+
+
+def test_public_device_omits_name_address_and_path() -> None:
+    device = SimpleNamespace(
+        mac="02:00:AA:BB:CC:DD",
+        name="Alex's iPhone",
+        icon="phone",
+        likely_iphone=True,
+        paired=True,
+        trusted=True,
+        connected=True,
+        services_resolved=True,
+        ancs_bonded=False,
+        device_path="/org/bluez/hci0/dev_02_00_AA_BB_CC_DD",
+    )
+    public = quirks_report.public_device(device)
+    encoded = json.dumps(public)
+    assert "Alex" not in encoded
+    assert "02:00" not in encoded
+    assert "AA:BB" not in encoded
+    assert "hci0" not in encoded
+    assert "id" not in public
+    assert public["likely_iphone"] is True
+    assert public["ancs_uuid"] is False
+
+
+def test_save_report_scrubs_payload_and_keeps_ten(tmp_path) -> None:
+    directory = tmp_path / "blueferry"
+    written = []
+    for index in range(MAX_REPORTS + 3):
+        written.append(
+            quirks_report.save_report(
+                {
+                    "index": index,
+                    "mac": "AA:BB:CC:DD:EE:FF",
+                    "path": "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF",
+                },
+                directory=directory,
+            )
+        )
+    reports = sorted(directory.glob("quirks-*.json"))
+    assert len(reports) == MAX_REPORTS
+    bodies = [path.read_text() for path in reports]
+    assert all("AA:BB:CC:DD:EE:FF" not in body for body in bodies)
+    assert all("dev_AA_BB" not in body for body in bodies)
+    assert all("xx:xx:xx:xx:xx:xx" in body for body in bodies)
+    assert json.loads(written[-1].read_text())["index"] == MAX_REPORTS + 2
+
+
+def _paired_device() -> pair_setup.PairedDevice:
+    return pair_setup.PairedDevice(
+        mac="02:00:00:00:00:01",
+        name="Alex's iPhone",
+        icon="phone",
+        trusted=True,
+        connected=True,
+        paired=True,
+        adapter_path="/org/bluez/hci0",
+        device_path="/org/bluez/hci0/dev_02_00_00_00_00_01",
+        uuids=frozenset({config.ANCS_SOLICIT_UUID}),
+        services_resolved=True,
+    )
+
+
+def test_complete_pairing_writes_a_scrubbed_success_report(
+    report_dir, monkeypatch,
+) -> None:
+    device = _paired_device()
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "KDE")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(
+        pair_setup,
+        "bluetooth_compatibility",
+        lambda _adapter: {
+            "hardware_supported": True,
+            "notifications_supported": True,
+            "bearer_api_active": True,
+        },
+    )
+    monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
+    monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
+    monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path, **_kwargs: None)
+    monkeypatch.setattr(
+        pair_setup,
+        "_bluetooth_session_owners",
+        lambda: ["org.kde.BlueDevil.Client", "org.kde.kded6"],
+    )
+
+    def _ready_transports(*, attempt=None, **_kwargs):
+        pair_setup._remember_daemon_status(
+            attempt,
+            SimpleNamespace(
+                extra={
+                    "ancs_subscribed": True,
+                    "ancs_authorized": True,
+                    "bredr": True,
+                    "le": True,
+                }
+            ),
+        )
+        return (True, True, True)
+
+    monkeypatch.setattr(pair_setup, "_wait_for_daemon_transports", _ready_transports)
+    monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
+    monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(bluez_setup, "unregister_advert", lambda _adapter: None)
+    monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: None)
+    monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: None)
+    monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: None)
+    monkeypatch.setattr(pair_setup, "_adapter_identity", lambda adapter, *_args, **_kwargs: {"name": adapter})
+    monkeypatch.setattr(
+        pair_setup,
+        "_le_bearer_snapshot",
+        lambda _path: {
+            "present": True, "paired": True, "bonded": True, "connected": True,
+        },
+    )
+
+    result = pair_setup.complete_pairing(device.mac)
+    payload = Path(result["quirks_report"]).read_text()
+
+    assert result["ok"] is True
+    assert result["ancs_ready"] is True
+    assert "02:00:00:00:00:01" not in payload
+    assert "Alex" not in payload
+    assert "dev_02_00" not in payload
+    parsed = json.loads(payload)
+    assert parsed["outcome"]["bonded"] is True
+    assert parsed["outcome"]["setup_complete"] is True
+    assert "pairing" not in parsed["outcome"]
+    assert parsed["outcome"]["map"] is True
+    assert parsed["outcome"]["pbap"] is True
+    assert parsed["outcome"]["ancs"] is True
+    assert parsed["outcome"]["ancs_subscribed"] is True
+    assert parsed["outcome"]["ancs_authorized"] is True
+    assert "last_le_error" not in parsed["outcome"]
+    assert parsed["session"] == {
+        "desktop": "KDE",
+        "session_type": "wayland",
+        "bluetooth_owners": ["org.kde.BlueDevil.Client", "org.kde.kded6"],
+    }
+    assert "transports" not in parsed
+    assert "id" not in parsed["phone"]
+    assert parsed["phone"]["likely_iphone"] is True
+    assert parsed["controller"]["name"] == "hci0"
+    assert "adapter" not in parsed
+    assert "compatibility" not in parsed
+    assert Path(result["quirks_report"]).is_relative_to(report_dir)
+    events = [item["event"] for item in parsed["timeline"]]
+    assert events[0] == "start"
+    assert events[-1] == "finished"
+    assert "prepare_classic_sent" in events
+    assert "advert_ready" in events
+    assert "advert_removed" in events
+    assert "daemon_restarted" in events
+    assert "ancs_subscribed" in events
+    assert "ancs_authorized" in events
+    assert "map_ready" in events
+    times = [item["t"] for item in parsed["timeline"]]
+    assert times[0] == 0
+    assert times == sorted(times)
+    assert "_t0" not in parsed
+    assert parsed["duration_s"] >= times[-1]
+
+
+def test_pairing_report_keeps_last_le_error_when_ancs_stays_down(
+    report_dir, monkeypatch,
+) -> None:
+    device = _paired_device()
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(
+        pair_setup,
+        "bluetooth_compatibility",
+        lambda _adapter: {
+            "hardware_supported": True,
+            "notifications_supported": True,
+            "bearer_api_active": True,
+        },
+    )
+    monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
+    monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
+    monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path, **_kwargs: None)
+    monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
+    monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(bluez_setup, "unregister_advert", lambda _adapter: None)
+    monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: None)
+    monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: None)
+    monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: None)
+    monkeypatch.setattr(pair_setup, "_adapter_identity", lambda adapter, *_args, **_kwargs: {"name": adapter})
+    monkeypatch.setattr(
+        pair_setup,
+        "_le_bearer_snapshot",
+        lambda _path: {
+            "present": True, "paired": True, "bonded": False, "connected": False,
+        },
+    )
+
+    def _ancs_missing(*, attempt=None, **_kwargs):
+        pair_setup._remember_daemon_status(
+            attempt,
+            SimpleNamespace(
+                extra={
+                    "ancs_subscribed": False,
+                    "ancs_authorized": False,
+                    "bredr": True,
+                    "le": False,
+                    "last_le_error": "org.bluez.Error.Failed",
+                    "last_le_error_message": "le-connection-abort-by-local",
+                }
+            ),
+        )
+        return (True, True, False)
+
+    monkeypatch.setattr(pair_setup, "_wait_for_daemon_transports", _ancs_missing)
+
+    result = pair_setup.complete_pairing(device.mac)
+    parsed = json.loads(Path(result["quirks_report"]).read_text())
+
+    assert result["ancs_ready"] is False
+    assert parsed["outcome"]["bonded"] is True
+    assert parsed["outcome"]["setup_complete"] is True
+    assert parsed["outcome"]["map"] is True
+    assert parsed["outcome"]["ancs"] is False
+    assert parsed["outcome"]["ancs_subscribed"] is False
+    assert parsed["outcome"]["ancs_authorized"] is False
+    assert parsed["outcome"]["last_le_error"] == "org.bluez.Error.Failed"
+    assert parsed["outcome"]["last_le_error_message"] == "le-connection-abort-by-local"
+    assert parsed["phone"]["le_bearer"]["bonded"] is False
+    assert parsed["phone"]["le_bearer"]["last_error"] == "org.bluez.Error.Failed"
+    assert parsed["phone"]["le_bearer"]["last_error_message"] == (
+        "le-connection-abort-by-local"
+    )
+    assert "le_connect_failed" in [item["event"] for item in parsed["timeline"]]
+
+
+def test_failed_pairing_still_writes_a_report(report_dir, monkeypatch) -> None:
+    device = _paired_device()
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(
+        pair_setup,
+        "bluetooth_compatibility",
+        lambda _adapter: {
+            "hardware_supported": True,
+            "notifications_supported": True,
+            "bearer_api_active": True,
+            "low_energy": True,
+            "advertising": True,
+            "secure_conn": False,
+            "current_settings": ["advertising", "br/edr", "le", "powered"],
+            "supported_settings": [
+                "advertising", "br/edr", "le", "powered", "secure-conn",
+            ],
+        },
+    )
+    monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
+    monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: False)
+    monkeypatch.setattr(
+        pair_setup,
+        "_le_bearer_snapshot",
+        lambda _path: {
+            "present": False, "paired": False, "bonded": False, "connected": False,
+        },
+    )
+    monkeypatch.setattr(pair_setup, "_adapter_identity", lambda adapter, *_args, **_kwargs: {"name": adapter})
+
+    with pytest.raises(pair_setup.PairingError) as raised:
+        pair_setup.complete_pairing(device.mac)
+
+    path = Path(raised.value.report_path)
+    payload = path.read_text()
+    assert path.is_relative_to(report_dir)
+    assert "02:00:00:00:00:01" not in payload
+    assert "Alex" not in payload
+    parsed = json.loads(payload)
+    assert parsed["outcome"]["bonded"] is True
+    assert parsed["outcome"]["setup_complete"] is False
+    assert "pairing" not in parsed["outcome"]
+    assert parsed["outcome"]["map"] is None
+    assert parsed["outcome"]["ancs"] is None
+    assert "error" in parsed["outcome"]
+    events = [item["event"] for item in parsed["timeline"]]
+    assert events[0] == "start"
+    assert events[-1] == "failed"
+    assert "prepare_classic_sent" in events
+    assert "advert_removed" not in events
+    assert "agent_released" not in events
+    assert parsed["controller"]["notifications_supported"] is True
+    assert parsed["controller"]["low_energy"] is True
+    assert parsed["controller"]["advertising"] is True
+    assert parsed["controller"]["secure_conn"] is False
+    assert parsed["controller"]["current_settings"] == [
+        "advertising", "br/edr", "le", "powered",
+    ]
+    assert "secure-conn" in parsed["controller"]["supported_settings"]
+    assert parsed["controller"]["name"] == "hci0"
+    assert "adapter" not in parsed
+    assert "compatibility" not in parsed
+    assert "device" not in parsed
+    assert "desktop" in parsed["session"]
+    assert "session_type" in parsed["session"]
+    assert parsed["session"]["bluetooth_owners"] == []
+
+
+def test_unexpected_pairing_exception_still_writes_a_report(
+    report_dir, monkeypatch,
+) -> None:
+    device = _paired_device()
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(
+        pair_setup,
+        "bluetooth_compatibility",
+        lambda _adapter: {
+            "hardware_supported": True,
+            "notifications_supported": True,
+            "bearer_api_active": True,
+        },
+    )
+    monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
+    monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
+    monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path, **_kwargs: None)
+    monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
+    monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(bluez_setup, "unregister_advert", lambda _adapter: None)
+    monkeypatch.setattr(pair_setup, "_adapter_identity", lambda adapter, *_args, **_kwargs: {"name": adapter})
+    monkeypatch.setattr(
+        pair_setup,
+        "_le_bearer_snapshot",
+        lambda _path: {
+            "present": False, "paired": False, "bonded": False, "connected": False,
+        },
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "trust_device",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("bluez properties vanished")),
+    )
+
+    with pytest.raises(pair_setup.PairingError, match="bluez properties vanished") as raised:
+        pair_setup.complete_pairing(device.mac)
+
+    assert raised.value.report_path
+    parsed = json.loads(Path(raised.value.report_path).read_text())
+    assert parsed["outcome"]["bonded"] is True
+    assert parsed["outcome"]["setup_complete"] is False
+    assert "bluez properties vanished" in str(parsed["outcome"]["error"])
+    events = [item["event"] for item in parsed["timeline"]]
+    assert "advert_removed" not in events
+    assert "agent_released" not in events

--- a/tests/test_setup_client.py
+++ b/tests/test_setup_client.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import io
+import json
+
+import pytest
 
 from blueferry import pair_setup, setup_client
 
@@ -68,12 +71,14 @@ def test_compatibility_and_configuration_are_typed(monkeypatch):
             "path": "/tmp/local.env",
         },
     )
+    monkeypatch.setattr(setup_client.quirks_report, "issue_report", lambda: None)
 
     client = setup_client.SetupClient()
 
     assert client.compatibility().pairing_ready is True
     assert client.compatibility().adapter == "hci2"
     assert client.configuration().configured is False
+    assert client.configuration().pairing_issue_report == ""
 
 
 def test_device_operations_delegate_with_requested_scan(monkeypatch):
@@ -171,3 +176,43 @@ def test_isolated_pairing_answers_helper_confirmation(monkeypatch):
     assert process.stdin.getvalue() == "yes\n"
     assert result.ancs_ready is True
     assert commands[0][-2:] == ["--replace-saved-mac", "02:00:00:00:00:02"]
+
+
+def test_isolated_pairing_preserves_report_path_on_failure(monkeypatch):
+    device = _device()
+
+    class Process:
+        def __init__(self):
+            self.stdin = io.StringIO()
+            self.stdout = iter([
+                json.dumps({
+                    "ok": False,
+                    "error": "Bluetooth confirmation did not complete",
+                    "report_path": "/tmp/quirks-test.json",
+                }) + "\n"
+            ])
+
+        @staticmethod
+        def wait(*_args, **_kwargs):
+            return 2
+
+        @staticmethod
+        def poll():
+            return 2
+
+        @staticmethod
+        def terminate():
+            return None
+
+    monkeypatch.setattr(
+        setup_client.subprocess, "Popen", lambda *_args, **_kwargs: Process(),
+    )
+
+    with pytest.raises(setup_client.PairingError) as raised:
+        setup_client.SetupClient().complete_isolated(
+            device.mac,
+            confirmation=lambda _passkey: True,
+        )
+
+    assert raised.value.report_path == "/tmp/quirks-test.json"
+    assert str(raised.value) == "Bluetooth confirmation did not complete"

--- a/tests/test_setup_runner.py
+++ b/tests/test_setup_runner.py
@@ -37,3 +37,24 @@ def test_setup_runner_normalizes_failure_text() -> None:
 
     assert completed.wait(1)
     assert errors == ["failed"]
+
+
+def test_setup_runner_includes_pairing_report_path() -> None:
+    from blueferry.errors import PairingError
+
+    completed = threading.Event()
+    errors = []
+
+    def handoff(callback, value):
+        callback(value)
+
+    SetupRunner(handoff).run(
+        lambda: (_ for _ in ()).throw(
+            PairingError("adapter setup failed", report_path="/tmp/quirks-fail.json")
+        ),
+        lambda _value: None,
+        lambda error: (errors.append(error), completed.set()),
+    )
+
+    assert completed.wait(1)
+    assert errors == ["adapter setup failed"]


### PR DESCRIPTION
## Summary

Pairing now writes a local, attachable report whenever setup finishes or fails, so issues like #1 and #2 can be compared without asking people to paste `btmon` or their iPhone’s MAC.

- Save the last ten scrubbed JSON reports next to BlueFerry’s state directory.
- Record controller identity (chipset when we can resolve it), BlueZ version/`-E`, session desktop and Bluetooth owners, bonded vs setup-complete, MAP/PBAP/ANCS, subscribed vs authorized, and the last LE connect error name and message.
- Redact MACs, BlueZ device paths, and home/XDG prefixes so the file is safe to attach publicly.
- GTK, Qt, and Quickshell keep a **Report Pairing Issue** button under Pair. The CLI points at `blueferry pairing-issue`.
- That flow opens a GitHub new-issue URL with the `pairing-issue` label, a title like `Pairing issue: MediaTek MT7921 — MAP/PBAP success, ANCS fail`, and the report JSON in the body (plus blanks for iPhone model and iOS version).

This does not add an adapter picker. A second controller still needs `BLUEFERRY_ADAPTER` until that lands separately.

## Test plan

- [x] `pytest` on pairing/report/client tests (158 passed)
- [ ] Pair once (success or ANCS-down) and confirm `~/.local/state/blueferry/quirks-*.json` is written without a MAC or `$HOME`
- [ ] Confirm **Report Pairing Issue** sits under the Pair button and opens a GitHub form with label, chipset title, and JSON body
- [ ] `blueferry pairing-issue --no-open` prints the same URL
- [ ] Create the `pairing-issue` label on the repo if it does not exist yet