### PR TITLE
Prevent GTK and Qt package checks from hanging

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -71,7 +71,11 @@ check() {
     export DBUS_SYSTEM_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"
     export BLUEFERRY_TEST_DBUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS"
     export PYTHONPATH="$BLUEFERRY_TEST_ROOT/src"
-    python -m coverage run -m pytest -q
+    # GTK and Qt cannot safely initialize their GUI stacks in the same Python
+    # process: Qt can deadlock while creating the second QML component after
+    # the GTK conversation tests have run. Keep the QML checks isolated.
+    python -m coverage run -m pytest -q --ignore=tests/test_qml_presenters.py
+    python -m pytest -q tests/test_qml_presenters.py
     python -m coverage report
   '
   desktop-file-validate data/io.weirdware.BlueFerry.Gtk.desktop

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 import pytest
 
-os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+# These checks instantiate QML components without displaying them.  Do not
+# inherit a developer session's Wayland/X11 backend inside makepkg's private
+# D-Bus test session; Qt can otherwise wait indefinitely for desktop services.
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 pytest.importorskip("PySide6")
 

--- a/tests/test_quirks_report.py
+++ b/tests/test_quirks_report.py
@@ -245,6 +245,7 @@ def test_save_report_scrubs_home_paths_from_error_text(monkeypatch, tmp_path) ->
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     path = quirks_report.save_report(
         {"outcome": {"error": f"could not clear {home / '.config/blueferry/local.env'}"}},
         directory=tmp_path / "reports",


### PR DESCRIPTION
## Summary

- run QML presenter checks in a separate pytest process from GTK tests
- force the QML checks to use Qt's offscreen platform backend
- isolate the report-scrubbing test from the caller's XDG config environment

## Verification

- main suite: 536 passed
- isolated QML suite: 2 passed
- `git diff --check`