### PR TITLE
Let users pick a Bluetooth adapter when pairing

### DIFF
--- a/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
@@ -40,6 +40,12 @@
   </developer>
 
   <releases>
+    <release version="0.6.3" date="2026-08-13">
+      <description>
+        <p>Lets you pick a Bluetooth controller when more than one is present
+        and keeps pairing, scanning, and forget on that radio.</p>
+      </description>
+    </release>
     <release version="0.6.2" date="2026-08-10">
       <description>
         <p>Improves interactive Bluetooth pairing, diagnostics, and handling

--- a/data/io.weirdware.BlueFerry.Qt.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Qt.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.6.3" date="2026-08-13"><description><p>Lets you pick a Bluetooth controller when more than one is present and keeps pairing, scanning, and forget on that radio.</p></description></release>
     <release version="0.6.2" date="2026-08-10"><description><p>Improves interactive Bluetooth pairing, diagnostics, and forgotten-device handling.</p></description></release>
     <release version="0.6.1" date="2026-08-10"><description><p>Adds KDE tray integration and notification deep links.</p></description></release>
     <release version="0.6.0" date="2026-08-08"><description><p>First Qt/KDE client.</p></description></release>

--- a/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.6.3" date="2026-08-13"><description><p>Lets you pick a Bluetooth controller when more than one is present and keeps pairing, scanning, and forget on that radio.</p></description></release>
     <release version="0.6.2" date="2026-08-10"><description><p>Improves interactive Bluetooth pairing, diagnostics, and forgotten-device handling.</p></description></release>
     <release version="0.6.1" date="2026-08-10"><description><p>Adds notification deep links and backend upgrade handling.</p></description></release>
     <release version="0.6.0" date="2026-08-08"><description><p>First standalone Quickshell client.</p></description></release>

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -32,12 +32,15 @@ ShellRoot {
   property bool targetBonded: false
   property bool bondStateKnown: false
   property string configuredMac: ""
+  property string configuredAdapter: ""
   property bool pairingConfirmationPending: false
   property string pairingPasskey: ""
   property bool pairingResultReceived: false
   property string pairingIssueReport: ""
   property var pendingPairingDevice: null
   property string adapterName: ""
+  property bool scanAfterCompatibility: false
+  property var adapters: []
   property string onboardingStage: onboarding.stage
   property var backendStatus: ({})
   property string notificationPolicy: "messages"
@@ -166,11 +169,20 @@ ShellRoot {
     }
   }
 
+  function loadCompatibility(adapter) {
+    if (compatibilityProcess.running) return
+    compatibilityProcess.command = adapter
+      ? ["/usr/bin/blueferry", "pairing-compatibility-json", "--adapter", adapter]
+      : ["/usr/bin/blueferry", "pairing-compatibility-json"]
+    compatibilityProcess.running = true
+  }
+
   function loadPairingDevices(scan) {
     if (deviceProcess.running) return
-    deviceProcess.command = scan
-      ? ["/usr/bin/blueferry", "pairing-devices-json", "--scan-seconds", "8"]
-      : ["/usr/bin/blueferry", "pairing-devices-json"]
+    var command = ["/usr/bin/blueferry", "pairing-devices-json"]
+    if (scan) command.push("--scan-seconds", "24")
+    if (root.adapterName) command.push("--adapter", root.adapterName)
+    deviceProcess.command = command
     pairingStatus = scan ? "Scanning for Bluetooth devices…" : pairingStatus
     deviceProcess.running = true
   }
@@ -186,6 +198,8 @@ ShellRoot {
     pairProcess.command = [
       "/usr/bin/blueferry", "pairing-complete", device.mac, "--interactive-agent"
     ]
+    if (root.adapterName)
+      pairProcess.command.push("--adapter", root.adapterName)
     if (replaceSavedTarget)
       pairProcess.command.push("--replace-saved-mac", configuredMac)
     pairProcess.running = true
@@ -245,6 +259,12 @@ ShellRoot {
       root.targetBonded = true
       root.bondStateKnown = true
       root.configuredMac = parsed.device ? (parsed.device.mac || "") : ""
+      root.configuredAdapter = root.adapterName
+      if (parsed.device && parsed.device.adapter_path) {
+        var parts = String(parsed.device.adapter_path).split("/")
+        if (parts.length)
+          root.configuredAdapter = parts[parts.length - 1]
+      }
       root.loadPairingDevices(false)
       root.reload()
     } catch (error) {
@@ -293,8 +313,19 @@ ShellRoot {
           root.pairingReady = parsed.pairing_ready === true
           root.bluezActive = parsed.bearer_api_active === true
           root.adapterName = parsed.adapter || ""
+          root.adapters = Array.isArray(parsed.adapters) ? parsed.adapters : []
+          if (adapterCombo.count > 0) {
+            for (var index = 0; index < root.adapters.length; ++index) {
+              if (root.adapters[index].name === root.adapterName) {
+                adapterCombo.currentIndex = index
+                break
+              }
+            }
+          }
           if (!root.hardwareSupported) root.pairingStatus = parsed.issue || "Bluetooth controller is incompatible."
-          root.loadPairingDevices(false)
+          var scan = root.scanAfterCompatibility
+          root.scanAfterCompatibility = false
+          root.loadPairingDevices(scan)
         } catch (error) {
           root.markCompatibilityUnavailable("Bluetooth compatibility check returned invalid data.")
         }
@@ -319,6 +350,7 @@ ShellRoot {
           root.bondStateKnown = typeof parsed.bonded === "boolean"
           root.targetBonded = parsed.bonded === true
           root.configuredMac = root.targetSaved ? (parsed.mac || "") : ""
+          root.configuredAdapter = root.targetSaved ? (parsed.adapter || "") : ""
           if (typeof parsed.pairing_issue_report === "string")
             root.pairingIssueReport = parsed.pairing_issue_report
           if (root.targetSaved && root.bondStateKnown && !root.targetBonded)
@@ -546,8 +578,8 @@ ShellRoot {
           if (parsed.ok) {
             root.bluezActive = true
             root.pairingStatus = "Bluetooth support activated. Scan for the iPhone."
-            root.loadPairingDevices(true)
-            compatibilityProcess.running = true
+            root.scanAfterCompatibility = true
+            root.loadCompatibility(root.adapterName)
           } else {
             root.pairingStatus = parsed.error || "Bluetooth activation failed."
           }
@@ -601,6 +633,7 @@ ShellRoot {
             root.targetBonded = false
             root.bondStateKnown = true
             root.configuredMac = ""
+            root.configuredAdapter = ""
             root.backendStatus = ({})
             root.pairingDevices = []
             root.loadPairingDevices(false)
@@ -1234,6 +1267,18 @@ ShellRoot {
               confirmBluetoothRestart.checked = false
             }
           }
+          FerryComboBox {
+            id: adapterCombo
+            visible: !root.configured && root.adapters.length > 1
+            Layout.fillWidth: true
+            model: root.adapters
+            textRole: "label"
+            onActivated: {
+              var option = root.adapters[currentIndex]
+              if (option && option.name && option.name !== root.adapterName)
+                root.loadCompatibility(option.name)
+            }
+          }
           FerryButton {
             visible: !root.configured
             text: deviceProcess.running ? "Scanning…" : "1. Scan for iPhone"
@@ -1315,6 +1360,8 @@ ShellRoot {
               enabled: root.configuredMac !== "" && !forgetProcess.running
               onClicked: {
                 forgetProcess.command = ["/usr/bin/blueferry", "pairing-forget", root.configuredMac]
+                if (root.configuredAdapter)
+                  forgetProcess.command.push("--adapter", root.configuredAdapter)
                 forgetProcess.running = true
               }
             }

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   blueferry-qt
   blueferry-quickshell
 )
-pkgver=0.6.2
+pkgver=0.6.3
 pkgrel=1
 pkgdesc='BlueFerry Bluetooth bridge from iPhone to Linux'
 arch=('any')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueferry"
-version = "0.6.2"
+version = "0.6.3"
 description = "BlueFerry brings iPhone messages, notifications, and contacts to Linux"
 authors = [
   {name = "Erik Bourget", email = "erik@ebourget.net"},

--- a/src/blueferry/__init__.py
+++ b/src/blueferry/__init__.py
@@ -1,3 +1,3 @@
 """BlueFerry — Bluetooth bridge from a paired iPhone to Linux desktop."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -37,6 +37,25 @@ def _connect_error_parts(error: Exception) -> tuple[str, str]:
     return name[:256], message[:256]
 
 
+def preferred_bearer_unavailable(error: Exception) -> bool:
+    """True when this BlueZ build does not expose Device1.PreferredBearer.
+
+    Packaged bluetoothd reports that as UnknownProperty. Some experimental
+    trees raise org.bluez.Error.InvalidArguments with "No such property".
+    """
+    if not isinstance(error, dbus.exceptions.DBusException):
+        return False
+    name = error.get_dbus_name() or ""
+    if name in {
+        "org.freedesktop.DBus.Error.UnknownInterface",
+        "org.freedesktop.DBus.Error.UnknownMethod",
+        "org.freedesktop.DBus.Error.UnknownProperty",
+    }:
+        return True
+    detail = (error.get_dbus_message() or "").casefold()
+    return "no such property" in detail and "preferredbearer" in detail
+
+
 ReadConnected = Callable[[str], bool | None]
 Connect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
 Prefer = Callable[[str], None]
@@ -317,13 +336,9 @@ class BearerSupervisor:
             )
             log.debug("set iPhone PreferredBearer=%s", kind)
         except dbus.exceptions.DBusException as error:
-            if error.get_dbus_name() in {
-                "org.freedesktop.DBus.Error.UnknownInterface",
-                "org.freedesktop.DBus.Error.UnknownMethod",
-                "org.freedesktop.DBus.Error.UnknownProperty",
-            }:
-                # Older BlueZ releases can still accept inbound ANCS without
-                # exposing their experimental bearer-selection API.
+            if preferred_bearer_unavailable(error):
+                # Older or partial experimental BlueZ builds can still accept
+                # inbound ANCS without exposing PreferredBearer.
                 log.debug("PreferredBearer is unavailable on this BlueZ build")
                 return
             raise

--- a/src/blueferry/bluetooth_capabilities.py
+++ b/src/blueferry/bluetooth_capabilities.py
@@ -362,60 +362,55 @@ def bluez_stack(
     return stack
 
 
-def compatibility(
-    requested: str,
-    *,
-    adapter_name: str | None,
-    object_manager,
-    run_command: RunCommand,
-    support_status: Callable[[], dict],
-) -> dict:
-    """Describe supported profiles from capabilities, never vendor names."""
-    try:
-        managed = object_manager().GetManagedObjects()
-        adapters = [
-            str(path).rsplit("/", 1)[-1]
-            for path, interfaces in managed.items()
-            if "org.bluez.Adapter1" in interfaces
-        ]
-    except dbus.exceptions.DBusException:
-        adapters = []
-    candidates = (
-        [adapter_name]
-        if adapter_name is not None
-        else list(dict.fromkeys([requested, *adapters]))
+def _hci_sort_key(name: str) -> tuple[int, int | str]:
+    suffix = name[3:] if name.startswith("hci") else name
+    if suffix.isdigit():
+        return (0, int(suffix))
+    return (1, name)
+
+
+def _pairing_capable(inspected: tuple | None) -> bool:
+    if inspected is None:
+        return False
+    available, _supported, _current, _error, _identity, fields = inspected
+    return bool(available and fields["classic"] and fields["secure_pairing"])
+
+
+def adapter_label(name: str, hardware: dict[str, object] | None = None) -> str:
+    """Human controller name plus the hci index so two cards stay distinct."""
+    hardware = hardware or {}
+    vendor = str(hardware.get("vendor") or "").strip()
+    product = str(hardware.get("product") or "").strip()
+    chip = chipset_name(
+        usb_id=str(hardware.get("usb_id") or ""),
+        pci_id=str(hardware.get("pci_id") or ""),
+        driver=str(hardware.get("driver") or ""),
+        product=product,
     )
-    selected = None
-    fallback = None
-    for candidate in candidates:
-        inspected = (
-            candidate,
-            *controller_settings(candidate, run_command=run_command),
-        )
-        if fallback is None:
-            fallback = inspected
-        _name, available, settings, _current, _error, _identity = inspected
-        classic = bool({"br/edr", "bredr"} & settings)
-        secure = bool({"ssp", "secure-conn"} & settings)
-        if available and classic and secure:
-            selected = inspected
-            break
-    adapter, available, supported, current, command_error, identity = (
-        selected
-        or fallback
-        or (requested, False, set(), set(), "No adapter found", {})
-    )
+    pretty = chip or (product if product and not is_generic_product(product) else "")
+    if vendor and pretty:
+        pretty = pretty if vendor.casefold() in pretty.casefold() else f"{vendor} {pretty}"
+    else:
+        pretty = pretty or vendor
+    if pretty:
+        return f"{pretty} ({name})"
+    return name
+
+
+def _profile_fields(
+    adapter: str,
+    available: bool,
+    supported: set[str],
+    current: set[str],
+    command_error: str,
+    bearer_active: bool,
+) -> dict[str, object]:
     classic = bool({"br/edr", "bredr"} & supported)
     low_energy = "le" in supported
     advertising = "advertising" in supported
     secure_pairing = bool({"ssp", "secure-conn"} & supported)
     messages_supported = available and classic and secure_pairing
     notifications_supported = available and low_energy and advertising
-    try:
-        bearer_active = bool(support_status()["active"])
-    except PairingError:
-        bearer_active = False
-
     missing = [
         label for present, label in (
             (classic, "BR/EDR"), (secure_pairing, "secure pairing")
@@ -431,8 +426,7 @@ def compatibility(
         issue = "Messages and contacts are supported; per-app notifications are not"
     else:
         issue = ""
-    result: dict[str, object] = {
-        "adapter": adapter,
+    return {
         "available": available,
         "powered": "powered" in current,
         "classic": classic,
@@ -450,6 +444,91 @@ def compatibility(
         "issue": issue,
         "supported_settings": sorted(supported),
         "current_settings": sorted(current),
+    }
+
+
+def compatibility(
+    requested: str,
+    *,
+    adapter_name: str | None,
+    object_manager,
+    run_command: RunCommand,
+    support_status: Callable[[], dict],
+) -> dict:
+    """Describe supported profiles from capabilities, never vendor names."""
+    try:
+        managed = object_manager().GetManagedObjects()
+        discovered = [
+            str(path).rsplit("/", 1)[-1]
+            for path, interfaces in managed.items()
+            if "org.bluez.Adapter1" in interfaces
+        ]
+    except dbus.exceptions.DBusException:
+        discovered = []
+    names: list[str] = []
+    for name in discovered:
+        if name and is_valid_adapter(name) and name not in names:
+            names.append(name)
+    if (
+        adapter_name
+        and is_valid_adapter(adapter_name)
+        and adapter_name not in names
+    ):
+        names.append(adapter_name)
+    if not names and requested and is_valid_adapter(requested):
+        names = [requested]
+    names.sort(key=_hci_sort_key)
+    try:
+        bearer_active = bool(support_status()["active"])
+    except PairingError:
+        bearer_active = False
+    options: list[dict[str, object]] = []
+    inspected: dict[str, tuple] = {}
+    for name in names:
+        available, supported, current, error, identity = controller_settings(
+            name, run_command=run_command,
+        )
+        hardware = controller_hardware(name, run_command=None)
+        manufacturer_id = identity.get("manufacturer_id")
+        if isinstance(manufacturer_id, int):
+            apply_company_id(hardware, manufacturer_id)
+        else:
+            apply_chipset(hardware)
+            hardware["summary"] = _hardware_summary(hardware)
+        fields = _profile_fields(
+            name, available, supported, current, error, bearer_active,
+        )
+        options.append(
+            {
+                "name": name,
+                "label": adapter_label(name, hardware),
+                "available": bool(fields["available"]),
+                "powered": bool(fields["powered"]),
+                "hardware_supported": bool(fields["hardware_supported"]),
+                "notifications_supported": bool(fields["notifications_supported"]),
+                "pairing_ready": bool(fields["pairing_ready"]),
+                "issue": str(fields["issue"]),
+            }
+        )
+        inspected[name] = (available, supported, current, error, identity, fields)
+    if adapter_name is not None and adapter_name in inspected:
+        chosen = adapter_name
+    elif _pairing_capable(inspected.get(requested)):
+        chosen = requested
+    else:
+        chosen = next(
+            (
+                str(option["name"])
+                for option in options
+                if _pairing_capable(inspected.get(str(option["name"])))
+            ),
+            names[0],
+        )
+    _available, _supported, _current, _error, identity, fields = inspected[str(chosen)]
+    result: dict[str, object] = {
+        "adapter": chosen,
+        **fields,
+        "adapters": options,
     }
     if "manufacturer_id" in identity:
         result["manufacturer_id"] = identity["manufacturer_id"]

--- a/src/blueferry/cli.py
+++ b/src/blueferry/cli.py
@@ -144,6 +144,7 @@ def pair_setup(
 @app.command("pairing-devices-json", hidden=True)
 def pairing_devices_json(
     scan_seconds: int = typer.Option(0, "--scan-seconds", min=0, max=30),
+    adapter: str = typer.Option("", "--adapter"),
 ) -> None:
     """List Bluetooth devices for graphical setup clients."""
     import json
@@ -155,8 +156,10 @@ def pairing_devices_json(
     try:
         setup = SetupClient()
         configuration = setup.configuration()
+        selected = adapter.strip() or None
         devices = iphone_candidates(
-            setup.devices(scan_seconds=scan_seconds),
+            setup.devices(scan_seconds=scan_seconds, adapter=selected),
+            adapter=selected or "",
             configured_mac=configuration.mac,
             include_unpaired=scan_seconds > 0,
         )
@@ -182,7 +185,9 @@ def pairing_bluez_status_json() -> None:
 
 
 @app.command("pairing-compatibility-json", hidden=True)
-def pairing_compatibility_json() -> None:
+def pairing_compatibility_json(
+    adapter: str = typer.Option("", "--adapter"),
+) -> None:
     """Report controller capabilities for graphical setup clients."""
     import json
 
@@ -190,7 +195,8 @@ def pairing_compatibility_json() -> None:
     from blueferry.setup_client import SetupClient
 
     try:
-        typer.echo(json.dumps(SetupClient().compatibility().to_dict()))
+        selected = adapter.strip() or None
+        typer.echo(json.dumps(SetupClient().compatibility(selected).to_dict()))
     except PairingError as error:
         typer.echo(json.dumps({"hardware_supported": False, "error": str(error)}))
         raise typer.Exit(code=2) from None
@@ -226,6 +232,7 @@ def pairing_activate_bluez() -> None:
 def pairing_complete(
     mac: str,
     interactive_agent: bool = typer.Option(False, "--interactive-agent", hidden=True),
+    adapter: str = typer.Option("", "--adapter"),
     replace_saved_mac: str = typer.Option("", "--replace-saved-mac", hidden=True),
     debug: bool = typer.Option(False, "--debug"),
 ) -> None:
@@ -256,10 +263,13 @@ def pairing_complete(
 
     try:
         setup = SetupClient()
+        selected = adapter.strip() or None
         if replace_saved_mac:
-            setup.prepare_replacement(replace_saved_mac, mac)
+            saved = setup.configuration().adapter or None
+            setup.prepare_replacement(replace_saved_mac, mac, adapter=saved)
         result = setup.complete(
             mac,
+            adapter=selected,
             confirmation=confirm if interactive_agent else None,
             display=display if interactive_agent else None,
         )
@@ -307,7 +317,10 @@ def pairing_issue(
 
 
 @app.command("pairing-forget", hidden=True)
-def pairing_forget(mac: str) -> None:
+def pairing_forget(
+    mac: str,
+    adapter: str = typer.Option("", "--adapter"),
+) -> None:
     """Unpair the phone and clear it from BlueFerry configuration."""
     import json
 
@@ -315,7 +328,9 @@ def pairing_forget(mac: str) -> None:
     from blueferry.setup_client import SetupClient
 
     try:
-        SetupClient().forget(mac)
+        setup = SetupClient()
+        selected = adapter.strip() or setup.configuration().adapter or None
+        setup.forget(mac, adapter=selected)
         typer.echo(json.dumps({"ok": True, "mac": mac.upper()}))
     except PairingError as error:
         typer.echo(json.dumps({"ok": False, "error": str(error)}))

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -14,6 +14,7 @@ from gi.repository import GLib
 
 from blueferry import bluetooth_capabilities as capabilities
 from blueferry import config, quirks_report
+from blueferry.bearer_supervisor import preferred_bearer_unavailable
 from blueferry.bluetooth_devices import PairedDevice
 from blueferry.bus import get_session_bus, get_system_bus
 from blueferry.commands import run_command
@@ -33,6 +34,10 @@ _SESSION_BLUETOOTH_NAMES = (
     "org.gnome.SettingsDaemon.Rfkill",
 )
 CLASSIC_SETTLE_SECONDS = 3.0
+# One BR/EDR inquiry is 10.24s. USB dongles also need a moment to start
+# after another adapter is stopped; 8s was aborting mid-inquiry.
+DISCOVERY_SECONDS = 24
+MAX_DISCOVERY_SECONDS = 30
 
 ConfirmationCallback = Callable[[int | None], bool]
 DisplayCallback = Callable[[int], None]
@@ -152,32 +157,81 @@ def list_devices(*, paired_only: bool = False) -> list[PairedDevice]:
     )
 
 
-def discover_devices(seconds: int = 8) -> list[PairedDevice]:
-    """Scan through BlueZ and return paired and newly discovered devices."""
-    seconds = max(1, min(int(seconds), 30))
-    adapter_path = f"/org/bluez/{config.ADAPTER}"
-    discovered: list[PairedDevice] = []
+def _adapter_paths(objects: dict) -> list[str]:
+    return [
+        str(path) for path, ifaces in objects.items() if "org.bluez.Adapter1" in ifaces
+    ]
+
+
+def _resolve_adapter_path(
+    adapters: list[str], preferred: str, *, required: bool,
+) -> str:
+    match = next((path for path in adapters if path.endswith(f"/{preferred}")), None)
+    if match is not None:
+        return match
+    if required:
+        raise PairingError(f"Bluetooth adapter {preferred} is not available")
+    if adapters:
+        return adapters[0]
+    return f"/org/bluez/{preferred}"
+
+
+def _stop_discovery(path: str) -> None:
     try:
-        objects = _object_manager().GetManagedObjects()
-        adapters = [str(path) for path, ifaces in objects.items() if "org.bluez.Adapter1" in ifaces]
-        if adapters:
-            adapter_path = next(
-                (path for path in adapters if path.endswith(f"/{config.ADAPTER}")),
-                adapters[0],
-            )
-        obj = get_system_bus().get_object("org.bluez", adapter_path)
+        radio = dbus.Interface(
+            get_system_bus().get_object("org.bluez", path),
+            "org.bluez.Adapter1",
+        )
+        radio.StopDiscovery()
+    except dbus.exceptions.DBusException as error:
+        log.debug("Could not stop discovery on %s: %s", path, error)
+
+
+def _on_adapter(device: PairedDevice, adapter: str) -> bool:
+    return device.adapter_path.endswith(f"/{adapter}")
+
+
+def discover_devices(
+    seconds: int = DISCOVERY_SECONDS, *, adapter: str | None = None,
+) -> list[PairedDevice]:
+    """Scan through BlueZ and return devices seen on the selected adapter."""
+    seconds = max(1, min(int(seconds), MAX_DISCOVERY_SECONDS))
+    if adapter:
+        if not config.is_valid_adapter(adapter):
+            raise PairingError("invalid Bluetooth adapter name")
+        preferred = adapter
+        required = True
+    else:
+        preferred = config.ADAPTER
+        required = False
+    adapter_path = f"/org/bluez/{preferred}"
+    selected = preferred
+    discovered: list[PairedDevice] = []
+    radio = None
+    try:
+        adapters = _adapter_paths(_object_manager().GetManagedObjects())
+        adapter_path = _resolve_adapter_path(adapters, preferred, required=required)
+        selected = adapter_path.rsplit("/", 1)[-1]
+        bus = get_system_bus()
+        for other in adapters:
+            if other != adapter_path:
+                _stop_discovery(other)
+        obj = bus.get_object("org.bluez", adapter_path)
         props = dbus.Interface(obj, "org.freedesktop.DBus.Properties")
-        adapter = dbus.Interface(obj, "org.bluez.Adapter1")
+        radio = dbus.Interface(obj, "org.bluez.Adapter1")
         props.Set("org.bluez.Adapter1", "Powered", dbus.Boolean(True))
         try:
-            adapter.StartDiscovery()
+            radio.StartDiscovery()
         except dbus.exceptions.DBusException as error:
             if error.get_dbus_name() != "org.bluez.Error.InProgress":
                 raise
         deadline = time.monotonic() + seconds
         while True:
             discovered = list_devices()
-            if any(device.likely_iphone for device in discovered):
+            if any(
+                device.likely_iphone and _on_adapter(device, selected)
+                for device in discovered
+            ):
                 break
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -188,11 +242,12 @@ def discover_devices(seconds: int = 8) -> list[PairedDevice]:
             error.get_dbus_message() or error.get_dbus_name() or str(error)
         ) from error
     finally:
-        try:
-            adapter.StopDiscovery()
-        except (UnboundLocalError, dbus.exceptions.DBusException):
-            pass
-    return discovered or list_devices()
+        if radio is not None:
+            try:
+                radio.StopDiscovery()
+            except dbus.exceptions.DBusException:
+                pass
+    return [device for device in discovered if _on_adapter(device, selected)]
 
 
 def trust_device(mac: str, adapter_path: str) -> None:
@@ -204,30 +259,53 @@ def trust_device(mac: str, adapter_path: str) -> None:
     props.Set("org.bluez.Device1", "Trusted", dbus.Boolean(True))
 
 
-def _find_device(mac: str) -> PairedDevice | None:
-    normalized = mac.strip().upper()
-    for device in list_devices():
-        if device.mac.upper() == normalized:
-            return device
-    return None
+def _requested_adapter(adapter: str | None) -> str:
+    value = (adapter or "").strip()
+    if not value:
+        return ""
+    if not config.is_valid_adapter(value):
+        raise PairingError("invalid Bluetooth adapter name")
+    return value
 
 
-def _device(mac: str) -> PairedDevice:
+def _find_device(mac: str, *, adapter: str | None = None) -> PairedDevice | None:
     normalized = mac.strip().upper()
-    device = _find_device(normalized)
+    selected = _requested_adapter(adapter)
+    matches = [
+        device for device in list_devices() if device.mac.upper() == normalized
+    ]
+    if selected:
+        return next(
+            (device for device in matches if _on_adapter(device, selected)),
+            None,
+        )
+    adapters = {device.adapter_path for device in matches}
+    if len(adapters) > 1:
+        raise PairingError(
+            "This iPhone is present on more than one Bluetooth controller; "
+            "select a controller and pair again"
+        )
+    return matches[0] if matches else None
+
+
+def _device(mac: str, *, adapter: str | None = None) -> PairedDevice:
+    normalized = mac.strip().upper()
+    device = _find_device(normalized, adapter=adapter)
     if device is not None:
         return device
     raise PairingError(f"Bluetooth device {normalized} is no longer available; scan again")
 
 
-def _wait_for_paired_device(mac: str, *, timeout: float = 120) -> PairedDevice:
+def _wait_for_paired_device(
+    mac: str, *, adapter: str | None = None, timeout: float = 120,
+) -> PairedDevice:
     """Wait for a local or iPhone-initiated pairing transaction to settle."""
     log.debug("waiting up to %.0fs for the %s pairing record to settle", timeout, mac)
     deadline = time.monotonic() + timeout
-    device = _device(mac)
+    device = _device(mac, adapter=adapter)
     while not device.paired and time.monotonic() < deadline:
         time.sleep(0.25)
-        device = _device(mac)
+        device = _device(mac, adapter=adapter)
     if not device.paired:
         raise PairingError(
             "Bluetooth pairing did not finish. Keep the iPhone unlocked with "
@@ -358,7 +436,7 @@ def _connect_classic(
 
 
 def _prefer_bredr(device_path: str) -> None:
-    """Force the post-pair Device1.Connect transaction onto BR/EDR."""
+    """Prefer BR/EDR after pairing when BlueZ exposes PreferredBearer."""
     log.info(
         "setting Device1.PreferredBearer=bredr before post-pair connection"
     )
@@ -371,8 +449,13 @@ def _prefer_bredr(device_path: str) -> None:
             dbus.String("bredr"),
         )
     except dbus.exceptions.DBusException as error:
-        name = error.get_dbus_name() or ""
-        detail = error.get_dbus_message() or name or str(error)
+        if preferred_bearer_unavailable(error):
+            log.info(
+                "Device1.PreferredBearer is unavailable; "
+                "continuing with the existing Classic connection"
+            )
+            return
+        detail = error.get_dbus_message() or error.get_dbus_name() or str(error)
         raise PairingError(
             f"Could not select the BR/EDR bearer for the post-pair "
             f"connection: {detail}"
@@ -477,16 +560,15 @@ def _connect_ancs(device: PairedDevice, *, timeout: float = 30.0) -> str:
         log.debug("setting Device1.PreferredBearer=le")
         props.Set("org.bluez.Device1", "PreferredBearer", dbus.String("le"))
     except dbus.exceptions.DBusException as error:
-        name = error.get_dbus_name() or ""
-        if name in {
-            "org.freedesktop.DBus.Error.UnknownInterface",
-            "org.freedesktop.DBus.Error.UnknownMethod",
-            "org.freedesktop.DBus.Error.UnknownProperty",
-        }:
-            return "waiting for iPhone to connect"
-        raise PairingError(
-            error.get_dbus_message() or name or str(error)
-        ) from error
+        if preferred_bearer_unavailable(error):
+            log.debug(
+                "Device1.PreferredBearer is unavailable; connecting LE without it"
+            )
+        else:
+            name = error.get_dbus_name() or ""
+            raise PairingError(
+                error.get_dbus_message() or name or str(error)
+            ) from error
     for attempt in range(2):
         try:
             log.info("sending Bearer.LE1.Connect (attempt %d/2)", attempt + 1)
@@ -554,6 +636,7 @@ def _stop_user_service() -> None:
 def complete_pairing(
     mac: str,
     *,
+    adapter: str | None = None,
     confirmation: ConfirmationCallback | None = None,
     display: DisplayCallback | None = None,
 ) -> dict:
@@ -561,7 +644,11 @@ def complete_pairing(
     attempt = quirks_report.start_attempt(interactive=confirmation is not None)
     try:
         result = _execute_pairing(
-            mac, confirmation=confirmation, display=display, attempt=attempt,
+            mac,
+            adapter=adapter,
+            confirmation=confirmation,
+            display=display,
+            attempt=attempt,
         )
     except PairingError as error:
         path = _record_pairing_report(attempt, error=error)
@@ -658,6 +745,101 @@ def _compatibility_fields(compatibility: dict) -> dict:
     }
 
 
+def _bluetooth_uuid(code: int) -> str:
+    return f"0000{code:04x}-0000-1000-8000-00805f9b34fb"
+
+
+_LOCAL_SERVICE_NAMES = {
+    _bluetooth_uuid(0x1101): "serial-port",
+    _bluetooth_uuid(0x1105): "obex-object-push",
+    _bluetooth_uuid(0x1106): "obex-file-transfer",
+    _bluetooth_uuid(0x1108): "headset",
+    _bluetooth_uuid(0x110A): "audio-source",
+    _bluetooth_uuid(0x110B): "audio-sink",
+    _bluetooth_uuid(0x110C): "avrcp-target",
+    _bluetooth_uuid(0x110E): "avrcp",
+    _bluetooth_uuid(0x1112): "headset-audio-gateway",
+    _bluetooth_uuid(0x111E): "handsfree",
+    _bluetooth_uuid(0x111F): "handsfree-audio-gateway",
+    _bluetooth_uuid(0x112E): "phonebook-access-client",
+    _bluetooth_uuid(0x112F): "phonebook-access-server",
+    _bluetooth_uuid(0x1132): "message-access-server",
+    _bluetooth_uuid(0x1133): "message-notification-server",
+    _bluetooth_uuid(0x1134): "message-access-client",
+    _bluetooth_uuid(0x1200): "pnp-information",
+    _bluetooth_uuid(0x1800): "generic-access",
+    _bluetooth_uuid(0x1801): "generic-attribute",
+    _bluetooth_uuid(0x180A): "device-information",
+}
+
+# Kernel experimental features published as Adapter1.ExperimentalFeatures.
+# These are not the same as bluetoothd -E D-Bus APIs such as PreferredBearer.
+_EXPERIMENTAL_FEATURE_NAMES = {
+    "d4992530-b9ec-469f-ab01-6c481c47da1c": "debug",
+    "671b10b5-42c0-4696-9227-eb28d1b049d6": "simultaneous-central-peripheral",
+    "15c0a148-c273-11ea-b3de-0242ac130004": "ll-privacy",
+    "330859bc-7506-492d-9370-9a6f0614037f": "bluetooth-quality-report",
+    "a6695ace-ee7f-4fb9-881a-5fac66c629af": "offload-codecs",
+    "6fbaf188-05e0-496a-9885-d6ddfdb4e03e": "iso-socket",
+}
+
+
+def _decode_uuid_list(value: object, names: dict[str, str]) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    decoded: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        uuid = str(item).strip().casefold()
+        if not uuid:
+            continue
+        label = names.get(uuid, uuid)
+        if label in seen:
+            continue
+        seen.add(label)
+        decoded.append(label)
+    decoded.sort()
+    return decoded
+
+
+def _cod_handsfree(cod: int) -> bool:
+    major = (cod >> 8) & 0x1F
+    minor = (cod >> 2) & 0x3F
+    return major == config.COD_MAJOR and (minor << 2) == config.COD_MINOR
+
+
+def _adapter_dbus_fields(adapter: str) -> dict[str, object]:
+    """Read Adapter1 Class, local UUIDs, and kernel experimental features."""
+    if not config.is_valid_adapter(adapter):
+        return {}
+    try:
+        props = dbus.Interface(
+            get_system_bus().get_object("org.bluez", f"/org/bluez/{adapter}"),
+            "org.freedesktop.DBus.Properties",
+        )
+        values = dict(props.GetAll("org.bluez.Adapter1", timeout=5.0))
+    except Exception:
+        log.debug("could not read adapter D-Bus properties", exc_info=True)
+        return {}
+    fields: dict[str, object] = {}
+    raw_class = values.get("Class")
+    if raw_class is not None:
+        try:
+            cod = int(raw_class)
+        except (TypeError, ValueError):
+            pass
+        else:
+            fields["cod"] = f"0x{cod:06x}"
+            fields["cod_handsfree"] = _cod_handsfree(cod)
+    if "UUIDs" in values:
+        fields["uuids"] = _decode_uuid_list(values.get("UUIDs"), _LOCAL_SERVICE_NAMES)
+    if "ExperimentalFeatures" in values:
+        fields["experimental_features"] = _decode_uuid_list(
+            values.get("ExperimentalFeatures"), _EXPERIMENTAL_FEATURE_NAMES,
+        )
+    return fields
+
+
 def _controller_snapshot(adapter: str, compatibility: dict) -> dict:
     controller = _adapter_identity(adapter, compatibility)
     controller.update(_compatibility_fields(compatibility))
@@ -671,6 +853,7 @@ def _controller_snapshot(adapter: str, compatibility: dict) -> dict:
         )
     except Exception:
         log.debug("could not inspect the BlueZ stack", exc_info=True)
+    controller.update(_adapter_dbus_fields(adapter))
     return controller
 
 
@@ -855,22 +1038,25 @@ def _pairing_outcome(
 def _execute_pairing(
     mac: str,
     *,
+    adapter: str | None = None,
     confirmation: ConfirmationCallback | None = None,
     display: DisplayCallback | None = None,
     attempt: dict,
 ) -> dict:
     from blueferry import bluez_setup
 
-    device = _device(mac)
+    requested = _requested_adapter(adapter)
+    device = _device(mac, adapter=requested or None)
+    adapter = requested or device.adapter_path.rsplit("/", 1)[-1]
     log.info(
-        "starting setup for %s (%s): paired=%s trusted=%s connected=%s",
+        "starting setup for %s (%s) on %s: paired=%s trusted=%s connected=%s",
         device.name,
         device.mac,
+        adapter,
         device.paired,
         device.trusted,
         device.connected,
     )
-    adapter = device.adapter_path.rsplit("/", 1)[-1]
     session = attempt.setdefault("session", quirks_report.session_environment())
     if isinstance(session, dict):
         session["bluetooth_owners"] = _bluetooth_session_owners()
@@ -979,7 +1165,7 @@ def _execute_pairing(
                     }:
                         detail = f"Bluetooth confirmation did not complete: {detail}"
                     raise PairingError(detail) from error
-            device = _wait_for_paired_device(mac)
+            device = _wait_for_paired_device(mac, adapter=adapter)
             quirks_report.mark(attempt, "paired")
             _snapshot_phone(attempt, device)
         log.debug("setting Device1.Trusted=true for %s", device.device_path)
@@ -1007,7 +1193,7 @@ def _execute_pairing(
         # Start the long-lived owner while both the advert and temporary
         # pairing agent are still present.  Its first operation is a Classic
         # MAP/PBAP open; only when that attempt completes does it enable LE.
-        write_local_env(device.mac, device.adapter_path.rsplit("/", 1)[-1])
+        write_local_env(device.mac, adapter)
         log.debug("saved paired target %s; restarting user service", device.mac)
         quirks_report.mark(attempt, "daemon_restart_sent")
         _restart_user_service()
@@ -1037,7 +1223,7 @@ def _execute_pairing(
             if agent_registered:
                 quirks_report.mark(attempt, "agent_released")
 
-    device = _device(mac)
+    device = _device(mac, adapter=adapter)
     _snapshot_phone(attempt, device)
     return {
         "ok": True,
@@ -1056,12 +1242,12 @@ def _execute_pairing(
     }
 
 
-def forget_device(mac: str) -> None:
+def forget_device(mac: str, *, adapter: str | None = None) -> None:
     """Stop BlueFerry, remove the local bond, and clear the selected phone."""
     normalized = mac.strip().upper()
     if not config.is_valid_mac(normalized):
         raise PairingError("invalid Bluetooth device address")
-    device = _find_device(normalized)
+    device = _find_device(normalized, adapter=adapter)
     log.info("stopping the user service before forgetting target %s", normalized)
     _stop_user_service()
     if device is not None:
@@ -1082,15 +1268,17 @@ def forget_device(mac: str) -> None:
     log.info("cleared configured BlueFerry target %s", normalized)
 
 
-def prepare_target_replacement(previous_mac: str, next_mac: str) -> None:
+def prepare_target_replacement(
+    previous_mac: str, next_mac: str, *, adapter: str | None = None,
+) -> None:
     """Clear the saved target without losing the unpaired device being selected."""
     previous = previous_mac.strip().upper()
     selected = next_mac.strip().upper()
     if not config.is_valid_mac(previous) or not config.is_valid_mac(selected):
         raise PairingError("invalid Bluetooth device address")
-    device = _find_device(previous)
+    device = _find_device(previous, adapter=adapter)
     if previous != selected or (device is not None and device.paired):
-        forget_device(previous)
+        forget_device(previous, adapter=adapter)
         return
     # A stale saved MAC can refer to the unpaired device just discovered for
     # this attempt. Removing that BlueZ object would also remove the scan

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -11,7 +11,7 @@ from blueferry.bluetooth_devices import iphone_candidates
 from blueferry.client import BackendClient, BackendError
 from blueferry.errors import PairingError
 from blueferry.quirks_report import cli_issue_hint
-from blueferry.setup_client import SetupClient
+from blueferry.setup_client import DISCOVERY_SECONDS, SetupClient
 from blueferry.setup_verification import (
     NOTIFICATION_ACCESS,
     remaining_iphone_setup_tasks,
@@ -59,7 +59,10 @@ def run_wizard(*, verify_after: bool = True) -> int:
             typer.echo("Existing pairing and configuration left unchanged.")
             return 0
         try:
-            setup.forget(configuration.mac)
+            setup.forget(
+                configuration.mac,
+                adapter=getattr(configuration, "adapter", "") or None,
+            )
         except PairingError as error:
             typer.echo(typer.style(str(error), fg=typer.colors.RED))
             return 1
@@ -71,6 +74,23 @@ def run_wizard(*, verify_after: bool = True) -> int:
     except PairingError as error:
         typer.echo(typer.style(str(error), fg=typer.colors.RED))
         return 1
+    if len(compatibility.adapters) > 1:
+        typer.echo("Bluetooth controllers:\n")
+        for index, option in enumerate(compatibility.adapters, 1):
+            marker = " (selected)" if option.name == compatibility.adapter else ""
+            typer.echo(f"  [{index}] {option.label}{marker}")
+        raw = typer.prompt("Use which controller?", default="").strip()
+        if raw:
+            try:
+                picked = compatibility.adapters[int(raw) - 1]
+            except (ValueError, IndexError):
+                typer.echo(typer.style("Invalid choice.", fg=typer.colors.RED))
+                return 1
+            try:
+                compatibility = setup.compatibility(picked.name)
+            except PairingError as error:
+                typer.echo(typer.style(str(error), fg=typer.colors.RED))
+                return 1
     typer.echo(f"Controller: {compatibility.adapter}")
     if not compatibility.hardware_supported:
         typer.echo(
@@ -101,13 +121,16 @@ def run_wizard(*, verify_after: bool = True) -> int:
             return 0
         try:
             setup.activate_bluez()
+            compatibility = setup.compatibility(compatibility.adapter)
         except PairingError as error:
             typer.echo(typer.style(str(error), fg=typer.colors.RED))
             return 1
 
     typer.echo("\nUnlock the iPhone and keep Settings → Bluetooth open while scanning.")
     try:
-        devices = setup.devices(scan_seconds=8)
+        devices = setup.devices(
+            scan_seconds=DISCOVERY_SECONDS, adapter=compatibility.adapter,
+        )
     except PairingError as error:
         typer.echo(typer.style(str(error), fg=typer.colors.RED))
         return 1
@@ -165,6 +188,7 @@ def run_wizard(*, verify_after: bool = True) -> int:
     try:
         result = setup.complete(
             chosen.mac,
+            adapter=compatibility.adapter,
             confirmation=_confirm_pairing,
             display=_display_pairing_code,
         )

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -25,7 +25,7 @@ from blueferry.onboarding import derive_stage
 from blueferry.protocol import BUS_NAME, EVENTS_IFACE, OBJECT_PATH
 from blueferry.qt.tasks import Task
 from blueferry.quirks_report import issue_report, issue_url
-from blueferry.setup_client import SetupClient
+from blueferry.setup_client import DISCOVERY_SECONDS, SetupClient
 
 
 class BridgeController(QObject):
@@ -75,6 +75,7 @@ class BridgeController(QObject):
         self._configured = False
         self._target_saved = False
         self._configured_mac = ""
+        self._configured_adapter = ""
         self._setup_loaded = False
         self._onboarding_stage = str(
             derive_stage(
@@ -282,6 +283,7 @@ class BridgeController(QObject):
             self._configured = configuration.configured
             self._target_saved = configuration.saved
             self._configured_mac = configuration.mac
+            self._configured_adapter = configuration.adapter
             self._setup_loaded = True
             self.configuredChanged.emit()
             self.setupLoadedChanged.emit()
@@ -308,8 +310,13 @@ class BridgeController(QObject):
 
     @Slot()
     def loadSetupState(self) -> None:
+        self._reload_setup_state(scan_after=False)
+
+    def _reload_setup_state(self, *, scan_after: bool = False) -> None:
+        selected = str(self._compatibility.get("adapter", "")).strip() or None
+
         def operation():
-            return self._setup.compatibility(), self._setup.configuration()
+            return self._setup.compatibility(selected), self._setup.configuration()
 
         def completed(value: object) -> None:
             compatibility, configuration = value
@@ -317,6 +324,7 @@ class BridgeController(QObject):
             self._configured = configuration.configured
             self._target_saved = configuration.saved
             self._configured_mac = configuration.mac
+            self._configured_adapter = configuration.adapter
             self._setup_loaded = True
             self._bluetooth_active = compatibility.bearer_api_active
             self.compatibilityChanged.emit()
@@ -325,10 +333,32 @@ class BridgeController(QObject):
             self.bluetoothChanged.emit()
             self._update_onboarding_stage()
             self._set_pairing_issue_report(configuration.pairing_issue_report)
-            if self._devices:
+            if scan_after:
+                self.loadDevices(True)
+            elif self._devices:
                 self.loadDevices(False)
 
         self._run(operation, completed, busy=False)
+
+    @Slot(str)
+    def selectAdapter(self, name: str) -> None:
+        selected = name.strip()
+        if not selected or selected == str(self._compatibility.get("adapter", "")):
+            return
+        if self._devices:
+            self._devices = []
+            self.devicesChanged.emit()
+
+        def completed(value: object) -> None:
+            compatibility = value
+            self._compatibility = compatibility.to_dict()
+            self._bluetooth_active = bool(getattr(compatibility, "bearer_api_active", False))
+            self.compatibilityChanged.emit()
+            self.bluetoothChanged.emit()
+            self._update_onboarding_stage()
+            self.loadDevices(False)
+
+        self._run(lambda: self._setup.compatibility(selected), completed)
 
     def _snapshot(self) -> dict:
         def safely(operation, fallback):
@@ -548,16 +578,18 @@ class BridgeController(QObject):
                     )
                 )
 
+        adapter = str(self._compatibility.get("adapter", "")).strip() or None
         self._run(
-            lambda: self._setup.devices(scan_seconds=8 if scan else 0),
+            lambda: self._setup.devices(
+                scan_seconds=DISCOVERY_SECONDS if scan else 0, adapter=adapter,
+            ),
             completed,
         )
 
     @Slot()
     def activateBluetooth(self) -> None:
         def completed(_value: object) -> None:
-            self.loadSetupState()
-            self.loadDevices(True)
+            self._reload_setup_state(scan_after=True)
 
         self._run(self._setup.activate_bluez, completed)
 
@@ -574,6 +606,7 @@ class BridgeController(QObject):
             self._configured = True
             self._target_saved = True
             self._configured_mac = mac
+            self._configured_adapter = str(self._compatibility.get("adapter", ""))
             self.configuredChanged.emit()
             self._update_onboarding_stage()
             self.loadDevices(False)
@@ -605,17 +638,21 @@ class BridgeController(QObject):
             _ = passkey
 
         def operation():
-            if replace_saved_mac:
-                return self._setup.complete_isolated(
-                    mac,
-                    confirmation=confirm,
-                    display=display,
-                    replace_saved_mac=replace_saved_mac,
-                )
+            adapter = str(self._compatibility.get("adapter", "")).strip() or None
+            wanted = mac.strip().upper()
+            for item in self._devices:
+                if str(item.get("mac", "")).upper() != wanted:
+                    continue
+                path = str(item.get("adapter_path", ""))
+                if path:
+                    adapter = path.rsplit("/", 1)[-1]
+                break
             return self._setup.complete_isolated(
                 mac,
                 confirmation=confirm,
                 display=display,
+                adapter=adapter,
+                replace_saved_mac=replace_saved_mac,
             )
 
         def failed(message: str) -> None:
@@ -652,6 +689,7 @@ class BridgeController(QObject):
             self._configured = False
             self._target_saved = False
             self._configured_mac = ""
+            self._configured_adapter = ""
             self._status = {}
             self._threads = []
             self.configuredChanged.emit()
@@ -661,4 +699,5 @@ class BridgeController(QObject):
             self.loadDevices(False)
             self.loadSetupState()
 
-        self._run(lambda: self._setup.forget(mac), completed)
+        adapter = self._configured_adapter.strip() or None
+        self._run(lambda: self._setup.forget(mac, adapter=adapter), completed)

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -887,6 +887,18 @@ Kirigami.ApplicationWindow {
         property var device: selectedDevice >= 0 && selectedDevice < root.bridge.devices.length
             ? root.bridge.devices[selectedDevice]
             : null
+        property bool hasMultipleAdapters: (root.bridge.compatibility.adapters || []).length > 1
+
+        function syncAdapterCombo() {
+            const adapters = root.bridge.compatibility.adapters || []
+            const current = root.bridge.compatibility.adapter
+            for (let index = 0; index < adapters.length; ++index) {
+                if (adapters[index].name === current) {
+                    adapterCombo.currentIndex = index
+                    return
+                }
+            }
+        }
         property var configuredDevice: {
             for (let index = 0; index < root.bridge.devices.length; ++index) {
                 if (root.bridge.devices[index].mac === root.bridge.configuredMac)
@@ -919,6 +931,15 @@ Kirigami.ApplicationWindow {
                     text: qsTr("Keep the iPhone unlocked with its Bluetooth settings open during pairing.")
                 }
 
+                Connections {
+                    target: root.bridge
+                    function onCompatibilityChanged() { iphonePage.syncAdapterCombo() }
+                    function onDevicesChanged() {
+                        deviceCombo.currentIndex = root.bridge.devices.length > 0 ? 0 : -1
+                        iphonePage.selectedDevice = deviceCombo.currentIndex
+                    }
+                }
+
                 OnboardingSummary {
                     Layout.fillWidth: true
                     stage: iphonePage.effectiveStage
@@ -944,8 +965,24 @@ Kirigami.ApplicationWindow {
 
                     Controls.Label {
                         Kirigami.FormData.label: qsTr("Controller:")
+                        visible: !iphonePage.hasMultipleAdapters
                         text: root.bridge.compatibility.adapter || qsTr("Checking…")
                         textFormat: Text.PlainText
+                    }
+
+                    Controls.ComboBox {
+                        id: adapterCombo
+                        Kirigami.FormData.label: qsTr("Controller:")
+                        visible: iphonePage.hasMultipleAdapters
+                        model: root.bridge.compatibility.adapters || []
+                        textRole: "label"
+                        valueRole: "name"
+                        enabled: !root.bridge.busy
+                        onActivated: {
+                            if (currentValue)
+                                root.bridge.selectAdapter(currentValue)
+                        }
+                        Component.onCompleted: iphonePage.syncAdapterCombo()
                     }
 
                     Controls.Label {
@@ -1010,22 +1047,18 @@ Kirigami.ApplicationWindow {
                         textRole: "display_name"
                         valueRole: "mac"
                         enabled: !root.bridge.busy
+                        // org.kde.desktop paints displayText in the StyleItem
+                        // background. A contentItem Label would overlay a second copy.
                         delegate: Controls.ItemDelegate {
                             id: deviceOption
                             required property var modelData
                             width: deviceCombo.width
-                            text: modelData.display_name
+                            Accessible.name: deviceOption.modelData.display_name
                             contentItem: Controls.Label {
-                                text: deviceOption.text
+                                text: deviceOption.modelData.display_name
                                 textFormat: Text.PlainText
                                 elide: Text.ElideRight
                             }
-                        }
-                        contentItem: Controls.Label {
-                            text: deviceCombo.displayText
-                            textFormat: Text.PlainText
-                            verticalAlignment: Text.AlignVCenter
-                            elide: Text.ElideRight
                         }
                         onCurrentIndexChanged: iphonePage.selectedDevice = currentIndex
                     }

--- a/src/blueferry/setup_client.py
+++ b/src/blueferry/setup_client.py
@@ -14,6 +14,8 @@ from blueferry import pair_setup, quirks_report
 from blueferry.bluetooth_devices import PairedDevice
 from blueferry.errors import PairingError
 
+DISCOVERY_SECONDS = pair_setup.DISCOVERY_SECONDS
+
 
 @dataclass(frozen=True, slots=True)
 class BluezSupport:
@@ -38,6 +40,43 @@ class BluezSupport:
 
 
 @dataclass(frozen=True, slots=True)
+class AdapterOption:
+    name: str
+    label: str
+    available: bool = False
+    powered: bool = False
+    hardware_supported: bool = False
+    notifications_supported: bool = False
+    pairing_ready: bool = False
+    issue: str = ""
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> AdapterOption:
+        return cls(
+            name=str(value.get("name", "")),
+            label=str(value.get("label") or value.get("name") or ""),
+            available=bool(value.get("available", False)),
+            powered=bool(value.get("powered", False)),
+            hardware_supported=bool(value.get("hardware_supported", False)),
+            notifications_supported=bool(value.get("notifications_supported", False)),
+            pairing_ready=bool(value.get("pairing_ready", False)),
+            issue=str(value.get("issue", "")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "label": self.label,
+            "available": self.available,
+            "powered": self.powered,
+            "hardware_supported": self.hardware_supported,
+            "notifications_supported": self.notifications_supported,
+            "pairing_ready": self.pairing_ready,
+            "issue": self.issue,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class BluetoothCompatibility:
     adapter: str
     available: bool
@@ -53,9 +92,11 @@ class BluetoothCompatibility:
     pairing_ready: bool
     issue: str
     supported_settings: tuple[str, ...]
+    adapters: tuple[AdapterOption, ...] = ()
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> BluetoothCompatibility:
+        raw_adapters = value.get("adapters", ())
         return cls(
             adapter=str(value.get("adapter", "")),
             available=bool(value.get("available", False)),
@@ -73,13 +114,21 @@ class BluetoothCompatibility:
             supported_settings=tuple(
                 str(item) for item in value.get("supported_settings", ())
             ),
+            adapters=tuple(
+                AdapterOption.from_dict(item)
+                for item in raw_adapters
+                if isinstance(item, dict)
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:
         return {
             field: getattr(self, field)
             for field in self.__dataclass_fields__
-        } | {"supported_settings": list(self.supported_settings)}
+        } | {
+            "supported_settings": list(self.supported_settings),
+            "adapters": [item.to_dict() for item in self.adapters],
+        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,9 +217,9 @@ class SetupClient:
     def bluez_status(self) -> BluezSupport:
         return BluezSupport.from_dict(pair_setup.bluez_support_status())
 
-    def compatibility(self) -> BluetoothCompatibility:
+    def compatibility(self, adapter: str | None = None) -> BluetoothCompatibility:
         return BluetoothCompatibility.from_dict(
-            pair_setup.bluetooth_compatibility()
+            pair_setup.bluetooth_compatibility(adapter)
         )
 
     def configuration(self) -> ConfigurationState:
@@ -182,21 +231,25 @@ class SetupClient:
     def activate_bluez(self) -> BluezSupport:
         return BluezSupport.from_dict(pair_setup.activate_bluez_support())
 
-    def devices(self, *, scan_seconds: int = 0) -> list[PairedDevice]:
+    def devices(
+        self, *, scan_seconds: int = 0, adapter: str | None = None,
+    ) -> list[PairedDevice]:
         if scan_seconds:
-            return pair_setup.discover_devices(scan_seconds)
+            return pair_setup.discover_devices(scan_seconds, adapter=adapter)
         return pair_setup.list_devices()
 
     def complete(
         self,
         mac: str,
         *,
+        adapter: str | None = None,
         confirmation: pair_setup.ConfirmationCallback | None = None,
         display: pair_setup.DisplayCallback | None = None,
     ) -> PairingResult:
         return PairingResult.from_dict(
             pair_setup.complete_pairing(
                 mac,
+                adapter=adapter,
                 confirmation=confirmation,
                 display=display,
             )
@@ -208,6 +261,7 @@ class SetupClient:
         *,
         confirmation: pair_setup.ConfirmationCallback,
         display: pair_setup.DisplayCallback | None = None,
+        adapter: str | None = None,
         replace_saved_mac: str = "",
     ) -> PairingResult:
         """Run interactive pairing in a D-Bus/GLib-isolated child process."""
@@ -219,6 +273,8 @@ class SetupClient:
             mac,
             "--interactive-agent",
         ]
+        if adapter:
+            command.extend(["--adapter", adapter])
         if replace_saved_mac:
             command.extend(["--replace-saved-mac", replace_saved_mac])
         process = subprocess.Popen(  # nosec B603
@@ -263,8 +319,12 @@ class SetupClient:
                 process.terminate()
                 process.wait(timeout=5)
 
-    def forget(self, mac: str) -> None:
-        pair_setup.forget_device(mac)
+    def forget(self, mac: str, *, adapter: str | None = None) -> None:
+        pair_setup.forget_device(mac, adapter=adapter)
 
-    def prepare_replacement(self, previous_mac: str, next_mac: str) -> None:
-        pair_setup.prepare_target_replacement(previous_mac, next_mac)
+    def prepare_replacement(
+        self, previous_mac: str, next_mac: str, *, adapter: str | None = None,
+    ) -> None:
+        pair_setup.prepare_target_replacement(
+            previous_mac, next_mac, adapter=adapter,
+        )

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -771,13 +771,16 @@ class BlueFerryApp(App[None]):
             composer = self.query_one("#composer", TextArea)
             send_button = self.query_one("#send-reply", Button)
             roster_button = self.query_one("#edit-group-participants", Button)
+            title_view = self.query_one("#conversation-title", Static)
+            subtitle_view = self.query_one("#conversation-subtitle", Static)
+            badge_view = self.query_one("#conversation-badge", Static)
         except NoMatches:
             return
         await timeline.remove_children()
         if thread is None:
-            self.query_one("#conversation-title", Static).update("Select a conversation")
-            self.query_one("#conversation-subtitle", Static).update("")
-            self.query_one("#conversation-badge", Static).update("")
+            title_view.update("Select a conversation")
+            subtitle_view.update("")
+            badge_view.update("")
             await timeline.mount(
                 Static("Choose a conversation to start", id="empty-conversation")
             )
@@ -788,10 +791,10 @@ class BlueFerryApp(App[None]):
 
         title = thread.name + ("  ·  Group" if thread.is_group else "")
         recipients = ", ".join(thread.recipients)
-        self.query_one("#conversation-title", Static).update(Text(_one_line(title)))
-        self.query_one("#conversation-subtitle", Static).update(Text(_one_line(recipients)))
+        title_view.update(Text(_one_line(title)))
+        subtitle_view.update(Text(_one_line(recipients)))
         unread = _unread_count(thread)
-        self.query_one("#conversation-badge", Static).update(
+        badge_view.update(
             Text(f"{unread} unread" if unread else "up to date")
         )
         roster_button.display = bool(

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -12,6 +12,7 @@ from blueferry.models import BackendStatus
 from blueferry.onboarding import OnboardingStage, derive_stage
 from blueferry.quirks_report import issue_report, issue_url
 from blueferry.setup_client import (
+    DISCOVERY_SECONDS,
     BluetoothCompatibility,
     ConfigurationState,
     SetupClient,
@@ -78,6 +79,16 @@ class IPhonePage(Gtk.Box):
             subtitle=_("Checking compatibility…"),
             use_markup=False,
         )
+        self._adapter_model = Gtk.StringList()
+        self._adapter_row = Adw.ComboRow(
+            title=_("Bluetooth Controller"),
+            subtitle=_("Choose which radio to pair with"),
+            model=self._adapter_model,
+            use_markup=False,
+        )
+        self._adapter_row.set_visible(False)
+        self._adapter_row.connect("notify::selected", self._adapter_changed)
+        self._applying_adapter = False
         self._bluez_row = Adw.ActionRow(
             title=_("Bluetooth Support"),
             subtitle=_("Checking system configuration…"),
@@ -89,6 +100,7 @@ class IPhonePage(Gtk.Box):
         self._activate_button.connect("clicked", self._confirm_activate_bluez)
         self._bluez_row.add_suffix(self._activate_button)
         self._pairing_group.add(self._hardware_row)
+        self._pairing_group.add(self._adapter_row)
         self._pairing_group.add(self._bluez_row)
 
         scan = Adw.ActionRow(
@@ -207,7 +219,10 @@ class IPhonePage(Gtk.Box):
 
         daemon_group = Adw.PreferencesGroup(title=_("Connection Details"))
         recheck = Gtk.Button(label=_("Recheck"), valign=Gtk.Align.CENTER)
-        recheck.connect("clicked", lambda _b: self._refresh())
+        recheck.connect(
+            "clicked",
+            lambda _b: (self._load_setup_state(), self._refresh()),
+        )
         daemon_group.set_header_suffix(recheck)
         self._daemon_row = Adw.ActionRow(title=_("Background Service"))
         self._daemon_icon = Gtk.Image()
@@ -335,6 +350,7 @@ class IPhonePage(Gtk.Box):
         self._setup_spinner.set_spinning(busy)
         self._activate_button.set_sensitive(not busy)
         self._scan_button.set_sensitive(not busy)
+        self._adapter_row.set_sensitive(not busy)
         selected = self._selected_device()
         pairing_ready = bool(self._compatibility and self._compatibility.pairing_ready)
         self._pair_button.set_sensitive(not busy and pairing_ready and bool(selected))
@@ -347,6 +363,77 @@ class IPhonePage(Gtk.Box):
     def _selection_changed(self) -> None:
         self._set_pairing_busy(False)
         self._update_onboarding()
+
+    def _selected_adapter_name(self) -> str:
+        if self._compatibility is None:
+            return ""
+        return self._compatibility.adapter
+
+    def _apply_compatibility(self, compatibility) -> None:
+        self._compatibility = compatibility
+        adapters = list(compatibility.adapters)
+        self._applying_adapter = True
+        if len(adapters) > 1:
+            self._hardware_row.set_visible(False)
+            self._adapter_row.set_visible(True)
+            labels = [option.label for option in adapters]
+            self._adapter_model.splice(0, self._adapter_model.get_n_items(), labels)
+            selected = next(
+                (index for index, option in enumerate(adapters)
+                 if option.name == compatibility.adapter),
+                0,
+            )
+            self._adapter_row.set_selected(selected)
+        else:
+            self._adapter_row.set_visible(False)
+            self._hardware_row.set_visible(True)
+            if not compatibility.hardware_supported:
+                hardware = _("Unsupported")
+            elif compatibility.notifications_supported:
+                hardware = _("Compatible")
+            else:
+                hardware = _("Compatible for Messages and Contacts")
+            self._hardware_row.set_subtitle(
+                _("{adapter} — {status}").format(
+                    adapter=compatibility.adapter or _("No Adapter"),
+                    status=hardware,
+                )
+            )
+        self._applying_adapter = False
+        active = compatibility.bearer_api_active
+        if not compatibility.notifications_supported:
+            self._bluez_row.set_subtitle(
+                _("Not required; per-app notifications are unsupported")
+            )
+        else:
+            self._bluez_row.set_subtitle(
+                _("Active") if active else _("A one-time Bluetooth restart is required")
+            )
+        self._activate_button.set_visible(
+            compatibility.notifications_supported and not active
+        )
+
+    def _adapter_changed(self, *_args) -> None:
+        if self._applying_adapter or self._compatibility is None:
+            return
+        adapters = list(self._compatibility.adapters)
+        index = self._adapter_row.get_selected()
+        if index >= len(adapters):
+            return
+        name = adapters[index].name
+        if name == self._compatibility.adapter:
+            return
+
+        def loaded(compatibility) -> None:
+            had_devices = bool(self._devices)
+            self._apply_compatibility(compatibility)
+            self._set_pairing_busy(False)
+            self._update_onboarding()
+            self._load_devices(scan=False)
+            if had_devices:
+                self._toast(_("Scan again to find an iPhone on this controller"))
+
+        self._run_setup(lambda: self._setup.compatibility(name), loaded)
 
     def _run_setup(self, operation, on_done) -> None:
         """Run blocking BlueZ setup work away from GTK's main loop."""
@@ -408,35 +495,14 @@ class IPhonePage(Gtk.Box):
 
     def _load_setup_state(self, *, scan_after: bool = False) -> None:
         def operation():
-            return self._setup.compatibility(), self._setup.configuration()
+            adapter = self._selected_adapter_name() or None
+            return self._setup.compatibility(adapter), self._setup.configuration()
 
         def loaded(value) -> None:
             compatibility, configuration = value
-            self._compatibility = compatibility
             self._configuration = configuration
             self._setup_loaded = True
-            active = compatibility.bearer_api_active
-            if not compatibility.hardware_supported:
-                hardware = _("Unsupported")
-            elif compatibility.notifications_supported:
-                hardware = _("Compatible")
-            else:
-                hardware = _("Compatible for Messages and Contacts")
-            self._hardware_row.set_subtitle(
-                _("{adapter} — {status}").format(
-                    adapter=compatibility.adapter or _("No Adapter"),
-                    status=hardware,
-                )
-            )
-            if not compatibility.notifications_supported:
-                self._bluez_row.set_subtitle(
-                    _("Not required; per-app notifications are unsupported")
-                )
-            else:
-                self._bluez_row.set_subtitle(
-                    _("Active") if active else _("A one-time Bluetooth restart is required")
-                )
-            self._activate_button.set_visible(compatibility.notifications_supported and not active)
+            self._apply_compatibility(compatibility)
             self._set_pairing_busy(False)
             self._update_phone_controls()
             self._update_onboarding()
@@ -505,8 +571,11 @@ class IPhonePage(Gtk.Box):
                     )
                 )
 
+        adapter = self._selected_adapter_name() or None
         self._run_setup(
-            lambda: self._setup.devices(scan_seconds=8 if scan else 0),
+            lambda: self._setup.devices(
+                scan_seconds=DISCOVERY_SECONDS if scan else 0, adapter=adapter,
+            ),
             loaded,
         )
 
@@ -632,6 +701,7 @@ class IPhonePage(Gtk.Box):
                 device.mac,
                 confirmation=confirm,
                 display=display,
+                adapter=device.adapter_path.rsplit("/", 1)[-1],
                 replace_saved_mac=replace_saved_mac,
             ),
             completed,
@@ -677,7 +747,14 @@ class IPhonePage(Gtk.Box):
                     self._update_phone_controls()
 
                 self._run_setup(
-                    lambda: self._setup.forget(mac),
+                    lambda: self._setup.forget(
+                        mac,
+                        adapter=(
+                            self._configuration.adapter
+                            if self._configuration
+                            else None
+                        ) or None,
+                    ),
                     forgotten,
                 )
 

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -187,6 +187,30 @@ def test_bluez_preference_selects_requested_bearer(monkeypatch) -> None:
     ]
 
 
+def test_bluez_preference_ignores_a_missing_preferred_bearer_property(monkeypatch) -> None:
+    class Properties:
+        @staticmethod
+        def Set(_interface, _name, _value, *, timeout):
+            raise bearer_supervisor.dbus.exceptions.DBusException(
+                "No such property 'PreferredBearer'",
+                name="org.bluez.Error.InvalidArguments",
+            )
+
+    class Bus:
+        @staticmethod
+        def get_object(_service, _path):
+            return object()
+
+    monkeypatch.setattr(bearer_supervisor, "get_system_bus", Bus)
+    monkeypatch.setattr(
+        bearer_supervisor.dbus,
+        "Interface",
+        lambda _object, _interface: Properties(),
+    )
+
+    BearerSupervisor("/device")._prefer_bluez("bredr")
+
+
 def test_failed_connection_is_retried_after_backoff() -> None:
     attempts = []
     scheduled = []

--- a/tests/test_cli_pairing.py
+++ b/tests/test_cli_pairing.py
@@ -29,11 +29,14 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
     observed = []
 
     class Setup:
-        def prepare_replacement(self, previous_mac, next_mac):
-            observed.append(("replace", previous_mac, next_mac))
+        def configuration(self):
+            return SimpleNamespace(adapter="hci0")
 
-        def complete(self, mac, *, confirmation, display):
-            observed.append((mac, confirmation(12345)))
+        def prepare_replacement(self, previous_mac, next_mac, *, adapter=None):
+            observed.append(("replace", previous_mac, next_mac, adapter))
+
+        def complete(self, mac, *, confirmation, display, adapter=None):
+            observed.append((mac, adapter, confirmation(12345)))
             return SimpleNamespace(to_dict=lambda: {"ok": True, "device": {"mac": mac}})
 
     monkeypatch.setattr(setup_client, "SetupClient", Setup)
@@ -44,6 +47,8 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
             "pairing-complete",
             "02:00:00:00:00:01",
             "--interactive-agent",
+            "--adapter",
+            "hci1",
             "--replace-saved-mac",
             "02:00:00:00:00:02",
         ],
@@ -57,8 +62,8 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
         {"ok": True, "device": {"mac": "02:00:00:00:00:01"}},
     ]
     assert observed == [
-        ("replace", "02:00:00:00:00:02", "02:00:00:00:00:01"),
-        ("02:00:00:00:00:01", True),
+        ("replace", "02:00:00:00:00:02", "02:00:00:00:00:01", "hci0"),
+        ("02:00:00:00:00:01", "hci1", True),
     ]
 
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -288,6 +288,34 @@ def test_all_gui_clients_offer_contacts_aware_new_messages() -> None:
     assert '"contacts-json"' in quickshell
 
 
+def test_all_gui_clients_can_choose_a_bluetooth_controller() -> None:
+    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
+    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
+    quickshell = _qml_bundle(ROOT / "data/quickshell")
+
+    assert "_adapter_row" in gtk
+    assert "selectAdapter" in qt
+    assert "Bluetooth Controller" in gtk
+    assert "Controller:" in qt
+    assert "adapterCombo" in quickshell
+    assert "--adapter" in quickshell
+    assert 'pairProcess.command.push("--adapter", root.adapterName)' in quickshell
+    assert 'forgetProcess.command.push("--adapter", root.configuredAdapter)' in quickshell
+    assert "property string configuredAdapter" in quickshell
+    assert (
+        "root.configuredAdapter = root.targetSaved ? (parsed.adapter || \"\") : \"\""
+    ) in quickshell
+    assert "if (root.targetSaved && parsed.adapter)" not in quickshell
+    assert "scanAfterCompatibility" in quickshell
+    assert 'command.push("--scan-seconds", "24")' in quickshell
+    assert "scan_seconds=DISCOVERY_SECONDS if scan else 0" in (
+        ROOT / "src/blueferry/ui/status.py"
+    ).read_text()
+    assert "scan_seconds=DISCOVERY_SECONDS if scan else 0" in (
+        ROOT / "src/blueferry/qt/controller.py"
+    ).read_text()
+
+
 def test_all_gui_clients_offer_a_pairing_issue_button() -> None:
     gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
     qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
@@ -389,9 +417,10 @@ def test_remote_qml_text_is_rendered_as_plain_text() -> None:
         "text: contactDelegate.text\n"
         "                        textFormat: Text.PlainText"
     ) in qt_qml
+    assert "text: deviceCombo.displayText" not in qt_qml
     assert (
-        "text: deviceCombo.displayText\n"
-        "                            textFormat: Text.PlainText"
+        "text: deviceOption.modelData.display_name\n"
+        "                                textFormat: Text.PlainText"
     ) in qt_qml
     assert (
         "text: threadDelegate.modelData.name\n"

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -83,6 +83,120 @@ def test_discovery_stops_as_soon_as_an_iphone_appears(monkeypatch):
     assert elapsed < 8
 
 
+def test_discover_devices_starts_on_the_requested_adapter(monkeypatch):
+    started = []
+    stopped = []
+
+    class Adapter:
+        def __init__(self, path):
+            self.path = path
+
+        def Set(self, *_args):
+            pass
+
+        def StartDiscovery(self):
+            started.append(self.path)
+
+        def StopDiscovery(self):
+            stopped.append(self.path)
+
+    class ObjectManager:
+        def GetManagedObjects(self):
+            return {
+                "/org/bluez/hci0": {"org.bluez.Adapter1": {}},
+                "/org/bluez/hci1": {"org.bluez.Adapter1": {}},
+            }
+
+    class Bus:
+        def get_object(self, _service, path):
+            return Adapter(path)
+
+    monkeypatch.setattr(pair_setup, "_object_manager", ObjectManager)
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(pair_setup, "list_devices", lambda: [])
+    now = iter([0.0, 2.0])
+    monkeypatch.setattr(pair_setup.time, "monotonic", lambda: next(now, 2.0))
+
+    pair_setup.discover_devices(1, adapter="hci1")
+
+    assert started == ["/org/bluez/hci1"]
+    assert "/org/bluez/hci0" in stopped
+    assert "/org/bluez/hci1" in stopped
+
+
+def test_discover_devices_waits_for_an_iphone_on_the_requested_adapter(monkeypatch):
+    leftover = _device(paired=False)
+    phone = pair_setup.PairedDevice(
+        mac="02:00:00:00:00:02",
+        name="Test iPhone",
+        icon="phone",
+        trusted=False,
+        connected=False,
+        paired=False,
+        adapter_path="/org/bluez/hci1",
+        device_path="/org/bluez/hci1/dev_02_00_00_00_00_02",
+        uuids=frozenset(),
+        services_resolved=False,
+    )
+    scans = [[leftover], [leftover], [leftover, phone]]
+    sleeps = []
+    elapsed = 0.0
+
+    class Adapter:
+        def Set(self, *_args):
+            pass
+
+        def StartDiscovery(self):
+            pass
+
+        def StopDiscovery(self):
+            pass
+
+    class ObjectManager:
+        def GetManagedObjects(self):
+            return {
+                "/org/bluez/hci0": {"org.bluez.Adapter1": {}},
+                "/org/bluez/hci1": {"org.bluez.Adapter1": {}},
+            }
+
+    class Bus:
+        def get_object(self, *_args):
+            return Adapter()
+
+    def sleep(seconds):
+        nonlocal elapsed
+        sleeps.append(seconds)
+        elapsed += seconds
+
+    monkeypatch.setattr(pair_setup, "_object_manager", ObjectManager)
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(pair_setup, "list_devices", lambda: scans.pop(0))
+    monkeypatch.setattr(pair_setup.time, "monotonic", lambda: elapsed)
+    monkeypatch.setattr(pair_setup.time, "sleep", sleep)
+
+    assert pair_setup.discover_devices(8, adapter="hci1") == [phone]
+    assert sleeps == [0.25, 0.25]
+    assert elapsed < 8
+
+
+def test_discover_devices_rejects_a_missing_requested_adapter(monkeypatch):
+    class ObjectManager:
+        def GetManagedObjects(self):
+            return {"/org/bluez/hci0": {"org.bluez.Adapter1": {}}}
+
+    monkeypatch.setattr(pair_setup, "_object_manager", ObjectManager)
+
+    with pytest.raises(pair_setup.PairingError, match="hci1"):
+        pair_setup.discover_devices(1, adapter="hci1")
+
+
+def test_discover_devices_rejects_an_invalid_adapter_name():
+    with pytest.raises(pair_setup.PairingError, match="invalid Bluetooth adapter"):
+        pair_setup.discover_devices(1, adapter="not an adapter")
+
+
 def test_write_local_env_preserves_settings_and_is_private(tmp_path, monkeypatch):
     destination = tmp_path / "blueferry" / "local.env"
     destination.parent.mkdir()
@@ -136,9 +250,9 @@ def test_clear_local_target_preserves_unrelated_preferences(tmp_path, monkeypatc
 def test_replacing_stale_target_keeps_selected_unpaired_scan_result(monkeypatch):
     device = _device(paired=False)
     calls = []
-    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac, **_kwargs: device)
     monkeypatch.setattr(
-        pair_setup, "forget_device", lambda _mac: calls.append("forget")
+        pair_setup, "forget_device", lambda _mac, **_kwargs: calls.append("forget")
     )
     monkeypatch.setattr(
         pair_setup, "_stop_user_service", lambda: calls.append("stop")
@@ -154,9 +268,9 @@ def test_replacing_stale_target_keeps_selected_unpaired_scan_result(monkeypatch)
 
 def test_replacing_a_different_target_removes_its_bluez_device(monkeypatch):
     calls = []
-    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac: None)
+    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac, **_kwargs: None)
     monkeypatch.setattr(
-        pair_setup, "forget_device", lambda mac: calls.append(mac)
+        pair_setup, "forget_device", lambda mac, **_kwargs: calls.append(mac)
     )
 
     pair_setup.prepare_target_replacement(
@@ -164,6 +278,30 @@ def test_replacing_a_different_target_removes_its_bluez_device(monkeypatch):
     )
 
     assert calls == ["02:00:00:00:00:01"]
+
+
+def test_find_device_stays_on_the_requested_adapter(monkeypatch):
+    leftover = _device(paired=True)
+    phone = pair_setup.PairedDevice(
+        mac=leftover.mac,
+        name=leftover.name,
+        icon=leftover.icon,
+        trusted=True,
+        connected=True,
+        paired=True,
+        adapter_path="/org/bluez/hci1",
+        device_path="/org/bluez/hci1/dev_02_00_00_00_00_01",
+        uuids=leftover.uuids,
+        services_resolved=True,
+    )
+    monkeypatch.setattr(pair_setup, "list_devices", lambda: [leftover, phone])
+
+    with pytest.raises(pair_setup.PairingError, match="more than one"):
+        pair_setup._find_device(leftover.mac)
+    assert pair_setup._find_device(leftover.mac, adapter="hci0") == leftover
+    assert pair_setup._find_device(leftover.mac, adapter="hci1") == phone
+    assert pair_setup._find_device(leftover.mac, adapter="hci2") is None
+    assert pair_setup._device(leftover.mac, adapter="hci1") == phone
 
 
 def test_forget_stops_backend_removes_bond_and_clears_target(monkeypatch):
@@ -178,13 +316,13 @@ def test_forget_stops_backend_removes_bond_and_clears_target(monkeypatch):
         def RemoveDevice(self, path, *, timeout):
             calls.append(("remove", str(path), timeout))
 
-    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac, **_kwargs: device)
     monkeypatch.setattr(pair_setup, "_stop_user_service", lambda: calls.append("stop"))
     monkeypatch.setattr(pair_setup, "clear_local_target", lambda: calls.append("clear"))
     monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
     monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Adapter())
 
-    pair_setup.forget_device(device.mac)
+    pair_setup.forget_device(device.mac, adapter="hci0")
 
     assert calls == [
         "stop",
@@ -193,9 +331,50 @@ def test_forget_stops_backend_removes_bond_and_clears_target(monkeypatch):
     ]
 
 
+def test_forget_removes_the_bond_on_the_saved_adapter(monkeypatch):
+    leftover = _device(paired=True)
+    phone = pair_setup.PairedDevice(
+        mac=leftover.mac,
+        name=leftover.name,
+        icon=leftover.icon,
+        trusted=True,
+        connected=True,
+        paired=True,
+        adapter_path="/org/bluez/hci1",
+        device_path="/org/bluez/hci1/dev_02_00_00_00_00_01",
+        uuids=leftover.uuids,
+        services_resolved=True,
+    )
+    calls = []
+
+    class Bus:
+        def get_object(self, _service, path):
+            calls.append(("object", path))
+            return object()
+
+    class Adapter:
+        def RemoveDevice(self, path, *, timeout):
+            calls.append(("remove", str(path), timeout))
+
+    monkeypatch.setattr(pair_setup, "list_devices", lambda: [leftover, phone])
+    monkeypatch.setattr(pair_setup, "_stop_user_service", lambda: calls.append("stop"))
+    monkeypatch.setattr(pair_setup, "clear_local_target", lambda: calls.append("clear"))
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Adapter())
+
+    pair_setup.forget_device(leftover.mac, adapter="hci1")
+
+    assert calls == [
+        "stop",
+        ("object", phone.adapter_path),
+        ("remove", phone.device_path, 30.0),
+        "clear",
+    ]
+
+
 def test_forget_clears_target_when_another_bluetooth_ui_removed_bond(monkeypatch):
     calls = []
-    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac: None)
+    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac, **_kwargs: None)
     monkeypatch.setattr(pair_setup, "_stop_user_service", lambda: calls.append("stop"))
     monkeypatch.setattr(pair_setup, "clear_local_target", lambda: calls.append("clear"))
 
@@ -219,7 +398,7 @@ def test_forget_treats_bluez_race_as_already_removed(monkeypatch):
                 name="org.bluez.Error.DoesNotExist",
             )
 
-    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac, **_kwargs: device)
     monkeypatch.setattr(pair_setup, "_stop_user_service", lambda: calls.append("stop"))
     monkeypatch.setattr(pair_setup, "clear_local_target", lambda: calls.append("clear"))
     monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
@@ -394,6 +573,86 @@ def test_compatibility_is_based_on_controller_features_not_vendor(monkeypatch):
     assert status["current_settings"] == [
         "advertising", "br/edr", "le", "powered",
     ]
+    assert [item["name"] for item in status["adapters"]] == ["hci7"]
+
+
+def test_compatibility_ignores_a_configured_adapter_bluez_does_not_have(
+    monkeypatch,
+):
+    probed = []
+
+    class Manager:
+        def GetManagedObjects(self):
+            return {"/org/bluez/hci7": {"org.bluez.Adapter1": {}}}
+
+    def controller_info(command, **_kwargs):
+        index = command[2]
+        probed.append(index)
+        if index != "7":
+            return type("Result", (), {"returncode": 0, "stdout": (
+                f"hci{index}: Primary controller\n"
+                "supported settings: powered ssp br/edr le advertising secure-conn\n"
+            )})()
+        return type("Result", (), {"returncode": 0, "stdout": (
+            "hci7: Primary controller\n"
+            "supported settings: powered ssp br/edr le advertising secure-conn\n"
+        )})()
+
+    monkeypatch.setattr(pair_setup, "_object_manager", lambda: Manager())
+    monkeypatch.setattr(pair_setup, "run_command", controller_info)
+    monkeypatch.setattr(pair_setup, "bluez_support_status", lambda: {"active": True})
+    monkeypatch.setattr(pair_setup.config, "ADAPTER", "hci1")
+
+    status = pair_setup.bluetooth_compatibility()
+
+    assert probed == ["7"]
+    assert status["adapter"] == "hci7"
+    assert [item["name"] for item in status["adapters"]] == ["hci7"]
+
+
+def test_compatibility_lists_every_adapter_and_honors_an_explicit_choice(monkeypatch):
+    monkeypatch.setattr(pair_setup.config, "ADAPTER", "hci0")
+
+    class Manager:
+        def GetManagedObjects(self):
+            return {
+                "/org/bluez/hci0": {"org.bluez.Adapter1": {}},
+                "/org/bluez/hci1": {"org.bluez.Adapter1": {}},
+            }
+
+    monkeypatch.setattr(pair_setup, "_object_manager", lambda: Manager())
+
+    def controller_info(command, **_kwargs):
+        index = command[2]
+        settings = (
+            "powered ssp br/edr le advertising secure-conn"
+            if index in {"0", "1"}
+            else ""
+        )
+        return type(
+            "Result",
+            (),
+            {
+                "returncode": 0 if settings else 1,
+                "stdout": f"hci{index}: Primary controller\nsupported settings: {settings}\n",
+            },
+        )()
+
+    monkeypatch.setattr(pair_setup, "run_command", controller_info)
+    monkeypatch.setattr(pair_setup, "bluez_support_status", lambda: {"active": True})
+
+    automatic = pair_setup.bluetooth_compatibility()
+    assert automatic["adapter"] == "hci0"
+    assert [item["name"] for item in automatic["adapters"]] == ["hci0", "hci1"]
+
+    selected = pair_setup.bluetooth_compatibility("hci1")
+    assert selected["adapter"] == "hci1"
+    assert selected["hardware_supported"] is True
+    assert [item["name"] for item in selected["adapters"]] == ["hci0", "hci1"]
+
+    monkeypatch.setattr(pair_setup.config, "ADAPTER", "hci1")
+    remembered = pair_setup.bluetooth_compatibility()
+    assert remembered["adapter"] == "hci1"
 
 
 def test_compatibility_explains_missing_classic_transport(monkeypatch):
@@ -469,6 +728,7 @@ def test_controller_snapshot_does_not_repeat_btmgmt_or_systemctl(monkeypatch):
         )()
 
     monkeypatch.setattr(pair_setup, "run_command", run_command)
+    monkeypatch.setattr(pair_setup, "_adapter_dbus_fields", lambda _adapter: {})
     snapshot = pair_setup._controller_snapshot(
         "hci0",
         {
@@ -497,6 +757,128 @@ def test_controller_snapshot_does_not_repeat_btmgmt_or_systemctl(monkeypatch):
     assert snapshot["hci_version"] == 11
     assert snapshot["experimental"] is True
     assert snapshot["bluez_version"] == "5.87"
+    assert "cod" not in snapshot
+    assert "uuids" not in snapshot
+    assert "experimental_features" not in snapshot
+
+
+def test_adapter_dbus_fields_record_cod_uuids_and_experimental_features(
+    monkeypatch,
+):
+    class Properties:
+        @staticmethod
+        def GetAll(_interface, *, timeout):
+            assert timeout == 5.0
+            return {
+                "Class": 0x7C0408,
+                "UUIDs": [
+                    "00001133-0000-1000-8000-00805F9B34FB",
+                    "0000111E-0000-1000-8000-00805f9b34fb",
+                    "00005005-0000-1000-8000-0002ee000001",
+                ],
+                "ExperimentalFeatures": [
+                    "d4992530-b9ec-469f-ab01-6c481c47da1c",
+                    "15c0a148-c273-11ea-b3de-0242ac130004",
+                    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                ],
+                "Address": "AA:BB:CC:DD:EE:FF",
+                "Alias": "erik-laptop",
+            }
+
+    class Bus:
+        @staticmethod
+        def get_object(_service, path):
+            assert path == "/org/bluez/hci1"
+            return object()
+
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Properties())
+
+    fields = pair_setup._adapter_dbus_fields("hci1")
+
+    assert fields["cod"] == "0x7c0408"
+    assert fields["cod_handsfree"] is True
+    assert fields["uuids"] == [
+        "00005005-0000-1000-8000-0002ee000001",
+        "handsfree",
+        "message-notification-server",
+    ]
+    assert fields["experimental_features"] == [
+        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "debug",
+        "ll-privacy",
+    ]
+    assert "Address" not in fields
+    assert "Alias" not in fields
+
+
+def test_adapter_dbus_fields_omit_missing_experimental_features(monkeypatch):
+    class Properties:
+        @staticmethod
+        def GetAll(_interface, *, timeout):
+            return {"Class": 0x000000, "UUIDs": []}
+
+    monkeypatch.setattr(
+        pair_setup, "get_system_bus",
+        lambda: type("Bus", (), {"get_object": staticmethod(lambda *_args: object())})(),
+    )
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Properties())
+
+    fields = pair_setup._adapter_dbus_fields("hci0")
+
+    assert fields["cod"] == "0x000000"
+    assert fields["cod_handsfree"] is False
+    assert fields["uuids"] == []
+    assert "experimental_features" not in fields
+
+
+def test_adapter_dbus_fields_are_empty_when_bluez_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        pair_setup,
+        "get_system_bus",
+        lambda: (_ for _ in ()).throw(pair_setup.dbus.exceptions.DBusException()),
+    )
+
+    assert pair_setup._adapter_dbus_fields("hci0") == {}
+
+
+def test_controller_snapshot_includes_adapter_dbus_fields(monkeypatch):
+    monkeypatch.setattr(
+        pair_setup,
+        "run_command",
+        lambda *_args, **_kwargs: type(
+            "Result", (), {"returncode": 0, "stdout": "bluetoothctl: 5.87\n", "stderr": ""},
+        )(),
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_adapter_dbus_fields",
+        lambda adapter: {
+            "cod": "0x240408",
+            "cod_handsfree": True,
+            "uuids": ["message-notification-server"],
+            "experimental_features": ["debug"],
+        } if adapter == "hci0" else {},
+    )
+
+    snapshot = pair_setup._controller_snapshot(
+        "hci0",
+        {
+            "available": True,
+            "powered": True,
+            "classic": True,
+            "low_energy": True,
+            "advertising": True,
+            "secure_pairing": True,
+            "hardware_supported": True,
+            "bearer_api_active": True,
+        },
+    )
+
+    assert snapshot["cod"] == "0x240408"
+    assert snapshot["cod_handsfree"] is True
+    assert snapshot["uuids"] == ["message-notification-server"]
+    assert snapshot["experimental_features"] == ["debug"]
 
 
 def test_backend_restart_does_not_create_per_user_enablement(monkeypatch):
@@ -538,7 +920,7 @@ def _compatible(monkeypatch, *, notifications: bool = True) -> None:
 def test_complete_pairing_starts_profiles_while_pairing_advert_is_active(monkeypatch):
     device = _device(paired=True)
     calls = []
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: device)
     _compatible(monkeypatch)
     monkeypatch.setattr(
         bluez_setup,
@@ -584,6 +966,59 @@ def test_complete_pairing_starts_profiles_while_pairing_advert_is_active(monkeyp
         "restart",
         ("unregister", "hci0"),
     ]
+
+
+def test_complete_pairing_prepares_the_selected_adapter_not_a_leftover_bond(
+    monkeypatch,
+):
+    leftover = _device(paired=True)
+    phone = pair_setup.PairedDevice(
+        mac=leftover.mac,
+        name=leftover.name,
+        icon=leftover.icon,
+        trusted=True,
+        connected=False,
+        paired=True,
+        adapter_path="/org/bluez/hci1",
+        device_path="/org/bluez/hci1/dev_02_00_00_00_00_01",
+        uuids=leftover.uuids,
+        services_resolved=True,
+    )
+    prepared = []
+    saved = []
+    monkeypatch.setattr(pair_setup, "list_devices", lambda: [leftover, phone])
+    _compatible(monkeypatch)
+    monkeypatch.setattr(
+        bluez_setup,
+        "prepare_classic",
+        lambda **kwargs: prepared.append(kwargs["adapter"]) or True,
+    )
+    monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(bluez_setup, "unregister_advert", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: None)
+    monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda *_args: None)
+    monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
+    monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        pair_setup, "write_local_env",
+        lambda mac, adapter=None: saved.append((mac, adapter)),
+    )
+    monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: None)
+    monkeypatch.setattr(
+        pair_setup, "_wait_for_daemon_transports",
+        lambda **_kwargs: (True, True, True),
+    )
+    monkeypatch.setattr(pair_setup, "_adapter_dbus_fields", lambda _adapter: {})
+    monkeypatch.setattr(pair_setup, "_le_bearer_snapshot", lambda _path: {
+        "present": False, "paired": False, "bonded": False, "connected": False,
+    })
+    monkeypatch.setattr(pair_setup, "_bluetooth_session_owners", lambda: [])
+
+    result = pair_setup.complete_pairing(phone.mac, adapter="hci1")
+
+    assert result["ok"] is True
+    assert prepared == ["hci1"]
+    assert saved == [(phone.mac, "hci1")]
 
 
 def test_classic_connect_requires_observable_settled_connection(monkeypatch):
@@ -649,6 +1084,47 @@ def test_post_pair_bearer_preference_is_forced_to_bredr(monkeypatch):
         ("interface", "org.freedesktop.DBus.Properties"),
         ("org.bluez.Device1", "PreferredBearer", "bredr"),
     ]
+
+
+def test_post_pair_bearer_preference_is_optional_when_bluez_omits_it(monkeypatch):
+    class Properties:
+        @staticmethod
+        def Set(_interface, _name, _value):
+            raise pair_setup.dbus.exceptions.DBusException(
+                "No such property 'PreferredBearer'",
+                name="org.bluez.Error.InvalidArguments",
+            )
+
+    class Bus:
+        @staticmethod
+        def get_object(_service, _path):
+            return object()
+
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda _obj, _iface: Properties())
+
+    pair_setup._prefer_bredr("/org/bluez/hci0/dev_02_00_00_00_00_01")
+
+
+def test_post_pair_bearer_preference_still_fails_on_unexpected_errors(monkeypatch):
+    class Properties:
+        @staticmethod
+        def Set(_interface, _name, _value):
+            raise pair_setup.dbus.exceptions.DBusException(
+                "Permission denied",
+                name="org.freedesktop.DBus.Error.AccessDenied",
+            )
+
+    class Bus:
+        @staticmethod
+        def get_object(_service, _path):
+            return object()
+
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda _obj, _iface: Properties())
+
+    with pytest.raises(pair_setup.PairingError, match="Permission denied"):
+        pair_setup._prefer_bredr("/org/bluez/hci0/dev_02_00_00_00_00_01")
 
 
 def test_obex_mns_is_activated_before_pairing(monkeypatch):
@@ -742,6 +1218,52 @@ def test_ancs_retries_local_abort_after_classic_resettles(monkeypatch, caplog):
     assert "LE bearer connected" in caplog.text
 
 
+def test_connect_ancs_continues_when_preferred_bearer_is_missing(monkeypatch):
+    device = _device(paired=True)
+    connects = []
+
+    class Manager:
+        @staticmethod
+        def GetManagedObjects():
+            return {
+                pair_setup.dbus.ObjectPath(device.device_path): {
+                    "org.bluez.Bearer.LE1": {},
+                }
+            }
+
+    class Properties:
+        @staticmethod
+        def Set(*_args, **_kwargs):
+            raise pair_setup.dbus.exceptions.DBusException(
+                "No such property 'PreferredBearer'",
+                name="org.bluez.Error.InvalidArguments",
+            )
+
+    class LeBearer:
+        @staticmethod
+        def Connect(**_kwargs):
+            connects.append(True)
+
+    monkeypatch.setattr(pair_setup, "_object_manager", lambda: Manager())
+    monkeypatch.setattr(
+        pair_setup,
+        "get_system_bus",
+        lambda: type("Bus", (), {"get_object": staticmethod(lambda *_args: object())})(),
+    )
+    monkeypatch.setattr(
+        pair_setup.dbus,
+        "Interface",
+        lambda _obj, interface: (
+            Properties()
+            if interface == "org.freedesktop.DBus.Properties"
+            else LeBearer()
+        ),
+    )
+
+    assert pair_setup._connect_ancs(device) == "connected"
+    assert connects == [True]
+
+
 def test_complete_pairing_headless_pairs_from_linux(monkeypatch):
     unpaired = _device(paired=False)
     paired = _device(paired=True)
@@ -756,8 +1278,8 @@ def test_complete_pairing_headless_pairs_from_linux(monkeypatch):
         def get_object(*_args):
             return object()
 
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: unpaired)
-    monkeypatch.setattr(pair_setup, "_wait_for_paired_device", lambda _mac: paired)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: unpaired)
+    monkeypatch.setattr(pair_setup, "_wait_for_paired_device", lambda _mac, **_kwargs: paired)
     _compatible(monkeypatch)
     monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
     monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
@@ -802,11 +1324,11 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
     def display(_passkey):
         return None
 
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: unpaired)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: unpaired)
     monkeypatch.setattr(
         pair_setup,
         "_wait_for_paired_device",
-        lambda _mac: calls.append("settled") or paired,
+        lambda _mac, **_kwargs: calls.append("settled") or paired,
     )
     _compatible(monkeypatch)
     monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
@@ -895,8 +1417,8 @@ def test_peer_initiated_pairing_is_allowed_to_finish(monkeypatch):
         def get_object(*_args):
             return object()
 
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: unpaired)
-    monkeypatch.setattr(pair_setup, "_wait_for_paired_device", lambda _mac: paired)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: unpaired)
+    monkeypatch.setattr(pair_setup, "_wait_for_paired_device", lambda _mac, **_kwargs: paired)
     _compatible(monkeypatch)
     monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
     monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
@@ -916,7 +1438,7 @@ def test_peer_initiated_pairing_is_allowed_to_finish(monkeypatch):
 def test_pairing_starts_daemon_even_when_ancs_is_still_missing(monkeypatch):
     device = _device(paired=True)
     device.uuids = frozenset()
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: device)
     _compatible(monkeypatch)
     monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
     monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
@@ -942,7 +1464,7 @@ def test_pairing_starts_daemon_even_when_ancs_is_still_missing(monkeypatch):
 
 def test_pairing_does_not_gate_map_on_inbound_ancs(monkeypatch):
     device = _device(paired=True)
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: device)
     _compatible(monkeypatch)
     monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
     monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
@@ -965,7 +1487,7 @@ def test_pairing_does_not_gate_map_on_inbound_ancs(monkeypatch):
 
 def test_pairing_rejects_controller_without_ancs_before_saving_target(monkeypatch):
     device = _device(paired=True)
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: device)
     _compatible(monkeypatch, notifications=False)
     saved = []
     monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: saved.append(True))

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from blueferry import pairing_cli
 from blueferry.bluetooth_devices import PairedDevice
 from blueferry.pairing_cli import _print_iphone_steps
+from blueferry.setup_client import DISCOVERY_SECONDS
 from blueferry.setup_verification import CONTACTS
 
 
@@ -71,11 +72,11 @@ def test_cli_requires_phone_side_forget_before_clearing_saved_target(
     class Setup:
         @staticmethod
         def configuration():
-            return SimpleNamespace(saved=True, mac="02:00:00:00:00:01")
+            return SimpleNamespace(saved=True, mac="02:00:00:00:00:01", adapter="hci1")
 
         @staticmethod
-        def forget(mac):
-            forgotten.append(mac)
+        def forget(mac, *, adapter=None):
+            forgotten.append((mac, adapter))
             raise pairing_cli.PairingError("stop after forget")
 
     monkeypatch.setattr(pairing_cli, "SetupClient", Setup)
@@ -86,7 +87,7 @@ def test_cli_requires_phone_side_forget_before_clearing_saved_target(
     )
 
     assert pairing_cli.run_wizard(verify_after=False) == 1
-    assert forgotten == ["02:00:00:00:00:01"]
+    assert forgotten == [("02:00:00:00:00:01", "hci1")]
     assert prompts == [
         (
             "Forget BlueFerry's configured target and start fresh?",
@@ -118,6 +119,7 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> No
         issue="",
         notifications_supported=True,
         bearer_api_active=True,
+        adapters=(),
     )
 
     class Setup:
@@ -126,8 +128,8 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> No
             return compatibility
 
         @staticmethod
-        def devices(*, scan_seconds):
-            assert scan_seconds == 8
+        def devices(*, scan_seconds, adapter=None):
+            assert scan_seconds == DISCOVERY_SECONDS
             return [device]
 
         @staticmethod
@@ -135,8 +137,8 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> No
             return SimpleNamespace(saved=False, mac="")
 
         @staticmethod
-        def complete(mac, *, confirmation, display):
-            observed.append((mac, confirmation(12345)))
+        def complete(mac, *, confirmation, display, adapter=None):
+            observed.append((mac, adapter, confirmation(12345)))
             display(12345)
             return SimpleNamespace(device=device, ancs_ready=True)
 
@@ -155,7 +157,7 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> No
     monkeypatch.setattr(pairing_cli, "_print_iphone_steps", lambda *_args, **_kwargs: None)
 
     assert pairing_cli.run_wizard(verify_after=False) == 0
-    assert observed == [(device.mac, True)]
+    assert observed == [(device.mac, "hci0", True)]
     assert prompts == [
         ("\nUse this device?", {"default": True}),
         ("Do both devices show Bluetooth code 012345?", {"default": False}),
@@ -185,6 +187,7 @@ def test_cli_wizard_points_at_pairing_issue_when_ancs_stays_down(
         issue="",
         notifications_supported=True,
         bearer_api_active=True,
+        adapters=(),
     )
 
     class Setup:
@@ -193,7 +196,7 @@ def test_cli_wizard_points_at_pairing_issue_when_ancs_stays_down(
             return compatibility
 
         @staticmethod
-        def devices(*, scan_seconds):
+        def devices(*, scan_seconds, adapter=None):
             return [device]
 
         @staticmethod
@@ -201,7 +204,7 @@ def test_cli_wizard_points_at_pairing_issue_when_ancs_stays_down(
             return SimpleNamespace(saved=False, mac="")
 
         @staticmethod
-        def complete(mac, *, confirmation, display):
+        def complete(mac, *, confirmation, display, adapter=None):
             return SimpleNamespace(
                 device=device,
                 ancs_ready=False,

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -207,8 +207,8 @@ def test_pairing_uses_interactive_agent_and_accepts_matching_code(monkeypatch):
     observed = []
 
     class Setup:
-        def complete_isolated(self, mac, *, confirmation, display):
-            observed.append((mac, confirmation(12345)))
+        def complete_isolated(self, mac, *, confirmation, display, adapter=None, **_kwargs):
+            observed.append((mac, adapter, confirmation(12345)))
             display(12345)
             return object()
 
@@ -240,17 +240,18 @@ def test_pairing_uses_interactive_agent_and_accepts_matching_code(monkeypatch):
 
     controller.pairingConfirmationRequested.connect(confirm)
 
+    controller._compatibility = {"adapter": "hci1"}
     controller.completePairing("02:00:00:00:00:01")
 
     assert passkeys == ["012345"]
-    assert observed == [("02:00:00:00:00:01", True)]
+    assert observed == [("02:00:00:00:00:01", "hci1", True)]
 
 
 def test_pairing_rejects_when_confirmation_is_declined(monkeypatch):
     observed = []
 
     class Setup:
-        def complete_isolated(self, _mac, *, confirmation, display):
+        def complete_isolated(self, _mac, *, confirmation, display, **_kwargs):
             observed.append(confirmation(None))
             return object()
 
@@ -284,9 +285,10 @@ def test_replacing_saved_target_is_forwarded_to_pairing_helper(monkeypatch):
             *,
             confirmation,
             display,
-            replace_saved_mac,
+            adapter=None,
+            replace_saved_mac="",
         ):
-            observed.append((replace_saved_mac, mac))
+            observed.append((replace_saved_mac, mac, adapter))
             return object()
 
     controller = BridgeController(
@@ -306,13 +308,14 @@ def test_replacing_saved_target_is_forwarded_to_pairing_helper(monkeypatch):
     monkeypatch.setattr(controller, "loadSetupState", lambda: None)
     monkeypatch.setattr(controller, "refresh", lambda: None)
 
+    controller._compatibility = {"adapter": "hci1"}
     controller.replaceAndPair(
         "02:00:00:00:00:01",
         "02:00:00:00:00:02",
     )
 
     assert observed == [
-        ("02:00:00:00:00:01", "02:00:00:00:00:02")
+        ("02:00:00:00:00:01", "02:00:00:00:00:02", "hci1")
     ]
     assert controller.targetSaved is True
 
@@ -336,3 +339,101 @@ def test_pairing_issue_offer_stays_when_ancs_connects(monkeypatch, tmp_path) -> 
     controller._refresh_pairing_issue_report()
 
     assert controller.pairingIssueReport == str(path)
+
+
+def test_select_adapter_reloads_compatibility_for_that_radio(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    calls = []
+
+    class Setup:
+        def compatibility(self, adapter=None):
+            calls.append(adapter)
+            return SimpleNamespace(
+                to_dict=lambda: {
+                    "adapter": adapter or "hci0",
+                    "bearer_api_active": True,
+                    "adapters": [
+                        {"name": "hci0", "label": "hci0"},
+                        {"name": "hci1", "label": "hci1"},
+                    ],
+                },
+                bearer_api_active=True,
+            )
+
+    controller = BridgeController(
+        backend=_Backend(),
+        setup=Setup(),
+        subscribe=False,
+        autostart=False,
+    )
+    controller._compatibility = {"adapter": "hci0"}
+    controller._devices = [{"mac": "02:00:00:00:00:01", "display_name": "iPhone"}]
+    monkeypatch.setattr(
+        controller,
+        "_run",
+        lambda operation, on_done=None, *_args, **_kwargs: (
+            on_done(operation()) if on_done is not None else operation()
+        ),
+    )
+    loaded = []
+    monkeypatch.setattr(controller, "loadDevices", lambda scan: loaded.append(scan))
+
+    controller.selectAdapter("hci1")
+
+    assert calls == ["hci1"]
+    assert controller.compatibility["adapter"] == "hci1"
+    assert controller.devices == []
+    assert loaded == [False]
+
+
+def test_activating_bluetooth_reloads_the_selected_adapter_before_scanning(
+    monkeypatch,
+) -> None:
+    from types import SimpleNamespace
+
+    calls = []
+
+    class Setup:
+        def activate_bluez(self):
+            calls.append("activate")
+            return SimpleNamespace(active=True)
+
+        def compatibility(self, adapter=None):
+            calls.append(("compatibility", adapter))
+            return SimpleNamespace(
+                to_dict=lambda: {"adapter": adapter or "hci0", "bearer_api_active": True},
+                bearer_api_active=True,
+            )
+
+        def configuration(self):
+            return SimpleNamespace(
+                configured=False,
+                saved=False,
+                mac="",
+                adapter="hci0",
+                pairing_issue_report="",
+            )
+
+    controller = BridgeController(
+        backend=_Backend(),
+        setup=Setup(),
+        subscribe=False,
+        autostart=False,
+    )
+    controller._compatibility = {"adapter": "hci1"}
+    monkeypatch.setattr(
+        controller,
+        "_run",
+        lambda operation, on_done=None, *_args, **_kwargs: (
+            on_done(operation()) if on_done is not None else operation()
+        ),
+    )
+    loaded = []
+    monkeypatch.setattr(controller, "loadDevices", lambda scan: loaded.append(scan))
+
+    controller.activateBluetooth()
+
+    assert calls == ["activate", ("compatibility", "hci1")]
+    assert controller.compatibility["adapter"] == "hci1"
+    assert loaded == [True]

--- a/tests/test_quirks_report.py
+++ b/tests/test_quirks_report.py
@@ -339,7 +339,7 @@ def test_complete_pairing_writes_a_scrubbed_success_report(
     device = _paired_device()
     monkeypatch.setenv("XDG_CURRENT_DESKTOP", "KDE")
     monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: device)
     monkeypatch.setattr(
         pair_setup,
         "bluetooth_compatibility",
@@ -439,7 +439,7 @@ def test_pairing_report_keeps_last_le_error_when_ancs_stays_down(
     report_dir, monkeypatch,
 ) -> None:
     device = _paired_device()
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: device)
     monkeypatch.setattr(
         pair_setup,
         "bluetooth_compatibility",
@@ -507,7 +507,7 @@ def test_pairing_report_keeps_last_le_error_when_ancs_stays_down(
 
 def test_failed_pairing_still_writes_a_report(report_dir, monkeypatch) -> None:
     device = _paired_device()
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: device)
     monkeypatch.setattr(
         pair_setup,
         "bluetooth_compatibility",
@@ -577,7 +577,7 @@ def test_unexpected_pairing_exception_still_writes_a_report(
     report_dir, monkeypatch,
 ) -> None:
     device = _paired_device()
-    monkeypatch.setattr(pair_setup, "_device", lambda _mac: device)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: device)
     monkeypatch.setattr(
         pair_setup,
         "bluetooth_compatibility",

--- a/tests/test_setup_client.py
+++ b/tests/test_setup_client.py
@@ -44,7 +44,7 @@ def test_compatibility_and_configuration_are_typed(monkeypatch):
     monkeypatch.setattr(
         setup_client.pair_setup,
         "bluetooth_compatibility",
-        lambda: {
+        lambda *_args, **_kwargs: {
             "adapter": "hci2",
             "available": True,
             "powered": True,
@@ -87,7 +87,7 @@ def test_device_operations_delegate_with_requested_scan(monkeypatch):
     monkeypatch.setattr(
         setup_client.pair_setup,
         "discover_devices",
-        lambda seconds: calls.append(seconds) or [device],
+        lambda seconds, adapter=None: calls.append((seconds, adapter)) or [device],
     )
     monkeypatch.setattr(
         setup_client.pair_setup,
@@ -98,17 +98,19 @@ def test_device_operations_delegate_with_requested_scan(monkeypatch):
     client = setup_client.SetupClient()
 
     assert client.devices(scan_seconds=8) == [device]
+    assert client.devices(scan_seconds=8, adapter="hci1") == [device]
     assert client.devices() == [device]
-    assert calls == [8, "list"]
+    assert calls == [(8, None), (8, "hci1"), "list"]
 
 
 def test_complete_pairing_decodes_result_and_forget_delegates(monkeypatch):
     device = _device()
     forgotten = []
+    paired = []
     monkeypatch.setattr(
         setup_client.pair_setup,
         "complete_pairing",
-        lambda mac, **_kwargs: {
+        lambda mac, **kwargs: paired.append((mac, kwargs.get("adapter"))) or {
             "ok": True,
             "device": device.to_dict(),
             "config": "/tmp/test-config",
@@ -121,18 +123,19 @@ def test_complete_pairing_decodes_result_and_forget_delegates(monkeypatch):
     monkeypatch.setattr(
         setup_client.pair_setup,
         "forget_device",
-        lambda mac: forgotten.append(mac),
+        lambda mac, **kwargs: forgotten.append((mac, kwargs.get("adapter"))),
     )
 
     client = setup_client.SetupClient()
-    result = client.complete(device.mac)
-    client.forget(device.mac)
+    result = client.complete(device.mac, adapter="hci1")
+    client.forget(device.mac, adapter="hci1")
 
     assert result.device.device_path == device.device_path
     assert result.iphone_steps == ("Enable notifications",)
     assert result.ancs_ready is True
     assert result.to_dict()["device"]["mac"] == device.mac
-    assert forgotten == [device.mac]
+    assert paired == [(device.mac, "hci1")]
+    assert forgotten == [(device.mac, "hci1")]
 
 
 def test_isolated_pairing_answers_helper_confirmation(monkeypatch):
@@ -170,12 +173,15 @@ def test_isolated_pairing_answers_helper_confirmation(monkeypatch):
     result = setup_client.SetupClient().complete_isolated(
         device.mac,
         confirmation=lambda passkey: passkey == 123456,
+        adapter="hci1",
         replace_saved_mac="02:00:00:00:00:02",
     )
 
     assert process.stdin.getvalue() == "yes\n"
     assert result.ancs_ready is True
-    assert commands[0][-2:] == ["--replace-saved-mac", "02:00:00:00:00:02"]
+    assert commands[0][-4:] == [
+        "--adapter", "hci1", "--replace-saved-mac", "02:00:00:00:00:02",
+    ]
 
 
 def test_isolated_pairing_preserves_report_path_on_failure(monkeypatch):

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -295,12 +295,14 @@ def test_unchanged_poll_does_not_rebuild_the_terminal_view() -> None:
 
         async with app.run_test(size=(120, 36)) as pilot:
             await _wait_for_threads(app, pilot, 2)
+            await pilot.pause(0.1)
             thread_items = tuple(app.query_one("#thread-list", ListView).children)
             message_items = tuple(
                 app.query_one("#message-timeline").children
             )
 
             await app._apply_snapshot(state.fetch_snapshot())
+            await pilot.pause(0.1)
 
             assert tuple(app.query_one("#thread-list", ListView).children) == thread_items
             assert tuple(app.query_one("#message-timeline").children) == message_items


### PR DESCRIPTION
## Summary

BlueFerry can now pick a Bluetooth controller when more than one is present, and it keeps that radio for the rest of setup. This is 0.6.3.

- GTK, Qt, Quickshell, and the CLI wizard list every BlueZ adapter and only auto-select one that is actually present and capable.
- Scan waits for an iPhone on the selected controller (24s, still early-exits when one appears) and does not abort just because another adapter already has a leftover phone.
- Pairing, CoD/`btmgmt class`, `local.env`, and forget take adapter + MAC. The same phone on two radios no longer pairs or unpairs the leftover `hci0` bond.
- A missing `PreferredBearer` property is ignored instead of failing after a successful PIN exchange.
- Pairing reports now include Class of Device, local UUIDs, and kernel experimental features.
- Qt no longer paints two stacked “iPhone” labels. Quickshell keeps the combo selection separate from the saved phone’s adapter.

## Test plan

- [x] `pytest` (533 passed, 3 skipped at last full run)
- [ ] Plug in a second adapter, pick it in Qt/GTK/Quickshell, scan, and confirm the phone appears only after that radio’s inquiry
- [ ] With an existing bond on `hci0`, pair the same phone on `hci1` and confirm `btmgmt --index 1 class 4 8` (not index 0)
- [ ] Confirm `local.env` writes `BLUEFERRY_ADAPTER=hci1` and the daemon comes up on that radio
- [ ] Forget the saved phone and confirm the bond is removed from the saved adapter, not the combo selection
- [ ] Restart Bluetooth from the pairing page and confirm the selected controller is still selected, then scanned