### PR TITLE
Add pairing compatibility and build-aware lifecycle

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -39,17 +39,20 @@ jobs:
           useradd --create-home builder
           chown -R builder:builder .
           su builder -c './build.sh -- --noconfirm'
-      - name: Smoke-test the backend-only Arch install
+      - name: Smoke-test the Arch backend and bundled TUI
         run: |
           backend=$(find packaging/arch -name 'blueferry-backend-*.pkg.tar.zst' -print -quit)
-          ! bsdtar -tf "$backend" | grep -E '/(tui\.py|tui\.tcss|__pycache__/tui\..*\.pyc)$'
+          bsdtar -tf "$backend" | grep -E '(^|/)blueferry/tui\.py$'
+          bsdtar -tf "$backend" | grep -E '(^|/)blueferry/tui\.tcss$'
+          bsdtar -tf "$backend" | grep -E '(^|/)usr/bin/blueferry-tui$'
           pacman -U --noconfirm "$backend"
-          set +e
-          blueferry tui 2>tui.err
-          status=$?
-          set -e
-          test "$status" -eq 2
-          grep -F 'install the blueferry-tui package' tui.err
+          smoke_tui() {
+            "$@" </dev/null 2>tui.err && status=0 || status=$?
+            test "$status" -eq 2
+            grep -Fx 'blueferry-tui requires an interactive terminal' tui.err
+          }
+          smoke_tui blueferry-tui
+          smoke_tui blueferry tui
       - name: Install the built artifacts
         run: pacman -U --noconfirm packaging/arch/*.pkg.tar.zst
       - name: Smoke test
@@ -95,6 +98,13 @@ jobs:
           /usr/lib/bluetooth/bluetoothd --help 2>&1 | grep -F experimental
           blueferry version
           python -c 'import blueferry; print(blueferry.__version__)'
+          smoke_tui() {
+            "$@" </dev/null 2>tui.err && status=0 || status=$?
+            test "$status" -eq 2
+            grep -Fx 'blueferry-tui requires an interactive terminal' tui.err
+          }
+          smoke_tui blueferry-tui
+          smoke_tui blueferry tui
 
   build-deb:
     name: Build Debian packages

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,14 +21,18 @@ Quickshell client ┘                         │
   thread keys and cannot construct different recipients for an existing thread.
 - `pair_setup` is the low-level setup boundary. `setup_client` exposes its
   typed operations to GTK and Qt, and the hidden JSON commands adapt the same
-  operations for Quickshell. It discovers and pairs devices, writes the
-  selected MAC to the user's configuration, and requests explicit Polkit
-  authorization for system-level setup operations.
+  operations for Quickshell. `pairing_policy` resolves controller capability
+  and user overrides into one concrete recipe. Setup discovers and pairs
+  devices, writes the selected MAC and ANCS policy to the user's configuration,
+  and requests explicit Polkit authorization for system-level setup operations.
 - `onboarding` derives a toolkit-neutral first-run stage from configuration,
   controller capabilities, the selected bond, and backend status. Controller
-  support is detected from read-only capabilities instead of vendor names.
-  GTK, Kirigami, Quickshell, and the CLI share pair/configure/re-pair and
-  verified-readiness semantics.
+  support is detected from read-only capabilities instead of vendor names. A
+  raw hardware view remains separate from the saved target's ANCS policy so a
+  compatibility pairing can reach `ready-without-ancs` without making the
+  controller appear permanently incapable of full pairing. GTK, Kirigami,
+  Quickshell, and the CLI share pair/configure/re-pair and verified-readiness
+  semantics.
 - The daemon runs unprivileged and has no sudo command path.
 
 Stable D-Bus identifiers live in `blueferry.protocol`. The service exports
@@ -44,10 +48,10 @@ is checked against the dbus-python decorators in the service implementation.
 carries only a bounded, opaque MAP handle after the user invokes a desktop
 message notification; clients locate it in their own private thread snapshot.
 Complete message records, sender identities, ANCS fields, contacts, and
-connectivity details are never broadcast on the session bus. The daemon emits invalidations at message,
-contact-cache, connectivity, ANCS subscription, initialization, and storage
-transitions. Clients verify MAP/PBAP success without mistaking Linux-side bond
-creation for end-to-end success.
+connectivity details are never broadcast on the session bus. The daemon emits
+invalidations at message, contact-cache, connectivity, ANCS subscription,
+initialization, and storage transitions. Clients verify MAP/PBAP success
+without mistaking Linux-side bond creation for end-to-end success.
 
 Backend payloads cross D-Bus as JSON to keep the wire contract simple. Both
 Python client implementations decode them immediately into the shared models
@@ -69,12 +73,39 @@ while `event_dispatcher` owns persistence/notification
 fan-out. `ProfileSupervisor` owns MAP/PBAP open, close, retry, loss, and resume
 transitions; its worker, session, and timer protocols make those races testable
 without BlueZ. Interactive pairing rendering lives separately from the BlueZ
-pairing service. An interactive client owns a device-scoped agent, promotes it
-over any desktop default for the complete pairing and Classic-to-LE handoff,
-then unregisters it before persistence and daemon startup. CLI message commands
-use the same backend client as graphical UIs. Group replies use `SendToThread`,
-so routing always comes from the backend's current conversation projection
-rather than client-supplied recipients.
+pairing service. GTK and Qt run the agent workflow in a GLib/D-Bus-isolated
+helper and reserve stdout for its JSON interaction protocol. The normal
+interactive transaction registers a device-scoped default agent and calls
+`Device1.Connect()` so the iPhone initiates authentication. A separate
+explicit-pairing override calls `Device1.Pair()` for controllers that cancel
+Connect-first. The temporary agent remains present while the bond is trusted,
+Classic settles, solicitation is registered, and the daemon makes its first
+MAP/PBAP attempt; cleanup then releases the advertisement and agent in order.
+CLI message commands use the same backend client as graphical UIs. Group
+replies use `SendToThread`, so routing always comes from the backend's current
+conversation projection rather than client-supplied recipients.
+
+## Pairing policy
+
+Pairing has two independent axes rather than a growing table of device quirks:
+
+- Delivery mode is `full` when ANCS is supported and selected. Compatibility
+  mode, selected explicitly for older iOS or automatically when ANCS is
+  unavailable, persists `BLUEFERRY_ANCS_ENABLED=false`; MAP and PBAP remain the
+  success boundary and the daemon never enables LE/ANCS for that target.
+- Authentication strategy is normally `iphone-initiated-connect`. The user may
+  independently select `explicit-device-pair`; non-interactive callers also use
+  that strategy because they cannot present BlueFerry's confirmation UI.
+
+ANCS connection policy and ANCS solicitation are deliberately separate. After
+the Classic bond is trusted and settled, setup broadcasts the short-lived
+solicitation whenever the controller can advertise, including compatibility
+mode. Real-device testing indicates that older iOS uses this signal to expose
+its MAP/PBAP permission toggles even though BlueFerry must not connect ANCS.
+Full mode starts the daemon with LE held back until its first MAP/PBAP attempt
+completes; compatibility mode leaves LE disabled. Pairing reports record the
+resolved policy, controller capability, ordered timeline, package build ID, and
+full source-content SHA.
 
 ## Lifecycle
 
@@ -96,12 +127,18 @@ refusal state preserves the iPhone's
 `Connection refused (111)` detail so clients can explain that another computer
 may currently own its single MAP connection.
 
-Arch packages install a release marker owned by the backend package. A running
-daemon notices a changed marker and exits with a failure status so systemd
-restarts it. Clients perform a serialized fallback restart for daemons released
-before self-restart support. Pacman scripts never try to address arbitrary
-logged-in users' service managers; Arch's systemd package hook reloads changed
-user-unit metadata.
+Native packages install release and source-content SHA markers owned by the
+backend package. The daemon publishes their combined identity as the private
+`_build_id` status field, formatted as the package release plus a twelve-digit
+SHA prefix; pairing reports retain that ID and the complete SHA. A running
+daemon notices a changed marker and exits with status 75 so systemd restarts
+it; clients compare `_build_id` and perform a serialized fallback restart if an
+older process is still running. Missing SHA markers retain compatibility with
+older/source builds, and lifecycle tests replace marker reads and command
+runners so installed host state can never restart a real service. Content
+hashing distinguishes local rebuilds that retain the same package version.
+Package scripts never try to address arbitrary logged-in users' service
+managers; distro systemd hooks reload changed user-unit metadata.
 
 ## Data and trust
 
@@ -186,8 +223,12 @@ asynchronous controller to Kirigami, serializes work in a QThreadPool, and
 coalesces Events1 invalidations into snapshot refreshes. Neither presentation main loop waits
 on the backend, BlueZ, or systemd.
 
-The Textual TUI and stylesheet are packaged with the backend. Blocking snapshot
-reads and sends run in Textual workers with thread-owned D-Bus connections;
+Every native backend package includes the TUI. Arch uses the distribution's
+`python-textual` package, while DEB and RPM backend packages carry the Textual
+runtime in a private vendor directory. The launcher activates that private
+runtime only from packaged entry points, so
+it cannot hijack a venv or source checkout. Blocking snapshot reads and sends
+run in Textual workers with thread-owned D-Bus connections;
 content-free HistoryChanged and StatusChanged signals trigger coalesced refreshes,
 with a bounded periodic refresh as a fallback. The client pumps its GLib signal
 context without blocking Textual, follows notification-open requests, adapts to

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -5,10 +5,13 @@ the original one-off experiment scripts with conclusions that are useful to
 maintainers. These are empirical observations, not promises made by Apple.
 
 Unless stated otherwise, the behavior was observed with an iPhone 16 Pro Max
-running iOS 26.5, BlueZ 5.72 or newer, and Linux controllers supporting both
-BR/EDR and LE. The complete MAP, PBAP, and ANCS combination has been exercised
-with a MediaTek MT7922. Other iPhone, iOS, BlueZ, and controller versions need
-independent verification.
+running iOS 26.5 and Linux controllers supporting both BR/EDR and LE. MAP/PBAP
+behavior spans BlueZ 5.72 or newer; the dual-bearer ANCS flow requires BlueZ
+5.86 or newer with its bearer API exposed. The complete MAP, PBAP, and ANCS
+combination has been exercised with a MediaTek MT7922. A later first-attempt
+clean test also completed all three on a previously tested Intel controller
+with an iPhone 17 Pro Max running an iOS 27 beta. Other iPhone, iOS, BlueZ, and
+controller versions need independent verification.
 
 ## Pairing and iPhone permissions
 
@@ -28,8 +31,11 @@ during pairing. The reliable setup has these properties:
 - The working advertisement also contains inert private/test manufacturer and
   service identifiers `0xffff` and `0x9999`, following the behavior established
   by ancs4linux. They do not claim an Apple or hardware-vendor identity.
-- The adapter is powered, pairable, and discoverable while the user confirms
-  the same passkey on Linux and the iPhone.
+- Linux discovers the iPhone and initiates the connection to that selected
+  device; the user does not start pairing by tapping the computer under iOS
+  **Other Devices**. The pre-bond Linux identity does not need a globally
+  discoverable LE advertisement. The post-bond solicitation advert carries its
+  own bounded discoverability window.
 - Which side initiates the *authentication* decides whether one pairing
   covers both transports: the authentication initiator derives the LE keys
   over SMP-on-BR/EDR after encryption, and only the link central can. The
@@ -40,7 +46,8 @@ during pairing. The reliable setup has these properties:
   btmon capture shows neither side opening the SMP channel despite both
   advertising it and the link key being Secure Connections (`Type=8`). The
   same `Pair()` produced a dual bond on a MediaTek MT7922.
-- The sequence that produces the dual bond on every tested controller is to
+- The sequence that produced a dual bond on the tested Intel and MediaTek
+  controllers, when the transaction completed, is to
   register the pairing agent and then call `Device1.Connect()` on the
   *unpaired* device: iOS refuses the profile connection without security,
   initiates the pairing itself over the existing ACL, and — as central and
@@ -51,26 +58,22 @@ during pairing. The reliable setup has these properties:
   device record for the computer. The user confirms one numeric comparison
   on both screens; the adapter never needs to become discoverable.
 
-There are two reliable client transactions, depending on who owns the pairing
-UI. On a desktop running KDE BlueDevil, GNOME Shell, Cinnamon, or Blueman,
-BlueFerry leaves confirmation and its surrounding connection lifecycle to that
-desktop manager and starts pairing with `Device1.Pair()`. Registering
-BlueFerry's agent and issuing the unpaired `Device1.Connect()` at the same time
-races the desktop manager; on KDE/BlueDevil this produced
-`le-connection-abort-by-local`. In a session without an interactive Bluetooth
-manager, BlueFerry registers its `DisplayYesNo` agent and uses the unpaired
-`Device1.Connect()` transaction described above. This is the path that produces
-the dual bond reliably on the Intel AX210 and supplies confirmation UI on
-minimal desktops.
+Interactive BlueFerry clients now default to that Connect-first transaction.
+They register their device-scoped `DisplayYesNo` agent as the default, call
+`Device1.Connect()` on the unpaired device, and wait for iOS to initiate
+authentication. BlueZ exposes neither its registered-agent list nor the
+identity of its default agent, so automatic desktop-agent heuristics proved too
+indirect to choose a reliable transaction.
 
-BlueZ exposes neither its registered-agent list nor the identity of its default
-agent. Clients therefore select between these transactions using a deliberately
-narrow session-bus heuristic: known interactive manager names are recognized,
-and KDE counts only when the `bluedevil` module is loaded in `kded5` or `kded6`.
-Generic headless agents such as a `NoInputNoOutput` `bt-agent` do not count;
-they cannot display numeric comparison and must not suppress BlueFerry's agent.
-This choice lives in the shared setup implementation, so the GTK, Qt, and
-Quickshell clients all use the same transaction on a given desktop.
+Some controllers instead cancel the Connect-first transaction before pairing
+finishes. For those systems the independent **Use explicit Bluetooth pairing**
+override registers the same device-scoped agent but calls `Device1.Pair()`
+directly. Headless callers also use explicit Pair because they cannot present
+BlueFerry's interactive confirmation UI. Explicit Pair may produce only a
+Classic bond on controllers such as the tested Intel device, so it is a
+controller workaround rather than the full-mode default. Delivery mode and
+authentication strategy are independent: either full or compatibility mode
+can use Connect-first or explicit Pair.
 
 After pairing, the iPhone offers **Show Message Notifications** and
 **Sync Contacts** in the computer's Bluetooth entry. These permissions are
@@ -88,13 +91,27 @@ connection hung and ended in `le-connection-abort-by-local`, while MAP/PBAP
 worked when attempted first. BlueZ still reported its LE bearer as paired and
 bonded, so those properties cannot predict whether the phone will answer.
 
-The experimental pairing flow therefore keeps the ANCS solicitation
-advertisement active, activates obexd's local Message Notification Server
-before pairing, and makes MAP/PBAP the first post-pair profile attempt. LE is
-enabled after that attempt completes, whether it succeeds or fails. Before
-each connection request the daemon explicitly selects the corresponding BlueZ
-`PreferredBearer`; otherwise the pairing-time BR/EDR preference prevents the
-later LE request from completing.
+BlueFerry therefore resolves two delivery modes. Full mode requires a
+controller with BR/EDR, LE, and advertising plus BlueZ 5.86 or newer. Its
+bearer API must already be active or be activatable through the package's
+systemd drop-in before pairing proceeds. Compatibility mode is selected
+automatically when ANCS is unavailable or explicitly for iOS 18 and earlier.
+It still broadcasts ANCS solicitation when the controller can advertise,
+because that signal exposes the MAP/PBAP permissions, but persists
+`BLUEFERRY_ANCS_ENABLED=false` and never enables an outbound LE/ANCS
+connection. MAP and PBAP are its successful end state; absence of Notification
+Access is expected and group messages may consequently lack ANCS-derived group
+metadata.
+
+Both modes activate obexd's local Message Notification Server before pairing.
+After authentication, setup trusts the bond, selects BR/EDR as the preferred
+bearer, lets the existing Classic ACL settle, and only then registers the
+short-lived solicitation advertisement. The daemon starts while that advert
+and BlueFerry's temporary pairing agent are still present, and its first
+profile operation is MAP/PBAP. Full mode enables LE after that first profile
+attempt completes, whether it succeeds or fails; compatibility mode leaves LE
+disabled. Before later connection requests the daemon selects the corresponding
+BlueZ `PreferredBearer` when that property is available.
 
 On a clean iOS 26 test this ordering opened MAP/PBAP first; the pending LE
 request completed three seconds later, resolved all three ANCS characteristics,
@@ -116,10 +133,11 @@ interrupted probe is retried while MAP/PBAP remains available.
 Without the relevant permission, MAP or PBAP can be visible at the SDP level
 but reject an OBEX connection with `Forbidden`/`0x43`; that state resolves
 once the toggle is enabled and is not a reason to re-pair. A MAP `Connection
-refused (111)` at the transport level is a different, unrecoverable state
-observed with stale or incomplete bonds. BlueFerry therefore treats a
-completed bond as only the beginning of setup and verifies the live profiles
-before reporting success.
+refused (111)` at the transport level is different: another computer may own
+the iPhone's single MAP session, although stale or incomplete bonds can look
+similar. BlueFerry exposes that state distinctly and keeps polling rather than
+misreporting a permissions failure. A completed bond is therefore only the
+beginning of setup; clients verify the live profiles before reporting success.
 
 ## MAP receive behavior
 
@@ -233,12 +251,15 @@ is already in use by another computer, iOS rejects `CreateSession(MAP)` with
 keep the daemon available, expose the refusal to clients, and continue polling
 so Blueferry connects when the competing session is released.
 
-The saved target MAC is also the MAP trust boundary. Discovery or a Classic
-bond alone must never put a phone into Blueferry's configuration. The pairing
-flow persists the MAC and starts the daemon only after it has successfully
-connected the same bond over LE for ANCS. If ANCS/LE setup is incomplete, the
-phone may remain paired in BlueZ, but Blueferry does not persist that target
-MAC and therefore cannot attempt a MAP session to it.
+The saved target MAC is also the MAP trust boundary. Discovery alone must never
+put a phone into BlueFerry's configuration. Setup persists only the device it
+just authenticated, trusted, and settled over Classic, together with the
+resolved ANCS policy, then starts the daemon so MAP/PBAP can be verified.
+Compatibility mode intentionally persists a Classic-only target. Full mode may
+also persist before ANCS authorization finishes: the daemon continues the
+bounded LE connection, GATT discovery, and authorization probe while MAP/PBAP
+remain available. Removing the bond invalidates the saved runtime target and
+stops the daemon's connection attempts.
 
 - Keep one MAP and one PBAP session open for the daemon lifetime.
 - Serialize blocking MAP/PBAP operations on one worker.
@@ -274,11 +295,11 @@ method or `Connected` property) depending on the packaged BlueZ build, so the
 Classic bearer is driven and observed through `org.bluez.Device1` instead.
 During first-time setup, `Device1.PreferredBearer=le` followed by
 `Bearer.LE1.Connect` established (or confirmed) the LE connection on BlueZ
-5.87; the supervising daemon afterwards does not keep re-setting
-`PreferredBearer`, since BlueZ only applies that property while disconnected
-and preferring LE removes the device from the normal auto-connect list.
-BlueFerry supervises both connections for the daemon lifetime, repeats the
-sequence after disconnects and system resume, and backs off exponentially
+5.87. `PreferredBearer` is treated as an instruction for the next outbound
+connection, not a durable preference: the supervisor selects `bredr` or `le`
+immediately before requesting that bearer and does not leave LE preferred while
+idle. BlueFerry supervises both connections for the daemon lifetime, repeats
+the sequence after disconnects and system resume, and backs off exponentially
 when a bearer keeps refusing to connect: a rejected `Connect` repeated every
 five seconds against the iPhone was observed to keep the bond in a
 half-connected flapping state.
@@ -292,8 +313,13 @@ This works on the MediaTek MT7922 and the Intel AX210 while MAP and PBAP stay
 connected over BR/EDR; on the AX210 the LE half of the bond exists only when
 the iPhone initiated the authentication (see "Pairing and iPhone
 permissions").
-BlueFerry's Arch package enables the necessary bluetoothd experimental API. The
-requirement is based on controller capabilities, not an Intel vendor check.
+BlueFerry's Arch and RPM packages enable the necessary bluetoothd experimental
+API and require BlueZ 5.86 or newer. DEB packages target several distributions
+with older or divergent BlueZ releases and deliberately do not modify the
+system Bluetooth unit; full ANCS is offered there only when the installed
+daemon already exposes the 5.86+ bearer API. Otherwise pairing falls back to
+MAP/PBAP compatibility mode instead of blocking. The requirement is based on
+observed capabilities and the live API, not a controller-vendor check.
 
 ANCS responses have no outer total-length field and may arrive fragmented.
 Control Point requests must be serialized and reassembled according to the
@@ -323,6 +349,21 @@ oFono and PipeWire's native HFP backend race to register the same BlueZ
 profile, making startup ordering and distribution integration fragile. That
 complexity, dependency burden, and the project's messaging focus are why the
 feature was removed despite protocol feasibility.
+
+## Pairing diagnostics
+
+Each pairing attempt records the resolved delivery mode, authentication
+strategy, controller capability, phone/bearer observations, daemon transport
+state, and an ordered monotonic timeline. Reports redact device addresses,
+object paths, and user directories before they are retained or embedded in a
+GitHub issue URL.
+
+Native packages also bake a SHA-256 of their deterministic source snapshot.
+The report's `blueferry_build` uses the same package-release plus short-SHA
+format as the daemon's private `_build_id` status field, while
+`blueferry_sha` retains the complete digest. Source checkouts fall back to the
+Git commit SHA. These fields distinguish same-version local rebuilds without
+changing the public D-Bus interface version.
 
 ## Maintenance rule
 

--- a/README.md
+++ b/README.md
@@ -2,142 +2,154 @@
 
 ![BlueFerry messaging client](screenshot.png)
 
-iMessage Bluetooth bridge for Linux
+Use your iPhone's messages on Linux over Bluetooth.
 
 <p align="center">
   <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/90/Ferry_Blue_star_1_Rhodes.jpg/1920px-Ferry_Blue_star_1_Rhodes.jpg" width="320" alt="Blue Star ferry at Rhodes">
 </p>
 
-BlueFerry brings messages from a paired iPhone to a Linux desktop. It can
-receive and send SMS and iMessage, use the phone's contacts, and optionally
-mirror other iPhone notifications. It talks directly to the phone over
-Bluetooth; there is no Mac relay, Apple login, cloud service, or subscription.
+BlueFerry brings SMS and iMessage from a paired iPhone to your Linux desktop.
+You can read and reply to messages, start a conversation, search synced
+contacts, and optionally mirror other iPhone notifications. There is no Mac
+relay, Apple login, cloud service, or subscription.
 
-This is experimental software. Development has mostly used an iPhone 16 Pro
-Max running iOS 26.5, and Apple may change the behavior BlueFerry relies on.
-Don't make it your only way to receive an important message yet.
+This is still experimental software. Most development has used an iPhone 16
+Pro Max on iOS 26.5, with additional successful testing on an iPhone 17 Pro Max
+running an iOS 27 beta. Apple can change the Bluetooth behavior BlueFerry relies
+on, so don't make it your only way to receive an important message yet.
 
-## How it works
+## What works
 
-BlueFerry is not a reimplementation of Apple's private Messages protocol. It
-uses the Bluetooth accessory services exposed by the iPhone. On the tested
-phone, the Message Access Profile carries both SMS and iMessage; iOS still
-decides how an outgoing message is delivered.
+- Receive and send SMS and iMessage through the iPhone.
+- Sync contacts, including phone numbers and Apple-ID email addresses.
+- Mark messages read from the desktop.
+- Use native GTK, KDE/Kirigami, Quickshell, or terminal clients.
+- Keep local history encrypted with GNOME Keyring or KDE Wallet.
+- Reply to group chats when BlueFerry can identify the participants safely.
 
-There are native clients for GNOME, KDE, and Quickshell. They share one local
-backend, so pairing, contacts, preferences, and message history are the same
-whichever client you open.
+BlueFerry only knows about messages it sees while connected; it does not
+download your iCloud Messages archive. Attachments, reactions, typing
+indicators, FaceTime, calls, and complete sent-message history are not
+supported. MMS and RCS need more testing.
 
-New messages appear as they arrive and can be answered from the conversation.
-You can write to a phone number, an Apple-ID email address registered with
-iMessage, or a synced contact. BlueFerry only knows about messages it has seen;
-it is not an iCloud history browser and pairing will not download your complete
-Messages archive.
+Group replies are deliberately cautious. Bluetooth does not give BlueFerry a
+reliable group ID or complete roster, so it disables replies when the
+participants are unclear. Named groups may ask you to confirm a local reply
+roster. This does not change the group on the iPhone.
 
-Message popups are actionable: clicking one presents every currently running
-BlueFerry client and selects the matching conversation. The KDE client also
-provides a system-tray item; closing its window leaves it available there until
-you choose **Quit**.
+## Install
 
-Group chats work when BlueFerry can safely reconstruct the participants from
-the message and its matching iPhone notification. Bluetooth MAP does not send
-a group identifier or roster, so ambiguous groups remain read-only rather than
-risk replying to the wrong people. For a named group, BlueFerry can identify
-the thread but asks you to supply the other participants before enabling
-replies. That saved roster must be updated after membership changes.
-The roster is only BlueFerry's local reply map: editing it does not change the
-group in Messages on the iPhone. Named groups are keyed by their name because
-iOS exposes no conversation identifier, so two groups with the same name are
-ambiguous and may be combined. If a sender outside a saved roster appears,
-BlueFerry disables replies and warns that the roster needs review.
+### Arch Linux and CachyOS
 
-Attachments, reactions, typing indicators, FaceTime, calls, and a complete
-sent-message history are not supported. MMS and RCS have not been tested well
-enough to promise anything.
-
-## Install on Arch Linux
-
-Clone this repository and run:
+Clone the repository and run:
 
 ```bash
 ./build.sh -si
 ```
 
-The build uses dependencies from the official Arch repositories—nothing from
-the AUR or PyPI—and produces five ordinary pacman packages:
-`blueferry-backend`, `blueferry-gtk`, `blueferry-qt`, `blueferry-tui`, and
-`blueferry-quickshell`. Running `./build.sh` without `-i` builds them without
-installing them. The finished package archives are written to
-`packaging/arch/`.
+This builds and installs four normal pacman packages: `blueferry-backend`
+(including the terminal client), `blueferry-gtk`, `blueferry-qt`, and
+`blueferry-quickshell`. It uses repository dependencies rather than downloading
+from the AUR or PyPI.
 
-See [packaging/arch/README.md](packaging/arch/README.md) if you want to build
-individual packages or understand exactly what pacman owns.
+Run `./build.sh` without `-i` if you only want the package files. They are
+written to `packaging/arch/`. More details are in
+[packaging/arch/README.md](packaging/arch/README.md).
 
-Native package scaffolding is also available for Debian 13, Ubuntu 24.04 and 26.04,
-Linux Mint 22.3, Pop!_OS 24.04, PikaOS IV, and Fedora. See the
-[packaging support matrix](packaging/README.md) for the tested distributions,
-package split, and local build commands.
+### Debian, Ubuntu, Mint, Pop!_OS, PikaOS, and Fedora
+
+Native DEB and RPM recipes are included too. The tested matrix currently covers
+Debian 13, Ubuntu 24.04 and 26.04, Linux Mint 22.3, Pop!_OS 24.04, PikaOS IV,
+and Fedora 43 and 44. Some older Debian-family releases do not have the Qt
+dependencies, but the GTK client, backend, and TUI are still supported.
+
+See [packaging/README.md](packaging/README.md) for the exact support matrix and
+local build commands.
+
+Arch and Fedora packages can set up the newer Bluetooth support needed for
+iPhone system notifications. Debian-family packages do not change or restart
+Bluetooth; messages and contacts still work, and notifications are added only
+when that machine already supports them.
 
 ## Pair an iPhone
 
-Open the client for your desktop:
+Start the client that fits your desktop:
 
 ```bash
-blueferry-gtk         # GNOME
-blueferry-qt          # KDE
+blueferry-gtk         # GNOME, Cinnamon, and similar desktops
+blueferry-qt          # KDE Plasma
 blueferry-quickshell  # Quickshell
 ```
 
-On first launch it opens the iPhone setup page.
+Then:
 
-1. Let BlueFerry check the Bluetooth controller. Arch and Fedora packages
-   configure BlueZ's experimental bearer API and restart a running Bluetooth
-   service during installation. If that restart was suppressed, BlueFerry
-   offers to activate it through Polkit. Debian-family packages leave
-   Bluetooth unchanged and support MAP messages and PBAP contacts without
-   ANCS system notifications.
-2. Open your Bluetooth settings, click **Scan**, pick your phone, then hit
-   **Pair**. When this computer shows up in **Other Devices**, tap it and
-   approve the prompts. The confirmation code can take around 15 seconds to
-   appear on some controllers.
-3. Confirm the same code on both devices when prompted.
-4. On the iPhone, open **Settings → Bluetooth → ⓘ** beside the computer and
-   enable **Show Message Notifications** and **Sync Contacts**. You may need
-   to back out and tap **ⓘ** again before these toggles appear.
-   **Allow System Notifications** is also required to identify group text
-   threads; without it, a group text appears as a one-to-one conversation with
-   its sender.
-5. Wait for Messages and Contacts to show as connected. For the default
-   encrypted storage, approve the desktop wallet prompt that opens automatically.
+1. Keep the iPhone unlocked with **Settings → Bluetooth** open.
+2. Let BlueFerry check your Bluetooth controller.
+3. In BlueFerry, choose **Scan**, select the iPhone, and choose **Pair**.
+   BlueFerry starts the pairing request; you do not need to find and tap the
+   computer under **Other Devices** on the phone.
+4. When the request appears on the iPhone, approve it and confirm that both
+   devices show the same code. It can take around 15 seconds to appear.
+5. After pairing, tap **ⓘ** beside the computer on the iPhone and enable
+   **Show Message Notifications** and **Sync Contacts**. If the toggles are
+   missing, return to the Bluetooth device list and reopen the **ⓘ** page a few
+   times. If iOS asks to **Allow System Notifications**, approve that too.
+6. Wait for Messages and Contacts to show as connected. If you use the default
+   encrypted storage, approve the desktop wallet prompt.
 
-BlueFerry keeps a valid existing bond and will not repeatedly re-pair the
-phone. If you need a truly clean repair, forget the device on both sides and
-start again with the iPhone's Bluetooth page open.
+System Notification access lets BlueFerry recognize group-message metadata.
+When it is unavailable, ordinary messages and contacts still work, but a group
+message may look like a direct conversation with its sender.
 
-For a machine without a graphical client, the same setup is available from:
+### Pairing options
+
+Most people should leave both options unchecked.
+
+- **Compatibility pairing for iOS 18 or earlier** keeps the signal that makes
+  the Messages and Contacts permissions appear, but does not connect iPhone
+  system notifications. BlueFerry also chooses this automatically when the
+  local BlueZ stack cannot support them.
+- **Use explicit Bluetooth pairing** skips the normal connection-first
+  approach and asks BlueZ to pair immediately. Try it only if normal pairing
+  keeps getting canceled on that Bluetooth controller. It is independent of
+  iOS compatibility mode.
+
+For a clean retry, forget the computer on the iPhone and forget the iPhone on
+Linux before pairing again. Stale phone-side Bluetooth state can survive a
+one-sided forget, so reset both sides rather than repeatedly pairing over the
+old record.
+
+The terminal wizard exposes the same flow:
 
 ```bash
 blueferry pair-setup
+blueferry pair-setup --compatibility-mode
+blueferry pair-setup --explicit-pairing
 ```
 
-Once pairing is complete, opening a client starts the backend automatically.
-It also reconnects after normal Bluetooth interruptions and restarts itself
-after package upgrades; routine use should not require `systemctl --user`.
+Once setup is complete, the backend starts automatically and reconnects after
+normal Bluetooth interruptions. Package upgrades and same-version local
+rebuilds are detected automatically, so an old backend process is restarted
+when needed.
 
-On Arch, the Textual terminal client and its UI dependency are supplied by the
-separate `blueferry-tui` package. DEB and RPM builds include the client and a
-private Textual runtime in `blueferry-backend`. After pairing with a graphical
-client or `blueferry pair-setup`, start it with `blueferry-tui` (or
-`blueferry tui`). It
-provides searchable conversation previews, a message timeline, mouse support,
-a multiline composer, responsive narrow-terminal navigation, themes, and a
-command palette. Use the arrow keys or `j`/`k` to select a conversation,
-**Enter** to open it and to send from the composer, **Shift+Enter** for a new
-line, `/` to search, `n` for a new message, `?` for the keyboard map, and
-**Ctrl+P** for every command. Group
-replies show the backend-owned participant list in a confirmation dialog.
+## Terminal client
 
-### Omarchy Quattro
+The TUI is included in `blueferry-backend` on every supported package format.
+Arch uses its repository Textual package; DEB and RPM builds carry a private
+Textual 8 runtime for the TUI.
+
+Start it with either:
+
+```bash
+blueferry-tui
+blueferry tui
+```
+
+Press `?` for the keyboard map or `Ctrl+P` for the command palette. The TUI has
+conversation search, a multiline composer, mouse support, themes, and a layout
+that adapts to narrow terminals.
+
+## Omarchy Quattro
 
 The native bar panel lives in
 [omarchy-blueferry](https://github.com/erikwb/omarchy-blueferry):
@@ -146,39 +158,29 @@ The native bar panel lives in
 omarchy plugin add https://github.com/erikwb/omarchy-blueferry.git
 ```
 
-Its popup follows Quattro's own panel controls and shows connection health and
-recent conversations. The full Quickshell client handles messages, pairing,
-and preferences.
-
-Enable it from **Setup › Plugins**. If BlueFerry is not installed, clicking
-the widget opens a terminal with the source-build instructions. The standalone
-Quickshell client also follows the active Quattro theme.
+Enable it from **Setup › Plugins**. Its popup shows connection health and recent
+conversations; the full Quickshell client handles pairing, messages, and
+preferences.
 
 ## Notifications and local data
 
-The iPhone page can show message notifications only (the default), all iPhone
-notifications, or none. Ordinary app notifications are shown and discarded;
-they are not added to message history or exposed as a notification feed.
-Messages arriving through both MAP and ANCS are deduplicated.
-Because ordinary mirrored app notifications have no corresponding local view,
-only message notifications offer the open-conversation action.
+BlueFerry can show message notifications only—the default—all iPhone
+notifications, or none. Other app notifications are displayed and discarded;
+they are not added to message history. Messages seen through both MAP and ANCS
+are deduplicated.
 
-By default, message history and synced contacts are encrypted with a random key
-stored in GNOME Keyring or KDE Wallet. If the wallet is locked, live messages
-still work but history and contact lookup remain unavailable until you unlock
-it. The iPhone settings also offer unencrypted local storage, with an explicit
-warning, or **Do not retain local data**, which clears the cache and keeps new
-events ephemeral. Changing storage modes clears existing local history and
-cached contacts so encrypted and plaintext records are never mixed.
+Message history and contacts are encrypted by default with a random key stored
+in GNOME Keyring or KDE Wallet. If the wallet is locked, live messages continue
+to work, but retained history and contact lookup wait until you unlock it. You
+can also choose unencrypted storage or **Do not retain local data**. Changing
+storage modes clears the existing cache so encrypted and plaintext records are
+never mixed.
 
-BlueFerry stores configuration in `~/.config/blueferry` and local state in
-`~/.local/state/blueferry`. Pacman leaves those directories alone when the
-packages are removed. Delete them yourself if you want a complete reset; the
-encrypted mode's key is named “BlueFerry local storage key” in your wallet
-manager.
+Configuration lives in `~/.config/blueferry`; local state lives in
+`~/.local/state/blueferry`. Uninstalling packages does not delete either
+directory.
 
-The default popup lifetime and history limits can be changed in
-`~/.config/blueferry/local.env`:
+The common retention settings live in `~/.config/blueferry/local.env`:
 
 ```bash
 BLUEFERRY_SHOW_NOTIFICATION_CONTENT=false
@@ -188,11 +190,11 @@ BLUEFERRY_HISTORY_MAX_EVENTS=10000
 BLUEFERRY_HISTORY_MAX_PAYLOAD_BYTES=268435456
 ```
 
-Restart the user service after changing those environment settings.
+Restart the user service after editing those settings.
 
 ## Command line
 
-The graphical clients cover normal use, but the CLI is handy for diagnostics
+The graphical clients cover normal use, but the CLI is useful for diagnostics
 and scripts:
 
 ```bash
@@ -205,13 +207,13 @@ blueferry history-clear
 blueferry doctor
 ```
 
-`sms-list` asks the live phone first and falls back to retained history.
-Ambiguous contact names are resolved interactively rather than guessed.
+Ambiguous contact names are presented for you to choose from rather than
+guessed.
 
 ## Troubleshooting
 
-Start with the iPhone page in the app. It reports Messages, Contacts, and ANCS
-separately, which matters: messages and contact sync can work even when the
+Start with the iPhone page in the app. It reports Messages, Contacts, and iPhone
+Notifications separately; messages and contact sync can work even when the
 optional notification connection does not.
 
 For logs and prerequisite checks:
@@ -221,48 +223,37 @@ blueferry doctor
 journalctl --user -u blueferry -f
 ```
 
-If messages work but names do not, run **Sync Contacts** or
-`blueferry contacts-sync`. When reporting a hardware problem, include the
-iPhone model, iOS and BlueZ versions, and Bluetooth controller model. Remove
-phone numbers, names, message bodies, and Bluetooth addresses from logs first.
+If messages work but names do not, use **Sync Contacts** or run
+`blueferry contacts-sync`.
 
-## Technical notes
+Pairing failures save a scrubbed report that can be attached to a GitHub issue.
+It includes the package build and source SHA, pairing mode, controller details,
+and an ordered setup timeline. Please also include the iPhone model and iOS
+version. Reports remove Bluetooth addresses and home-directory paths, but it is
+still sensible to inspect anything before posting it publicly.
 
-BlueFerry uses three Bluetooth paths:
+## Technical details
 
-- MAP over OBEX carries messages, inbox queries, read state, and sends.
-- PBAP over OBEX supplies vCard contacts.
-- ANCS over BLE supplies optional app notifications and sometimes enough
-  display information to identify an unnamed group.
+BlueFerry uses three standard Bluetooth services:
 
-MAP and PBAP need a BR/EDR-capable controller. ANCS additionally needs usable
-Bluetooth LE support. The full path has been tested with a MediaTek MT7922, but
-BlueFerry checks controller capabilities rather than requiring a particular
-vendor.
+- MAP over Bluetooth Classic carries messages, read state, and sends.
+- PBAP over Bluetooth Classic supplies contacts.
+- ANCS over Bluetooth LE supplies optional notifications and group-message
+  display information.
 
-One unprivileged user daemon owns the Bluetooth sessions and exposes a small
-session D-Bus API to the clients. Private records are returned by method call,
-not broadcast in signals. Clients reply through opaque thread identities so a
-UI cannot silently change the recipients of an existing conversation. The
-default local encryption protects data at rest; unencrypted storage
-deliberately gives up that protection, and neither mode is a sandbox against
-another process already running as the same Unix user.
+One unprivileged per-user backend owns those connections and exposes a small
+session D-Bus API to the clients. Pairing uses normal Bluetooth confirmation
+and Polkit for the one system-level setup step; there is no sudoers rule or
+hidden Apple protocol.
 
-The pairing helper configures BlueZ through Polkit and presents the computer as
-an ordinary accessory. It does not exploit the phone, bypass pairing consent,
-or speak a hidden iCloud protocol. The long-running daemon is unprivileged and
-there is no sudoers rule.
+The deeper design and protocol notes live in
+[ARCHITECTURE.md](ARCHITECTURE.md), [PROTOCOL.md](PROTOCOL.md), and
+[TESTING.md](TESTING.md).
 
-BlueFerry used
+BlueFerry began from
 [iphonebridge](https://github.com/gabrielmeir53/iphonebridge), created by Gabe
-Shatunovsky, as its initial implementation point.
-
-The ANCS constants and wire-format
-parser/builders are adapted from
+Shatunovsky. The ANCS constants and wire-format code are adapted from
 [ANCS4Linux](https://github.com/bmh129/ancs4linux), by Paweł Zmarzły and
 Bradley Harmon, under GPL-2.0-or-later.
-
-The details live in [ARCHITECTURE.md](ARCHITECTURE.md),
-[PROTOCOL.md](PROTOCOL.md), and [TESTING.md](TESTING.md).
 
 BlueFerry is licensed under [GPL-2.0-only](LICENSE).

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ usage() {
     cat <<'EOF'
 Usage:
   ./build.sh                  Prepare the snapshot and run makepkg -C -f -s
-  ./build.sh -si              Build/install all five split packages
+  ./build.sh -si              Build/install all four split packages
   ./build.sh --prepare-only   Only refresh packaging/arch/blueferry-*.tar.gz
   ./build.sh -- <args...>     Pass arbitrary arguments to makepkg
 
@@ -57,7 +57,8 @@ fi
 
 archive="$ARCH_DIR/blueferry-$version.tar.gz"
 temporary="$archive.tmp.$$"
-trap 'rm -f -- "$temporary"' EXIT
+snapshot_work=$(mktemp -d)
+trap 'rm -f -- "$temporary"; rm -rf -- "$snapshot_work"' EXIT
 
 mapfile -d '' candidates < <(
     git -C "$ROOT" ls-files --cached --others --exclude-standard -z
@@ -80,13 +81,25 @@ if (( ${#files[@]} == 0 )); then
 fi
 
 source_epoch=$(git -C "$ROOT" log -1 --format=%ct)
-tar -C "$ROOT" \
+snapshot_dir="$snapshot_work/blueferry-$version"
+mkdir -p "$snapshot_dir"
+tar -C "$ROOT" -cf - -- "${files[@]}" | tar -C "$snapshot_dir" -xf -
+build_sha=$(
+    tar -C "$snapshot_dir" \
+        --sort=name \
+        --mtime="@$source_epoch" \
+        --owner=0 --group=0 --numeric-owner \
+        -cf - . | sha256sum | cut -d' ' -f1
+)
+printf '%s\n' "$build_sha" > "$snapshot_dir/.blueferry-build-sha"
+
+tar -C "$snapshot_work" \
     --sort=name \
     --mtime="@$source_epoch" \
     --owner=0 --group=0 --numeric-owner \
-    --transform="s|^|blueferry-$version/|" \
-    -cf - -- "${files[@]}" | gzip -n > "$temporary"
+    -cf - "blueferry-$version" | gzip -n > "$temporary"
 mv -f -- "$temporary" "$archive"
+rm -rf -- "$snapshot_work"
 trap - EXIT
 
 # makepkg must verify exactly the snapshot it is about to compile. Keep this
@@ -96,6 +109,7 @@ printf '%s\n' "$digest" > "$ARCH_DIR/.source-sha256"
 
 echo "Prepared $archive"
 echo "SHA-256: $digest"
+echo "Build SHA: $build_sha"
 echo "Snapshot files: ${#files[@]}"
 
 if "$prepare_only"; then

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -25,8 +25,12 @@ ShellRoot {
   property string pairingStatus: "Step 1: scan for the iPhone. Scanning does not pair it."
   property bool bluezActive: false
   property bool hardwareSupported: false
+  property bool messagesSupported: false
   property bool notificationsSupported: false
+  property bool ancsEnabled: true
   property bool pairingReady: false
+  property bool compatibilityModeOverride: false
+  property bool explicitPairingOverride: false
   property bool configured: false
   property bool targetSaved: false
   property bool targetBonded: false
@@ -55,6 +59,8 @@ ShellRoot {
     id: onboarding
     hardwareSupported: root.hardwareSupported
     notificationsSupported: root.notificationsSupported
+                            && root.ancsEnabled
+                            && !root.compatibilityModeOverride
     bluezActive: root.bluezActive
     configured: root.configured
     backendStatus: root.backendStatus
@@ -202,6 +208,10 @@ ShellRoot {
       pairProcess.command.push("--adapter", root.adapterName)
     if (replaceSavedTarget)
       pairProcess.command.push("--replace-saved-mac", configuredMac)
+    if (!notificationsSupported || compatibilityModeOverride)
+      pairProcess.command.push("--compatibility-mode")
+    if (explicitPairingOverride)
+      pairProcess.command.push("--explicit-pairing")
     pairProcess.running = true
   }
 
@@ -219,6 +229,7 @@ ShellRoot {
 
   function markCompatibilityUnavailable(message) {
     hardwareSupported = false
+    messagesSupported = false
     notificationsSupported = false
     pairingReady = false
     bluezActive = false
@@ -250,7 +261,8 @@ ShellRoot {
         return
       }
       root.pairingResultReceived = true
-      root.pairingStatus = parsed.ancs_ready || !root.notificationsSupported
+      root.ancsEnabled = parsed.ancs_enabled !== false
+      root.pairingStatus = parsed.ancs_ready || !root.ancsEnabled
         ? "Linux pairing complete. On the iPhone enable Show Message Notifications and Sync Contacts."
         : "Pairing is complete. Notification access is still settling; keep the iPhone Bluetooth settings open."
       root.pairingIssueReport = parsed.quirks_report || parsed.report_path || ""
@@ -309,6 +321,7 @@ ShellRoot {
         try {
           var parsed = JSON.parse(text)
           root.hardwareSupported = parsed.hardware_supported === true
+          root.messagesSupported = parsed.messages_supported === true
           root.notificationsSupported = parsed.notifications_supported === true
           root.pairingReady = parsed.pairing_ready === true
           root.bluezActive = parsed.bearer_api_active === true
@@ -351,6 +364,7 @@ ShellRoot {
           root.targetBonded = parsed.bonded === true
           root.configuredMac = root.targetSaved ? (parsed.mac || "") : ""
           root.configuredAdapter = root.targetSaved ? (parsed.adapter || "") : ""
+          root.ancsEnabled = parsed.ancs_enabled !== false
           if (typeof parsed.pairing_issue_report === "string")
             root.pairingIssueReport = parsed.pairing_issue_report
           if (root.targetSaved && root.bondStateKnown && !root.targetBonded)
@@ -634,6 +648,7 @@ ShellRoot {
             root.bondStateKnown = true
             root.configuredMac = ""
             root.configuredAdapter = ""
+            root.ancsEnabled = true
             root.backendStatus = ({})
             root.pairingDevices = []
             root.loadPairingDevices(false)
@@ -1245,20 +1260,36 @@ ShellRoot {
             visible: !root.configured
           }
           FerryLabel {
-            text: "Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. While it does, return to the Bluetooth device list and reopen this computer's ⓘ page a few times; turn on any new toggles that appear. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."
+            text: "Scan for and select your iPhone here, then choose Pair. When the pairing request appears on the iPhone, approve it and confirm that the codes match. Pairing may appear idle for up to 15 seconds. After it completes, return to the Bluetooth device list and open this computer's ⓘ page a few times; turn on any new toggles that appear. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."
             wrapMode: Text.Wrap
             Layout.fillWidth: true
             visible: !root.configured
           }
           FerryCheckBox {
+            id: compatibilityMode
+            visible: !root.configured
+            text: "Compatibility pairing for iOS 18 or earlier"
+            checked: !root.notificationsSupported || root.compatibilityModeOverride
+            enabled: root.notificationsSupported && !pairProcess.running
+            onClicked: root.compatibilityModeOverride = checked
+          }
+          FerryLabel {
+            visible: !root.configured && compatibilityMode.checked
+            text: "BlueFerry will still advertise ANCS solicitation so Messages and Contacts permissions appear, but it will not connect system notifications."
+            wrapMode: Text.Wrap
+            Layout.fillWidth: true
+          }
+          FerryCheckBox {
             id: confirmBluetoothRestart
             visible: !root.configured
                      && root.notificationsSupported && !root.bluezActive
+                     && !compatibilityMode.checked
             text: "I understand this briefly disconnects all Bluetooth devices"
           }
           FerryButton {
             visible: !root.configured
                      && root.notificationsSupported && !root.bluezActive
+                     && !compatibilityMode.checked
             text: bluezActivateProcess.running ? "Activating…" : "Activate Bluetooth support"
             enabled: confirmBluetoothRestart.checked && !bluezActivateProcess.running
             onClicked: {
@@ -1292,13 +1323,22 @@ ShellRoot {
             model: root.pairingDevices
             textRole: "label"
           }
+          FerryCheckBox {
+            id: explicitPairing
+            visible: !root.configured
+            text: "Use explicit Bluetooth pairing"
+            checked: root.explicitPairingOverride
+            enabled: !pairProcess.running
+            onClicked: root.explicitPairingOverride = checked
+          }
           FerryButton {
             visible: !root.configured
             text: pairProcess.running ? "Pairing…"
               : root.selectedPairingDevice() && root.selectedPairingDevice().paired
                 ? "Use existing pairing" : "2. Pair Selected iPhone"
             enabled: root.selectedPairingDevice() !== null
-                     && root.pairingReady
+                     && (compatibilityMode.checked
+                         ? root.messagesSupported : root.pairingReady)
                      && !deviceProcess.running && !pairProcess.running
             onClicked: {
               var device = root.selectedPairingDevice()

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -7,7 +7,7 @@ described below.
 
 | Package recipe | Tested distributions | Output |
 | --- | --- | --- |
-| `arch/PKGBUILD` | Arch Linux, CachyOS | backend, GTK, Qt, TUI, Quickshell |
+| `arch/PKGBUILD` | Arch Linux, CachyOS | backend with TUI, GTK, Qt, Quickshell |
 | `deb/` | Debian 13, Ubuntu 26.04, PikaOS IV | MAP/PBAP backend with TUI, GTK, Qt |
 | `deb/` | Ubuntu 24.04, Linux Mint 22.3, Pop!_OS 24.04 | MAP/PBAP backend with TUI, GTK |
 | `rpm/blueferry.spec` | Fedora 43, Fedora 44 | backend with TUI, GTK, Qt |

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -4,7 +4,6 @@ pkgname=(
   blueferry-backend
   blueferry-gtk
   blueferry-qt
-  blueferry-tui
   blueferry-quickshell
 )
 pkgver=0.6.3
@@ -91,8 +90,11 @@ check() {
 }
 
 package_blueferry-backend() {
-  pkgdesc='iPhone Bluetooth bridge backend, daemon, and CLI'
+  pkgdesc='iPhone Bluetooth bridge backend, daemon, CLI, and terminal client'
   install=blueferry-backend.install
+  conflicts=('blueferry-tui')
+  provides=('blueferry-tui')
+  replaces=('blueferry-tui')
   depends=(
     'bluez>=5.86'
     'bluez-obex'
@@ -104,16 +106,17 @@ package_blueferry-backend() {
     'python-cryptography>=42'
     'python-dbus'
     'python-gobject'
+    'python-textual>=8.0'
     'python-typer>=0.12'
   )
   cd "$pkgbase-$pkgver"
   install -d "$pkgdir/$_site"
   cp -a "$srcdir/$_stage/$_site/blueferry" "$pkgdir/$_site/"
   rm -rf -- "$pkgdir/$_site/blueferry/ui" "$pkgdir/$_site/blueferry/qt"
-  rm -f -- "$pkgdir/$_site/blueferry/tui.py" "$pkgdir/$_site/blueferry/tui.tcss"
-  rm -f -- "$pkgdir/$_site/blueferry/__pycache__/tui."*.pyc
   cp -a "$srcdir/$_stage/$_site/blueferry-$pkgver.dist-info" "$pkgdir/$_site/"
   install -Dm755 "$srcdir/$_stage/usr/bin/blueferry" "$pkgdir/usr/bin/blueferry"
+  install -Dm755 "$srcdir/$_stage/usr/bin/blueferry-tui" \
+    "$pkgdir/usr/bin/blueferry-tui"
 
   install -Dm644 systemd/blueferry.service \
     "$pkgdir/usr/lib/systemd/user/blueferry.service"
@@ -127,6 +130,8 @@ package_blueferry-backend() {
   install -d "$pkgdir/usr/share/blueferry"
   printf '%s\n' "$pkgver-$pkgrel" \
     > "$pkgdir/usr/share/blueferry/package-release"
+  install -Dm644 .blueferry-build-sha \
+    "$pkgdir/usr/share/blueferry/build-sha"
   install -Dm644 packaging/arch/blueferry-bluetooth.conf \
     "$pkgdir/usr/lib/systemd/system/bluetooth.service.d/blueferry.conf"
   install -Dm644 packaging/arch/70-blueferry-restart-bluetooth.hook \
@@ -180,24 +185,6 @@ package_blueferry-qt() {
     "$pkgdir/usr/share/metainfo/io.weirdware.BlueFerry.Qt.metainfo.xml"
   install -Dm644 data/icons/io.weirdware.BlueFerry.Gtk.svg \
     "$pkgdir/usr/share/icons/hicolor/scalable/apps/io.weirdware.BlueFerry.Qt.svg"
-  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
-}
-
-package_blueferry-tui() {
-  pkgdesc='Textual terminal client for BlueFerry'
-  depends=(
-    "blueferry-backend=$pkgver-$pkgrel"
-    'python-textual>=8.0'
-  )
-
-  cd "$pkgbase-$pkgver"
-  install -d "$pkgdir/$_site/blueferry"
-  install -Dm644 "$srcdir/$_stage/$_site/blueferry/tui.py" \
-    "$pkgdir/$_site/blueferry/tui.py"
-  install -Dm644 "$srcdir/$_stage/$_site/blueferry/tui.tcss" \
-    "$pkgdir/$_site/blueferry/tui.tcss"
-  install -Dm755 "$srcdir/$_stage/usr/bin/blueferry-tui" \
-    "$pkgdir/usr/bin/blueferry-tui"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }
 

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -1,7 +1,7 @@
 # Arch packages
 
-BlueFerry builds as five split pacman packages: the backend plus clients for
-GNOME, KDE, the terminal, and Quickshell. All build and runtime dependencies
+BlueFerry builds as four split pacman packages: the backend with its terminal
+client, plus clients for GNOME, KDE, and Quickshell. All build and runtime dependencies
 come from the official Arch repositories. The same packages are intended for
 Arch Linux and CachyOS and are built in both environments in package CI.
 The backend requires BlueZ 5.86 or newer because that is the first upstream
@@ -40,11 +40,10 @@ building. Finished package archives are left in `packaging/arch/`.
 
 The resulting packages are:
 
-- `blueferry-backend` for the daemon, CLI, D-Bus service, BlueZ setup, and
-  pairing support;
+- `blueferry-backend` for the daemon, CLI, terminal client, D-Bus service,
+  BlueZ setup, and pairing support;
 - `blueferry-gtk` for the GTK/libadwaita client;
 - `blueferry-qt` for the Qt/Kirigami client;
-- `blueferry-tui` for the Textual terminal client;
 - `blueferry-quickshell` for the standalone Quickshell client.
 
 Install only the clients you use. Each graphical client can perform first-run
@@ -57,10 +56,10 @@ The optional Omarchy bar widget is distributed separately from
 
 ## Removing BlueFerry
 
-For example, to remove all five packages:
+For example, to remove all four packages:
 
 ```bash
-sudo pacman -Rns blueferry-backend blueferry-gtk blueferry-qt blueferry-tui blueferry-quickshell
+sudo pacman -Rns blueferry-backend blueferry-gtk blueferry-qt blueferry-quickshell
 ```
 
 Pacman removes the daemon, clients, units, BlueZ drop-in, and application

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -8,7 +8,7 @@ OUTPUT="$ROOT/dist/deb"
 WORK=$(mktemp -d)
 trap 'rm -rf -- "$WORK"' EXIT
 
-for command in dpkg-buildpackage git python3 tar; do
+for command in dpkg-buildpackage git python3 sha256sum tar; do
     command -v "$command" >/dev/null || {
         echo "error: required command not found: $command" >&2
         exit 127
@@ -47,10 +47,16 @@ if (( ${#files[@]} == 0 )); then
 fi
 
 tar -C "$ROOT" -cf - -- "${files[@]}" | tar -C "$source_dir" -xf -
+source_epoch=$(git -C "$ROOT" log -1 --format=%ct)
+build_sha=$(
+    tar -C "$source_dir" --sort=name --mtime="@$source_epoch" \
+        --owner=0 --group=0 --numeric-owner -cf - . \
+        | sha256sum | cut -d' ' -f1
+)
+printf '%s\n' "$build_sha" > "$source_dir/.blueferry-build-sha"
 mkdir "$source_dir/debian"
 cp -a "$source_dir/packaging/deb/." "$source_dir/debian/"
 
-source_epoch=$(git -C "$ROOT" log -1 --format=%ct)
 tar -C "$WORK" --sort=name --mtime="@$source_epoch" \
     --owner=0 --group=0 --numeric-owner \
     --exclude="blueferry-$version/debian" \

--- a/packaging/build-rpm.sh
+++ b/packaging/build-rpm.sh
@@ -8,7 +8,7 @@ OUTPUT="$ROOT/dist/rpm"
 WORK=$(mktemp -d)
 trap 'rm -rf -- "$WORK"' EXIT
 
-for command in git gzip python3 rpmbuild tar; do
+for command in git gzip python3 rpmbuild sha256sum tar; do
     command -v "$command" >/dev/null || {
         echo "error: required command not found: $command" >&2
         exit 127
@@ -49,10 +49,18 @@ mkdir -p "$topdir"/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 archive="$topdir/SOURCES/blueferry-$version.tar.gz"
 temporary="$archive.tmp"
 source_epoch=$(git -C "$ROOT" log -1 --format=%ct)
-tar -C "$ROOT" --sort=name --mtime="@$source_epoch" \
+source_dir="$WORK/blueferry-$version"
+mkdir -p "$source_dir"
+tar -C "$ROOT" -cf - -- "${files[@]}" | tar -C "$source_dir" -xf -
+build_sha=$(
+    tar -C "$source_dir" --sort=name --mtime="@$source_epoch" \
+        --owner=0 --group=0 --numeric-owner -cf - . \
+        | sha256sum | cut -d' ' -f1
+)
+printf '%s\n' "$build_sha" > "$source_dir/.blueferry-build-sha"
+tar -C "$WORK" --sort=name --mtime="@$source_epoch" \
     --owner=0 --group=0 --numeric-owner \
-    --transform="s|^|blueferry-$version/|" \
-    -cf - -- "${files[@]}" | gzip -n > "$temporary"
+    -cf - "blueferry-$version" | gzip -n > "$temporary"
 mv -f -- "$temporary" "$archive"
 cp "$ROOT/packaging/rpm/blueferry.spec" "$topdir/SPECS/"
 

--- a/packaging/deb/README.md
+++ b/packaging/deb/README.md
@@ -22,8 +22,8 @@ client for your desktop, for example:
 sudo apt install ./dist/deb/blueferry-backend_*.deb ./dist/deb/blueferry-gtk_*.deb
 ```
 
-`blueferry-backend` includes `blueferry-tui` and a pinned private Textual 8
-runtime under `/usr/lib/blueferry/vendor`. The package build is offline: its
+`blueferry-backend` includes the `blueferry-tui` command and a pinned private
+Textual 8 runtime under `/usr/lib/blueferry/vendor`. The package build is offline: its
 wheel bundle is stored in the source tree and verified against committed
 SHA-256 checksums. Nothing is installed into Python's system package directory,
 so the bundle cannot replace or conflict with `python3-textual`.

--- a/packaging/deb/blueferry-backend.install
+++ b/packaging/deb/blueferry-backend.install
@@ -10,5 +10,6 @@ usr/lib/blueferry/vendor
 usr/lib/systemd/user/blueferry.service
 usr/lib/systemd/user/default.target.wants/blueferry.service
 usr/share/blueferry/package-release
+usr/share/blueferry/build-sha
 usr/share/dbus-1/interfaces/io.weirdware.BlueFerry.xml
 usr/share/dbus-1/services/io.weirdware.BlueFerry.service

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -36,6 +36,8 @@ override_dh_auto_install:
 		debian/tmp/usr/share/dbus-1/interfaces/io.weirdware.BlueFerry.xml
 	install -d debian/tmp/usr/share/blueferry
 	dpkg-parsechangelog -S Version > debian/tmp/usr/share/blueferry/package-release
+	install -Dm644 .blueferry-build-sha \
+		debian/tmp/usr/share/blueferry/build-sha
 	install -Dm644 data/io.weirdware.BlueFerry.Gtk.desktop \
 		debian/tmp/usr/share/applications/io.weirdware.BlueFerry.Gtk.desktop
 	install -Dm644 data/io.weirdware.BlueFerry.Gtk.metainfo.xml \

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -23,8 +23,8 @@ sudo dnf install dist/rpm/blueferry-backend-*.noarch.rpm \
   dist/rpm/blueferry-gtk-*.noarch.rpm
 ```
 
-`blueferry-backend` includes `blueferry-tui` and a pinned private Textual 8
-runtime under `/usr/lib/blueferry/vendor`. The package build is offline: its
+`blueferry-backend` includes the `blueferry-tui` command and a pinned private
+Textual 8 runtime under `/usr/lib/blueferry/vendor`. The package build is offline: its
 wheel bundle is stored in the source tree and verified against committed
 SHA-256 checksums. Nothing is installed into Python's system package directory,
 so the bundle cannot replace or conflict with Fedora's `python3-textual`.

--- a/packaging/rpm/blueferry.spec
+++ b/packaging/rpm/blueferry.spec
@@ -102,6 +102,8 @@ install -Dm0644 packaging/rpm/blueferry-bluetooth.conf \
 install -d %{buildroot}%{_datadir}/blueferry
 printf '%s\n' '%{version}-%{release}' \
     > %{buildroot}%{_datadir}/blueferry/package-release
+install -Dm0644 .blueferry-build-sha \
+    %{buildroot}%{_datadir}/blueferry/build-sha
 
 install -Dm0644 data/io.weirdware.BlueFerry.Gtk.desktop \
     %{buildroot}%{_datadir}/applications/io.weirdware.BlueFerry.Gtk.desktop
@@ -165,6 +167,7 @@ fi
 %{_userunitdir}/default.target.wants/blueferry.service
 %{_unitdir}/bluetooth.service.d/blueferry.conf
 %{_datadir}/blueferry/package-release
+%{_datadir}/blueferry/build-sha
 %{_datadir}/dbus-1/interfaces/io.weirdware.BlueFerry.xml
 %{_datadir}/dbus-1/services/io.weirdware.BlueFerry.service
 

--- a/packaging/vendor/textual/README.md
+++ b/packaging/vendor/textual/README.md
@@ -5,8 +5,8 @@ The DEB and RPM recipes unpack these pinned, pure-Python wheels into
 visible only to the BlueFerry TUI process. They do not provide, replace, or
 conflict with a distribution's system Python packages.
 
-Arch does not install this bundle; its `blueferry-tui` split package depends on
-the repository's `python-textual` package instead.
+Arch does not install this bundle; `blueferry-backend` includes the TUI and
+depends on the repository's `python-textual` package instead.
 
 `SHA256SUMS` is checked during every DEB and RPM build. The wheels retain their
 upstream metadata and license files. To update the bundle, resolve Textual's

--- a/src/blueferry/backend_lifecycle.py
+++ b/src/blueferry/backend_lifecycle.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import dbus
 import dbus.exceptions
 
+from blueferry.build_info import build_id, installed_build_sha
 from blueferry.bus import get_session_bus
 from blueferry.commands import run_command
 from blueferry.errors import BlueFerryError, CommandError
@@ -101,6 +102,8 @@ def ensure_backend_current(
     """
     read_status = status_reader or _status
     expected = installed_release()
+    expected_sha = installed_build_sha()
+    expected_build = build_id(expected, expected_sha) if expected is not None else None
     try:
         status = read_status()
     except (dbus.exceptions.DBusException, ValueError) as first_error:
@@ -116,7 +119,10 @@ def ensure_backend_current(
 
     # No marker means a source checkout or a package transaction currently
     # replacing the file. Neither case justifies restarting a live service.
-    if expected is None or status.get("backend_release") == expected:
+    if expected is None or (
+        status.get("backend_release") == expected
+        and (expected_sha is None or status.get("_build_id") == expected_build)
+    ):
         return status
 
     # A missing key is expected from versions released before lifecycle
@@ -128,15 +134,22 @@ def ensure_backend_current(
             status = read_status()
         except (dbus.exceptions.DBusException, ValueError):
             status = {}
-        if status.get("backend_release") != expected:
+        if status.get("backend_release") != expected or (
+            expected_sha is not None and status.get("_build_id") != expected_build
+        ):
             restart_backend()
             try:
                 status = read_status()
             except (dbus.exceptions.DBusException, ValueError) as error:
                 raise BackendLifecycleError(str(error)) from error
     actual = status.get("backend_release")
-    if actual != expected:
+    actual_build = status.get("_build_id")
+    if actual != expected or (
+        expected_sha is not None and actual_build != expected_build
+    ):
         raise BackendLifecycleError(
-            f"backend release is {actual or 'unknown'}; installed release is {expected}"
+            "backend build is "
+            f"{actual_build or actual or 'unknown'}; installed build is "
+            f"{expected_build or expected}"
         )
     return status

--- a/src/blueferry/build_info.py
+++ b/src/blueferry/build_info.py
@@ -1,0 +1,49 @@
+"""Private build identity shared by clients, the daemon, and diagnostics."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from blueferry.commands import run_command
+from blueferry.errors import CommandError
+
+BUILD_SHA_PATH = Path("/usr/share/blueferry/build-sha")
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SHA = re.compile(r"[0-9a-f]{7,64}")
+
+
+def _valid_sha(value: object) -> str | None:
+    candidate = str(value or "").strip().casefold()
+    return candidate if _SHA.fullmatch(candidate) else None
+
+
+def installed_build_sha() -> str | None:
+    """Return the content SHA baked into a native package."""
+    try:
+        return _valid_sha(BUILD_SHA_PATH.read_text(encoding="utf-8"))
+    except OSError:
+        return None
+
+
+def source_git_sha(*, project_root: Path = _PROJECT_ROOT) -> str | None:
+    """Return the checkout commit for source-run diagnostics."""
+    try:
+        result = run_command(
+            ["git", "-C", str(project_root), "rev-parse", "--verify", "HEAD"],
+            timeout=2,
+        )
+    except (CommandError, OSError):
+        return None
+    return _valid_sha(result.stdout)
+
+
+def running_build_sha() -> str | None:
+    """Return the packaged content SHA, or the checkout commit as a fallback."""
+    return installed_build_sha() or source_git_sha()
+
+
+def build_id(release: str, sha: str | None) -> str:
+    """Combine a public release with a short private source identity."""
+    valid = _valid_sha(sha)
+    return f"{release}+sha.{valid[:12]}" if valid else release

--- a/src/blueferry/cli.py
+++ b/src/blueferry/cli.py
@@ -130,6 +130,19 @@ def pair_setup(
         "--debug",
         help="Print detailed Bluetooth pairing and connection activity",
     ),
+    compatibility_mode: bool = typer.Option(
+        False,
+        "--compatibility-mode",
+        help=(
+            "Skip ANCS connection attempts and use MAP/PBAP only "
+            "(recommended for iOS 18 or earlier)"
+        ),
+    ),
+    explicit_pairing: bool = typer.Option(
+        False,
+        "--explicit-pairing",
+        help="Call Pair immediately instead of initiating pairing with Connect",
+    ),
 ):
     """First-run wizard: pick a paired iPhone, write the local config,
     walk through the iPhone-side toggle steps."""
@@ -138,7 +151,12 @@ def pair_setup(
 
     from blueferry.pairing_cli import run_wizard
 
-    raise typer.Exit(code=run_wizard(verify_after=not no_verify))
+    code = run_wizard(
+        verify_after=not no_verify,
+        compatibility_mode=compatibility_mode,
+        explicit_pairing=explicit_pairing,
+    )
+    raise typer.Exit(code=code)
 
 
 @app.command("pairing-devices-json", hidden=True)
@@ -234,6 +252,12 @@ def pairing_complete(
     interactive_agent: bool = typer.Option(False, "--interactive-agent", hidden=True),
     adapter: str = typer.Option("", "--adapter"),
     replace_saved_mac: str = typer.Option("", "--replace-saved-mac", hidden=True),
+    compatibility_mode: bool = typer.Option(
+        False, "--compatibility-mode", hidden=True,
+    ),
+    explicit_pairing: bool = typer.Option(
+        False, "--explicit-pairing", hidden=True,
+    ),
     debug: bool = typer.Option(False, "--debug"),
 ) -> None:
     """Pair and perform all Linux-side setup for graphical clients."""
@@ -272,6 +296,8 @@ def pairing_complete(
             adapter=selected,
             confirmation=confirm if interactive_agent else None,
             display=display if interactive_agent else None,
+            compatibility_mode=compatibility_mode,
+            explicit_pairing=explicit_pairing,
         )
         emit(result.to_dict())
     except PairingError as error:

--- a/src/blueferry/config.py
+++ b/src/blueferry/config.py
@@ -12,6 +12,7 @@ MAX_CONFIG_FILE_BYTES = 64 * 1024
 LOCAL_ENV_KEYS = frozenset({
     "BLUEFERRY_MAC",
     "BLUEFERRY_ADAPTER",
+    "BLUEFERRY_ANCS_ENABLED",
     "BLUEFERRY_SHOW_NOTIFICATION_CONTENT",
     "BLUEFERRY_NOTIFICATION_TIMEOUT_MS",
     "BLUEFERRY_HISTORY_RETENTION_DAYS",
@@ -142,6 +143,13 @@ def _env_int(name: str, default: int, minimum: int, maximum: int) -> int:
         value = default
     return max(minimum, min(value, maximum))
 
+
+ANCS_ENABLED: bool = _env_bool("BLUEFERRY_ANCS_ENABLED", True)
+"""Whether the daemon should connect and subscribe to ANCS over LE.
+
+The pairing solicitation advertisement is deliberately independent: even
+compatibility mode broadcasts it so iOS exposes MAP/PBAP permissions.
+"""
 
 SHOW_NOTIFICATION_CONTENT: bool = _env_bool(
     "BLUEFERRY_SHOW_NOTIFICATION_CONTENT", True

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -17,6 +17,7 @@ from blueferry.ancs.client import AncsClient
 from blueferry.backend_lifecycle import installed_release
 from blueferry.backend_operations import BackendDependencies
 from blueferry.bearer_supervisor import BearerSupervisor
+from blueferry.build_info import build_id, installed_build_sha, running_build_sha
 from blueferry.bus import get_system_bus, main_loop
 from blueferry.connectivity import Connectivity
 from blueferry.contacts import ContactsResolver, clear_contact_cache, pull_phonebook
@@ -104,6 +105,13 @@ class Daemon:
         packaged_release = installed_release()
         self._packaged = packaged_release is not None
         self._running_release = packaged_release or __version__
+        self._running_build_sha = (
+            installed_build_sha() if self._packaged else running_build_sha()
+        )
+        self._running_build_id = build_id(
+            self._running_release,
+            self._running_build_sha,
+        )
         self._release_check_id: int | None = None
         self._target_config_check_id: int | None = None
         self._restart_after_upgrade = False
@@ -119,7 +127,9 @@ class Daemon:
             on_ready=self._post_sessions_setup,
             on_lost=self._profiles_lost,
             on_status=self._emit_status,
-            on_first_attempt_complete=self.bearers.enable_le,
+            on_first_attempt_complete=(
+                self.bearers.enable_le if config.ANCS_ENABLED else None
+            ),
         )
 
     def _emit_status(self) -> None:
@@ -260,7 +270,7 @@ class Daemon:
         # The bearer supervisor connects LE alongside BR/EDR; the client waits
         # for the three ANCS characteristics and subscribes when they appear.
         device_path = f"/org/bluez/{config.ADAPTER}/dev_{config.IPHONE_MAC.replace(':', '_')}"
-        if self.ancs is None:
+        if config.ANCS_ENABLED and self.ancs is None:
             candidate = AncsClient(
                 device_path,
                 on_event=self.events.ancs,
@@ -275,6 +285,8 @@ class Daemon:
                 candidate.stop()
                 raise
             self.ancs = candidate
+        elif not config.ANCS_ENABLED:
+            log.info("ANCS connection disabled by pairing compatibility policy")
         self._watch_sleep_resume()
 
         # Sinks don't need the OBEX sessions — set them up now so ANCS events
@@ -374,6 +386,7 @@ class Daemon:
         ancs = self.ancs
         return {
             "backend_release": self._running_release,
+            "_build_id": self._running_build_id,
             "initializing": self._initializing,
             "ancs": bool(ancs and ancs.connected),
             "ancs_subscribed": bool(ancs and ancs.subscribed),
@@ -416,10 +429,14 @@ class Daemon:
 
     def _check_package_release(self) -> bool:
         current = installed_release()
-        if current == self._running_release:
+        current_sha = installed_build_sha()
+        current_build = build_id(current, current_sha) if current is not None else None
+        if current_build == self._running_build_id:
             self._release_missing_checks = 0
             return True
-        if current is None:
+        if current is None or (
+            self._running_build_sha is not None and current_sha is None
+        ):
             # Pacman may briefly replace the marker during an upgrade. Three
             # consecutive misses distinguish removal from that transient.
             self._release_missing_checks += 1
@@ -431,8 +448,8 @@ class Daemon:
         self._release_missing_checks = 0
         log.info(
             "installed backend changed from %s to %s; restarting",
-            self._running_release,
-            current,
+            self._running_build_id,
+            current_build,
         )
         self._restart_after_upgrade = True
         main_loop.quit()

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -19,6 +19,7 @@ from blueferry.bluetooth_devices import PairedDevice
 from blueferry.bus import get_session_bus, get_system_bus
 from blueferry.commands import run_command
 from blueferry.errors import CommandError, PairingError
+from blueferry.pairing_policy import resolve_pairing_policy
 from blueferry.private_files import atomic_write_private_text
 from blueferry.setup_verification import clear_setup_verification
 
@@ -60,6 +61,10 @@ def configuration_status() -> dict:
         "bonded": bonded,
         "mac": mac if saved else "",
         "adapter": adapter,
+        "ancs_enabled": (
+            values.get("BLUEFERRY_ANCS_ENABLED", "true").casefold()
+            not in {"0", "false", "no", "off"}
+        ),
         "path": str(LOCAL_ENV_PATH),
     }
 
@@ -647,6 +652,8 @@ def complete_pairing(
     adapter: str | None = None,
     confirmation: ConfirmationCallback | None = None,
     display: DisplayCallback | None = None,
+    compatibility_mode: bool = False,
+    explicit_pairing: bool = False,
 ) -> dict:
     """Pair if needed and finish every Linux-side BlueFerry setup step."""
     attempt = quirks_report.start_attempt(interactive=confirmation is not None)
@@ -656,6 +663,8 @@ def complete_pairing(
             adapter=adapter,
             confirmation=confirmation,
             display=display,
+            compatibility_mode=compatibility_mode,
+            explicit_pairing=explicit_pairing,
             attempt=attempt,
         )
     except PairingError as error:
@@ -1056,6 +1065,8 @@ def _execute_pairing(
     adapter: str | None = None,
     confirmation: ConfirmationCallback | None = None,
     display: DisplayCallback | None = None,
+    compatibility_mode: bool = False,
+    explicit_pairing: bool = False,
     attempt: dict,
 ) -> dict:
     from blueferry import bluez_setup
@@ -1082,8 +1093,22 @@ def _execute_pairing(
     quirks_report.mark(attempt, "compatibility_ready")
     if not compatibility["hardware_supported"]:
         raise PairingError(compatibility["issue"] or "Bluetooth controller is incompatible")
-    notifications_supported = compatibility["notifications_supported"]
-    if notifications_supported and not compatibility["bearer_api_active"]:
+    policy = resolve_pairing_policy(
+        compatibility,
+        force_compatibility=compatibility_mode,
+        force_explicit_pairing=explicit_pairing,
+        interactive=confirmation is not None,
+    )
+    attempt["pairing_policy"] = policy.to_dict()
+    log.info(
+        "pairing policy: mode=%s strategy=%s ANCS=%s solicitation=%s (%s)",
+        policy.mode.value,
+        policy.pairing_strategy,
+        "enabled" if policy.ancs_enabled else "disabled",
+        "enabled" if policy.solicitation_enabled else "unavailable",
+        policy.reason,
+    )
+    if policy.ancs_enabled and not compatibility["bearer_api_active"]:
         raise PairingError("Activate Bluetooth support before pairing or re-pairing the iPhone")
     # No LE advertisement during pairing: iOS would connect the unbonded
     # advert as a separate accessory and keep two device records. The advert
@@ -1135,28 +1160,35 @@ def _execute_pairing(
                         if display is not None:
                             display(passkey)
 
-                    # Connecting the unpaired ACL makes iOS initiate pairing,
-                    # and the authentication initiator is the side that derives
-                    # the cross-transport LE keys. The client has explicit
-                    # confirmation UI, so its device-scoped agent temporarily
-                    # becomes BlueZ default for this transaction even when a
-                    # desktop agent is already registered.
+                    # Normally the iPhone initiates authentication so it owns
+                    # cross-transport key derivation. The explicit option
+                    # instead skips Connect for controllers known to cancel it.
                     registered = pairing_agents.enter_context(
                         RegisteredPairingAgent(
                             device.device_path,
                             timed_confirmation,
                             timed_display,
+                            make_default=policy.iphone_initiated,
                         )
                     )
                     agent_registered = True
                     quirks_report.mark(attempt, "agent_registered")
-                    _connect_classic(
-                        device.device_path,
-                        timeout=60.0,
-                        settle=False,
-                        attempt=attempt,
-                    )
-                    registered.wait_for_pair(timeout=120.0)
+                    if policy.iphone_initiated:
+                        _connect_classic(
+                            device.device_path,
+                            timeout=60.0,
+                            settle=False,
+                            attempt=attempt,
+                        )
+                        registered.wait_for_pair(timeout=120.0)
+                        attempt["pairing_transaction"] = (
+                            "iphone-initiated-connect"
+                        )
+                    else:
+                        quirks_report.mark(attempt, "pair_sent")
+                        registered.pair(timeout=120.0)
+                        quirks_report.mark(attempt, "pair_replied")
+                        attempt["pairing_transaction"] = "explicit-device-pair"
             except dbus.exceptions.DBusException as error:
                 name = error.get_dbus_name() or ""
                 if name in {
@@ -1182,19 +1214,18 @@ def _execute_pairing(
         trust_device(device.mac, device.adapter_path)
         quirks_report.mark(attempt, "trusted")
 
-        if notifications_supported:
-            _prefer_bredr(device.device_path)
-            quirks_report.mark(attempt, "preferred_bearer_bredr")
-        # The pairing transaction already established the Classic ACL.  A
-        # second generic Device1.Connect can wander into LE and hangs on the
-        # observed iOS 18 path, so only require that existing ACL to settle.
+        _prefer_bredr(device.device_path)
+        quirks_report.mark(attempt, "preferred_bearer_bredr")
+        # Both pairing transactions should leave a Classic ACL behind. A
+        # second generic Device1.Connect can wander into LE, so only require
+        # that the existing ACL settle.
         _wait_for_classic_settled(device.device_path, attempt=attempt)
 
         # Keep ANCS solicitation active because iOS 26 testing found that it
         # surfaced the MAP/PBAP permission toggles.  It is a pairing signal,
         # not a prerequisite connection: the daemon below attempts MAP/PBAP
         # before it is allowed to connect the LE bearer.
-        if notifications_supported:
+        if policy.solicitation_enabled:
             log.debug("registering ANCS solicitation advertisement on %s", adapter)
             quirks_report.mark(attempt, "advert_register_sent")
             if not bluez_setup.register_advert(adapter, settle_for_pairing=True):
@@ -1203,24 +1234,28 @@ def _execute_pairing(
             quirks_report.mark(attempt, "advert_ready")
         else:
             log.info(
-                "BlueZ lacks usable per-bearer controls; continuing with "
-                "MAP/PBAP without ANCS"
+                "the controller cannot advertise ANCS solicitation; "
+                "continuing with MAP/PBAP"
             )
 
         # Start the long-lived owner while both the advert and temporary
-        # pairing agent are still present.  Its first operation is a Classic
-        # MAP/PBAP open; only when that attempt completes does it enable LE.
-        write_local_env(device.mac, adapter)
+        # pairing agent are still present. Its first operation is a Classic
+        # MAP/PBAP open; full mode enables LE only after that attempt, while
+        # compatibility mode leaves LE disabled permanently.
+        if policy.ancs_enabled:
+            write_local_env(device.mac, adapter)
+        else:
+            write_local_env(device.mac, adapter, False)
         log.debug("saved paired target %s; restarting user service", device.mac)
         quirks_report.mark(attempt, "daemon_restart_sent")
         _restart_user_service()
         quirks_report.mark(attempt, "daemon_restarted")
         map_ready, pbap_ready, ancs_ready = _wait_for_daemon_transports(
             attempt=attempt,
-            notifications_supported=notifications_supported,
+            notifications_supported=policy.ancs_enabled,
         )
-        if not notifications_supported:
-            ancs = "unsupported"
+        if not policy.ancs_enabled:
+            ancs = "disabled"
         else:
             ancs = "connected" if ancs_ready else "daemon connecting"
         log.info(
@@ -1252,6 +1287,7 @@ def _execute_pairing(
         "config": str(LOCAL_ENV_PATH),
         "service": "package-enabled and restarted",
         "ancs": ancs,
+        "ancs_enabled": policy.ancs_enabled,
         "ancs_ready": ancs_ready,
         "iphone_steps": [
             "Open Settings → Bluetooth and tap ⓘ next to this computer",
@@ -1314,6 +1350,7 @@ def clear_local_target() -> Path:
     existing = config.read_local_env(LOCAL_ENV_PATH)
     existing.pop("BLUEFERRY_MAC", None)
     existing.pop("BLUEFERRY_ADAPTER", None)
+    existing.pop("BLUEFERRY_ANCS_ENABLED", None)
     content = "".join(
         f"{key}={existing[key]}\n" for key in sorted(config.LOCAL_ENV_KEYS) if key in existing
     )
@@ -1332,7 +1369,11 @@ def clear_local_target() -> Path:
     return LOCAL_ENV_PATH
 
 
-def write_local_env(mac: str, adapter: str | None = None) -> Path:
+def write_local_env(
+    mac: str,
+    adapter: str | None = None,
+    ancs_enabled: bool = True,
+) -> Path:
     normalized_mac = mac.strip().upper()
     if not config.is_valid_mac(normalized_mac):
         raise PairingError("invalid Bluetooth device address")
@@ -1342,7 +1383,8 @@ def write_local_env(mac: str, adapter: str | None = None) -> Path:
     existing["BLUEFERRY_MAC"] = normalized_mac
     if adapter:
         existing["BLUEFERRY_ADAPTER"] = adapter
-    ordered = ["BLUEFERRY_MAC", "BLUEFERRY_ADAPTER"]
+    existing["BLUEFERRY_ANCS_ENABLED"] = "true" if ancs_enabled else "false"
+    ordered = ["BLUEFERRY_MAC", "BLUEFERRY_ADAPTER", "BLUEFERRY_ANCS_ENABLED"]
     ordered.extend(sorted(config.LOCAL_ENV_KEYS - set(ordered)))
     content = "".join(f"{key}={existing[key]}\n" for key in ordered if key in existing)
     try:

--- a/src/blueferry/pairing_agent.py
+++ b/src/blueferry/pairing_agent.py
@@ -162,13 +162,12 @@ class PairingAgent(dbus.service.Object):
 
 
 class RegisteredPairingAgent:
-    """Register the default agent for one interactive pairing transaction.
+    """Register a device-scoped agent for one interactive transaction.
 
-    The agent's D-Bus callbacks are dispatched by a GLib loop running on the
-    caller's thread (``wait_for_pair``). An earlier design ran the loop on a
-    background thread next to a synchronous ``Device1.Pair()``; dbus-python
-    intermittently lost the confirmation reply in that arrangement, producing
-    spurious authentication failures.
+    iPhone-initiated pairing makes this agent temporarily default so the
+    authentication request reaches it. Explicit ``Device1.Pair`` instead
+    selects the agent through its D-Bus connection. Both paths dispatch
+    callbacks on this thread's GLib loop.
     """
 
     def __init__(
@@ -176,6 +175,8 @@ class RegisteredPairingAgent:
         expected_device: str,
         confirmation: ConfirmationCallback,
         display: DisplayCallback | None = None,
+        *,
+        make_default: bool = False,
     ) -> None:
         self._bus = get_system_bus()
         self._expected_device = expected_device
@@ -190,6 +191,7 @@ class RegisteredPairingAgent:
             "org.bluez.AgentManager1",
         )
         self._registered = False
+        self._make_default = make_default
 
     def __enter__(self) -> RegisteredPairingAgent:
         try:
@@ -203,16 +205,15 @@ class RegisteredPairingAgent:
                 timeout=10.0,
             )
             self._registered = True
-            # The BlueFerry client owns the confirmation UI for this explicit
-            # transaction. Become default so an iPhone-initiated request
-            # reaches this scoped agent even if a desktop or headless agent was
-            # registered first. UnregisterAgent removes us from BlueZ's
-            # default-agent queue and restores the previous agent afterward.
-            self._manager.RequestDefaultAgent(
-                dbus.ObjectPath(AGENT_PATH),
-                timeout=10.0,
-            )
-            log.info("BlueFerry pairing agent is now the BlueZ default")
+            if self._make_default:
+                # The transaction is initiated by the iPhone, so BlueZ must
+                # route its confirmation to this scoped agent.
+                # UnregisterAgent restores the previous default afterward.
+                self._manager.RequestDefaultAgent(
+                    dbus.ObjectPath(AGENT_PATH),
+                    timeout=10.0,
+                )
+                log.info("BlueFerry pairing agent is now the BlueZ default")
         except dbus.exceptions.DBusException as error:
             self._unregister()
             self._agent.remove_from_connection()
@@ -229,7 +230,8 @@ class RegisteredPairingAgent:
             return
         try:
             log.info(
-                "unregistering BlueFerry pairing agent; restoring previous default"
+                "unregistering BlueFerry pairing agent%s",
+                "; restoring previous default" if self._make_default else "",
             )
             self._manager.UnregisterAgent(
                 dbus.ObjectPath(AGENT_PATH),
@@ -241,6 +243,53 @@ class RegisteredPairingAgent:
                 error.get_dbus_name() or str(error),
             )
         self._registered = False
+
+    def pair(self, timeout: float = 120.0) -> None:
+        """Run explicit Device1.Pair while dispatching Agent1 callbacks."""
+        log.info("sending Device1.Pair for %s", self._expected_device)
+        loop = GLib.MainLoop()
+        failure: list[Exception] = []
+        finished = False
+
+        def paired() -> None:
+            nonlocal finished
+            finished = True
+            log.info("Device1.Pair completed successfully")
+            loop.quit()
+
+        def failed(error: Exception) -> None:
+            nonlocal finished
+            finished = True
+            failure.append(error)
+            loop.quit()
+
+        def timed_out() -> bool:
+            if finished:
+                return GLib.SOURCE_REMOVE
+            failure.append(PairingError(
+                "Timed out waiting for the iPhone to pair. Keep Bluetooth "
+                "settings open on the phone and retry."
+            ))
+            loop.quit()
+            return GLib.SOURCE_REMOVE
+
+        interface = dbus.Interface(
+            self._bus.get_object("org.bluez", self._expected_device),
+            "org.bluez.Device1",
+        )
+        interface.Pair(
+            reply_handler=paired,
+            error_handler=failed,
+            timeout=timeout,
+        )
+        timeout_source = GLib.timeout_add(int(timeout * 1000), timed_out)
+        try:
+            loop.run()
+        finally:
+            if finished:
+                GLib.source_remove(timeout_source)
+        if failure:
+            raise failure[0]
 
     def wait_for_pair(self, timeout: float = 120.0) -> None:
         """Dispatch Agent1 callbacks until BlueZ reports the device paired."""

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -31,7 +31,20 @@ def _display_pairing_code(passkey: int) -> None:
     typer.echo(f"Bluetooth pairing code: {passkey:06d}")
 
 
-def run_wizard(*, verify_after: bool = True) -> int:
+def _verification_detail(*, ancs_ready: bool, compatibility_mode: bool) -> str:
+    if ancs_ready:
+        return "including iPhone notifications"
+    if compatibility_mode:
+        return "messages and contacts; ANCS was disabled by compatibility mode"
+    return "messages and contacts; this controller has no ANCS support"
+
+
+def run_wizard(
+    *,
+    verify_after: bool = True,
+    compatibility_mode: bool = False,
+    explicit_pairing: bool = False,
+) -> int:
     """Run the same full pairing workflow exposed by the graphical clients."""
     typer.echo(
         typer.style("\n=== BlueFerry first-run setup ===\n", fg=typer.colors.CYAN, bold=True)
@@ -113,7 +126,11 @@ def run_wizard(*, verify_after: bool = True) -> int:
                 fg=typer.colors.YELLOW,
             )
         )
-    if compatibility.notifications_supported and not compatibility.bearer_api_active:
+    if (
+        not compatibility_mode
+        and compatibility.notifications_supported
+        and not compatibility.bearer_api_active
+    ):
         if not typer.confirm(
             "Activate Bluetooth support? This briefly disconnects Bluetooth devices.",
             default=True,
@@ -185,12 +202,21 @@ def run_wizard(*, verify_after: bool = True) -> int:
             return 1
 
     typer.echo("\nActivating Bluetooth, then starting secure pairing…")
+    if compatibility_mode:
+        typer.echo(
+            "Compatibility mode: BlueFerry will set up Messages and Contacts "
+            "without connecting ANCS."
+        )
+    if explicit_pairing:
+        typer.echo("Explicit pairing: skipping the initial Device1.Connect attempt.")
     try:
         result = setup.complete(
             chosen.mac,
             adapter=compatibility.adapter,
             confirmation=_confirm_pairing,
             display=_display_pairing_code,
+            compatibility_mode=compatibility_mode,
+            explicit_pairing=explicit_pairing,
         )
     except PairingError as error:
         typer.echo(typer.style(str(error), fg=typer.colors.RED))
@@ -204,14 +230,20 @@ def run_wizard(*, verify_after: bool = True) -> int:
         verified = BackendClient().status().verified_iphone_setup
     except BackendError:
         verified = ()
+    ancs_enabled = getattr(
+        result,
+        "ancs_enabled",
+        compatibility.notifications_supported and not compatibility_mode,
+    )
     remaining = remaining_iphone_setup_tasks(
         verified,
-        notifications_supported=compatibility.notifications_supported,
+        notifications_supported=ancs_enabled,
     )
     _print_iphone_steps(
         result.device.uuids,
         remaining=remaining,
         notifications_supported=compatibility.notifications_supported,
+        ancs_enabled=ancs_enabled,
         ancs_ready=result.ancs_ready,
     )
 
@@ -233,12 +265,11 @@ def run_wizard(*, verify_after: bool = True) -> int:
                 time.sleep(2)
                 continue
             profiles_ready = status.map and status.pbap
-            notification_ready = status.ancs or not compatibility.notifications_supported
+            notification_ready = status.ancs or not ancs_enabled
             if profiles_ready and notification_ready:
-                detail = (
-                    "including iPhone notifications"
-                    if status.ancs
-                    else ("messages and contacts; this controller has no ANCS support")
+                detail = _verification_detail(
+                    ancs_ready=status.ancs,
+                    compatibility_mode=compatibility_mode,
                 )
                 typer.echo(typer.style(f"✓ Setup verified: {detail}", fg=typer.colors.GREEN))
                 typer.echo("New incoming messages will appear automatically.")
@@ -259,6 +290,7 @@ def _print_iphone_steps(
     *,
     remaining: tuple[str, ...],
     notifications_supported: bool,
+    ancs_enabled: bool,
     ancs_ready: bool,
 ) -> None:
     if not remaining:
@@ -279,7 +311,7 @@ def _print_iphone_steps(
     if NOTIFICATION_ACCESS in remaining:
         typer.echo("\nANCS notification access is negotiated during pairing. Some")
         typer.echo("iOS versions do not show a separate system-notification toggle.")
-    if NOTIFICATION_ACCESS in remaining or not notifications_supported:
+    if NOTIFICATION_ACCESS in remaining or not ancs_enabled:
         typer.echo(
             "Without System Notification access, group texts appear as "
             "individual conversations with their sender."

--- a/src/blueferry/pairing_policy.py
+++ b/src/blueferry/pairing_policy.py
@@ -1,0 +1,85 @@
+"""Resolve the two supported iPhone pairing recipes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any
+
+
+class PairingMode(str, Enum):
+    """End-to-end behavior selected for one iPhone bond."""
+
+    FULL = "full"
+    COMPATIBILITY = "compatibility"
+
+
+@dataclass(frozen=True, slots=True)
+class PairingPolicy:
+    """Concrete pairing and runtime decisions derived from capabilities."""
+
+    mode: PairingMode
+    pairing_strategy: str
+    ancs_capable: bool
+    ancs_enabled: bool
+    solicitation_enabled: bool
+    user_forced: bool
+    reason: str
+
+    @property
+    def iphone_initiated(self) -> bool:
+        return self.pairing_strategy == "iphone-initiated-connect"
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["mode"] = self.mode.value
+        return value
+
+
+def resolve_pairing_policy(
+    compatibility: Mapping[str, Any],
+    *,
+    force_compatibility: bool = False,
+    force_explicit_pairing: bool = False,
+    interactive: bool = True,
+) -> PairingPolicy:
+    """Choose full ANCS setup or the MAP/PBAP compatibility recipe.
+
+    The short-lived ANCS solicitation is independent of connecting ANCS. It
+    remains enabled whenever the adapter can advertise because older iOS uses
+    it as the signal that exposes MAP/PBAP permissions.
+    """
+    ancs_capable = bool(compatibility.get("notifications_supported", False))
+    solicitation_enabled = ancs_capable or bool(
+        compatibility.get("low_energy", False)
+        and compatibility.get("advertising", False)
+    )
+    compatibility_mode = force_compatibility or not ancs_capable
+    if force_compatibility:
+        reason = "user-override"
+    elif not ancs_capable:
+        reason = "ancs-unavailable"
+    else:
+        reason = "ancs-available"
+
+    # Interactive transactions normally let the iPhone initiate
+    # authentication, which is the reliable path for deriving the
+    # cross-transport keys ANCS needs. A user-selected controller workaround
+    # and headless callers instead start with explicit Pair.
+    pairing_strategy = (
+        "explicit-device-pair"
+        if force_explicit_pairing or not interactive
+        else "iphone-initiated-connect"
+    )
+    return PairingPolicy(
+        mode=(
+            PairingMode.COMPATIBILITY if compatibility_mode else PairingMode.FULL
+        ),
+        pairing_strategy=pairing_strategy,
+        ancs_capable=ancs_capable,
+        ancs_enabled=not compatibility_mode,
+        solicitation_enabled=solicitation_enabled,
+        user_forced=force_compatibility,
+        reason=reason,
+    )

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -74,6 +74,7 @@ class BridgeController(QObject):
         self._compatibility: dict = {}
         self._configured = False
         self._target_saved = False
+        self._ancs_enabled = True
         self._configured_mac = ""
         self._configured_adapter = ""
         self._setup_loaded = False
@@ -81,7 +82,7 @@ class BridgeController(QObject):
             derive_stage(
                 setup_loaded=self._setup_loaded,
                 configured=self._configured,
-                compatibility=self._compatibility,
+                compatibility=self._onboarding_compatibility(),
                 status=self._status,
             )
         )
@@ -136,6 +137,16 @@ class BridgeController(QObject):
     def compatibility(self):
         return self._compatibility
 
+    def _onboarding_compatibility(self) -> dict:
+        compatibility = dict(self._compatibility)
+        if self._target_saved and not self._ancs_enabled:
+            compatibility["notifications_supported"] = False
+        return compatibility
+
+    @Property("QVariantMap", notify=compatibilityChanged)
+    def onboardingCompatibility(self):
+        return self._onboarding_compatibility()
+
     @Property(bool, notify=configuredChanged)
     def configured(self) -> bool:
         return self._configured
@@ -161,7 +172,7 @@ class BridgeController(QObject):
             derive_stage(
                 setup_loaded=self._setup_loaded,
                 configured=self._configured,
-                compatibility=self._compatibility,
+                compatibility=self._onboarding_compatibility(),
                 status=self._status,
             )
         )
@@ -282,10 +293,12 @@ class BridgeController(QObject):
             configuration, status = result
             self._configured = configuration.configured
             self._target_saved = configuration.saved
+            self._ancs_enabled = bool(getattr(configuration, "ancs_enabled", True))
             self._configured_mac = configuration.mac
             self._configured_adapter = configuration.adapter
             self._setup_loaded = True
             self.configuredChanged.emit()
+            self.compatibilityChanged.emit()
             self.setupLoadedChanged.emit()
             if status:
                 self._status = dict(status)
@@ -323,6 +336,7 @@ class BridgeController(QObject):
             self._compatibility = compatibility.to_dict()
             self._configured = configuration.configured
             self._target_saved = configuration.saved
+            self._ancs_enabled = bool(getattr(configuration, "ancs_enabled", True))
             self._configured_mac = configuration.mac
             self._configured_adapter = configuration.adapter
             self._setup_loaded = True
@@ -593,21 +607,50 @@ class BridgeController(QObject):
 
         self._run(self._setup.activate_bluez, completed)
 
-    @Slot(str)
-    def completePairing(self, mac: str) -> None:
-        self._start_pairing(mac)
+    @Slot(str, bool, bool)
+    def completePairing(
+        self,
+        mac: str,
+        compatibility_mode: bool = False,
+        explicit_pairing: bool = False,
+    ) -> None:
+        self._start_pairing(
+            mac,
+            compatibility_mode=compatibility_mode,
+            explicit_pairing=explicit_pairing,
+        )
 
-    @Slot(str, str)
-    def replaceAndPair(self, previous_mac: str, mac: str) -> None:
-        self._start_pairing(mac, replace_saved_mac=previous_mac)
+    @Slot(str, str, bool, bool)
+    def replaceAndPair(
+        self,
+        previous_mac: str,
+        mac: str,
+        compatibility_mode: bool = False,
+        explicit_pairing: bool = False,
+    ) -> None:
+        self._start_pairing(
+            mac,
+            replace_saved_mac=previous_mac,
+            compatibility_mode=compatibility_mode,
+            explicit_pairing=explicit_pairing,
+        )
 
-    def _start_pairing(self, mac: str, *, replace_saved_mac: str = "") -> None:
+    def _start_pairing(
+        self,
+        mac: str,
+        *,
+        replace_saved_mac: str = "",
+        compatibility_mode: bool = False,
+        explicit_pairing: bool = False,
+    ) -> None:
         def completed(value: object) -> None:
             self._configured = True
             self._target_saved = True
+            self._ancs_enabled = bool(getattr(value, "ancs_enabled", True))
             self._configured_mac = mac
             self._configured_adapter = str(self._compatibility.get("adapter", ""))
             self.configuredChanged.emit()
+            self.compatibilityChanged.emit()
             self._update_onboarding_stage()
             self.loadDevices(False)
             self.loadSetupState()
@@ -647,13 +690,17 @@ class BridgeController(QObject):
                 if path:
                     adapter = path.rsplit("/", 1)[-1]
                 break
-            return self._setup.complete_isolated(
-                mac,
-                confirmation=confirm,
-                display=display,
-                adapter=adapter,
-                replace_saved_mac=replace_saved_mac,
-            )
+            options = {
+                "confirmation": confirm,
+                "display": display,
+                "adapter": adapter,
+                "replace_saved_mac": replace_saved_mac,
+            }
+            if compatibility_mode:
+                options["compatibility_mode"] = True
+            if explicit_pairing:
+                options["explicit_pairing"] = True
+            return self._setup.complete_isolated(mac, **options)
 
         def failed(message: str) -> None:
             self._operation_failed(message)
@@ -688,11 +735,13 @@ class BridgeController(QObject):
         def completed(_value: object) -> None:
             self._configured = False
             self._target_saved = False
+            self._ancs_enabled = True
             self._configured_mac = ""
             self._configured_adapter = ""
             self._status = {}
             self._threads = []
             self.configuredChanged.emit()
+            self.compatibilityChanged.emit()
             self.statusChanged.emit()
             self.threadsChanged.emit()
             self._update_onboarding_stage()

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -446,6 +446,8 @@ Kirigami.ApplicationWindow {
     Kirigami.PromptDialog {
         id: replaceTargetDialog
         property string mac: ""
+        property bool compatibilityMode: false
+        property bool explicitPairing: false
         title: qsTr("Replace the Saved iPhone?")
         subtitle: qsTr("Pairing this iPhone will remove BlueFerry's saved phone and its local Bluetooth bond. Before continuing, also forget this computer in the old iPhone's Bluetooth settings.")
         dialogType: Kirigami.PromptDialog.Warning
@@ -454,7 +456,12 @@ Kirigami.ApplicationWindow {
             text: qsTr("Replace and Pair")
             icon.name: "edit-delete-remove"
             onTriggered: {
-                root.bridge.replaceAndPair(root.bridge.configuredMac, replaceTargetDialog.mac)
+                root.bridge.replaceAndPair(
+                    root.bridge.configuredMac,
+                    replaceTargetDialog.mac,
+                    replaceTargetDialog.compatibilityMode,
+                    replaceTargetDialog.explicitPairing
+                )
                 replaceTargetDialog.close()
             }
         }]
@@ -907,6 +914,7 @@ Kirigami.ApplicationWindow {
             return null
         }
         property string effectiveStage: root.bridge.onboardingStage
+        property bool compatibilityModeOverride: false
 
         ColumnLayout {
             width: parent.width
@@ -942,21 +950,11 @@ Kirigami.ApplicationWindow {
 
                 OnboardingSummary {
                     Layout.fillWidth: true
-                    stage: iphonePage.effectiveStage
-                    compatibility: root.bridge.compatibility
+                    stage: compatibilityMode.checked
+                        && iphonePage.effectiveStage === "activate-bluetooth"
+                        ? "select-device" : iphonePage.effectiveStage
+                    compatibility: root.bridge.onboardingCompatibility
                     status: root.bridge.status
-                }
-
-                Kirigami.Heading {
-                    visible: !root.bridge.configured
-                    text: qsTr("Pair an iPhone")
-                    level: 2
-                }
-                Controls.Label {
-                    Layout.fillWidth: true
-                    visible: !root.bridge.configured
-                    wrapMode: Text.Wrap
-                    text: qsTr("Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. While it does, return to the Bluetooth device list and reopen this computer's ⓘ page a few times; turn on any new toggles that appear.")
                 }
 
                 Kirigami.FormLayout {
@@ -1006,7 +1004,8 @@ Kirigami.ApplicationWindow {
 
                     Controls.Label {
                         Kirigami.FormData.label: qsTr("Bluetooth Support:")
-                        text: !root.bridge.compatibility.notifications_supported
+                        text: compatibilityMode.checked
+                            || !root.bridge.compatibility.notifications_supported
                             ? qsTr("Not Required")
                             : root.bridge.bluetoothActive
                                 ? qsTr("Active")
@@ -1019,6 +1018,7 @@ Kirigami.ApplicationWindow {
                     Controls.Button {
                         visible: root.bridge.compatibility.notifications_supported === true
                             && !root.bridge.bluetoothActive
+                            && !compatibilityMode.checked
                         text: qsTr("Restart Bluetooth")
                         icon.name: "network-bluetooth"
                         enabled: !root.bridge.busy
@@ -1064,6 +1064,28 @@ Kirigami.ApplicationWindow {
                     }
                 }
 
+                Controls.CheckBox {
+                    id: compatibilityMode
+                    Layout.fillWidth: true
+                    visible: !root.bridge.configured
+                    text: qsTr("Compatibility pairing for iOS 18 or earlier")
+                    checked: root.bridge.compatibility.notifications_supported !== true
+                        || iphonePage.compatibilityModeOverride
+                    enabled: root.bridge.compatibility.notifications_supported === true
+                        && !root.bridge.busy
+                    onClicked: iphonePage.compatibilityModeOverride = checked
+                    Accessible.description: qsTr("Sets up Messages and Contacts without connecting ANCS.")
+                }
+
+                Controls.CheckBox {
+                    id: explicitPairing
+                    Layout.fillWidth: true
+                    visible: !root.bridge.configured
+                    text: qsTr("Use explicit Bluetooth pairing")
+                    enabled: !root.bridge.busy
+                    Accessible.description: qsTr("Skips the initial Bluetooth connection attempt and calls Pair immediately. Try this for controllers that cancel normal pairing.")
+                }
+
                 RowLayout {
                     visible: !root.bridge.configured
                     Controls.Button {
@@ -1071,14 +1093,22 @@ Kirigami.ApplicationWindow {
                             ? qsTr("Use Existing Pairing") : qsTr("2. Pair Selected iPhone")
                         icon.name: "network-connect"
                         enabled: iphonePage.device !== null
-                            && root.bridge.compatibility.pairing_ready
+                            && (compatibilityMode.checked
+                                ? root.bridge.compatibility.messages_supported
+                                : root.bridge.compatibility.pairing_ready)
                             && !root.bridge.busy
                         onClicked: {
                             if (!iphonePage.device.paired && root.bridge.targetSaved) {
                                 replaceTargetDialog.mac = iphonePage.device.mac
+                                replaceTargetDialog.compatibilityMode = compatibilityMode.checked
+                                replaceTargetDialog.explicitPairing = explicitPairing.checked
                                 replaceTargetDialog.open()
                             } else {
-                                root.bridge.completePairing(iphonePage.device.mac)
+                                root.bridge.completePairing(
+                                    iphonePage.device.mac,
+                                    compatibilityMode.checked,
+                                    explicitPairing.checked
+                                )
                             }
                         }
                     }
@@ -1092,6 +1122,13 @@ Kirigami.ApplicationWindow {
                             forgetDialog.open()
                         }
                     }
+                }
+
+                Controls.Label {
+                    Layout.fillWidth: true
+                    visible: !root.bridge.configured && compatibilityMode.checked
+                    wrapMode: Text.Wrap
+                    text: qsTr("BlueFerry will still advertise ANCS solicitation so the iPhone exposes its Messages and Contacts permissions, but it will not connect system notifications.")
                 }
 
                 Controls.Button {

--- a/src/blueferry/qt/qml/OnboardingSummary.qml
+++ b/src/blueferry/qt/qml/OnboardingSummary.qml
@@ -65,7 +65,7 @@ Kirigami.InlineMessage {
             "checking": qsTr("Inspecting the selected Bluetooth controller without changing it."),
             "incompatible": compatibility.issue || qsTr("A controller with BR/EDR and secure pairing is required."),
             "activate-bluetooth": qsTr("The packaged BlueZ bearer support needs one authorized Bluetooth restart."),
-            "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. On the iPhone, open Settings → Bluetooth, find this computer under \"Other Devices\", tap it, and approve the matching codes. Pairing may appear idle for up to 15 seconds. While it does, return to the Bluetooth device list and reopen this computer's ⓘ page a few times; turn on any new toggles that appear. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."),
+            "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. When the pairing request appears on the iPhone, approve it and confirm that the codes match. Pairing may appear idle for up to 15 seconds. After it completes, return to the Bluetooth device list and open this computer's ⓘ page a few times; turn on any new toggles that appear. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."),
             "starting": qsTr("The configured backend is starting. This normally takes a few seconds."),
             "iphone-settings": pendingTasksText(),
             "ready": qsTr("Bluetooth services and iPhone permissions have been verified."),

--- a/src/blueferry/quirks_report.py
+++ b/src/blueferry/quirks_report.py
@@ -13,7 +13,9 @@ from typing import Any
 from urllib.parse import urlencode
 
 from blueferry import config
+from blueferry.backend_lifecycle import installed_release
 from blueferry.bluetooth_capabilities import chipset_name, is_generic_product
+from blueferry.build_info import build_id, running_build_sha
 from blueferry.private_files import atomic_write_private_text, ensure_private_directory
 
 log = logging.getLogger(__name__)
@@ -123,9 +125,13 @@ def session_environment() -> dict[str, str]:
 def start_attempt(*, interactive: bool) -> dict[str, Any]:
     from blueferry import __version__
 
+    build_sha = running_build_sha()
+    release = installed_release() or __version__
     attempt: dict[str, Any] = {
         "started_at": datetime.now(timezone.utc).isoformat(),
         "blueferry": __version__,
+        "blueferry_build": build_id(release, build_sha),
+        "blueferry_sha": build_sha or "unknown",
         "pairing_path": "interactive" if interactive else "headless",
         "session": session_environment(),
         "_t0": time.monotonic(),

--- a/src/blueferry/setup_client.py
+++ b/src/blueferry/setup_client.py
@@ -140,6 +140,7 @@ class ConfigurationState:
     saved: bool = False
     bonded: bool | None = None
     pairing_issue_report: str = ""
+    ancs_enabled: bool = True
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> ConfigurationState:
@@ -155,6 +156,7 @@ class ConfigurationState:
                 else None
             ),
             pairing_issue_report=str(value.get("pairing_issue_report", "")),
+            ancs_enabled=bool(value.get("ancs_enabled", True)),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -166,6 +168,7 @@ class ConfigurationState:
             "saved": self.saved,
             "bonded": self.bonded,
             "pairing_issue_report": self.pairing_issue_report,
+            "ancs_enabled": self.ancs_enabled,
         }
 
 
@@ -177,6 +180,7 @@ class PairingResult:
     service: str
     ancs: str
     ancs_ready: bool
+    ancs_enabled: bool
     iphone_steps: tuple[str, ...]
     quirks_report: str = ""
 
@@ -193,6 +197,7 @@ class PairingResult:
             service=str(value.get("service", "")),
             ancs=str(value.get("ancs", "")),
             ancs_ready=bool(value.get("ancs_ready", False)),
+            ancs_enabled=bool(value.get("ancs_enabled", True)),
             iphone_steps=tuple(str(item) for item in raw_steps)
             if isinstance(raw_steps, list | tuple) else (),
             quirks_report=str(value.get("quirks_report", "")),
@@ -206,6 +211,7 @@ class PairingResult:
             "service": self.service,
             "ancs": self.ancs,
             "ancs_ready": self.ancs_ready,
+            "ancs_enabled": self.ancs_enabled,
             "iphone_steps": list(self.iphone_steps),
             "quirks_report": self.quirks_report,
         }
@@ -245,6 +251,8 @@ class SetupClient:
         adapter: str | None = None,
         confirmation: pair_setup.ConfirmationCallback | None = None,
         display: pair_setup.DisplayCallback | None = None,
+        compatibility_mode: bool = False,
+        explicit_pairing: bool = False,
     ) -> PairingResult:
         return PairingResult.from_dict(
             pair_setup.complete_pairing(
@@ -252,6 +260,8 @@ class SetupClient:
                 adapter=adapter,
                 confirmation=confirmation,
                 display=display,
+                compatibility_mode=compatibility_mode,
+                explicit_pairing=explicit_pairing,
             )
         )
 
@@ -263,6 +273,8 @@ class SetupClient:
         display: pair_setup.DisplayCallback | None = None,
         adapter: str | None = None,
         replace_saved_mac: str = "",
+        compatibility_mode: bool = False,
+        explicit_pairing: bool = False,
     ) -> PairingResult:
         """Run interactive pairing in a D-Bus/GLib-isolated child process."""
         command = [
@@ -277,6 +289,10 @@ class SetupClient:
             command.extend(["--adapter", adapter])
         if replace_saved_mac:
             command.extend(["--replace-saved-mac", replace_saved_mac])
+        if compatibility_mode:
+            command.append("--compatibility-mode")
+        if explicit_pairing:
+            command.append("--explicit-pairing")
         process = subprocess.Popen(  # nosec B603
             command,
             stdin=subprocess.PIPE,

--- a/src/blueferry/tui_launcher.py
+++ b/src/blueferry/tui_launcher.py
@@ -56,7 +56,7 @@ def main() -> int:
         if error.name != "blueferry.tui":
             raise
         print(
-            "The BlueFerry TUI is not installed; install the blueferry-tui package.",
+            "The BlueFerry TUI is not installed; reinstall blueferry-backend.",
             file=sys.stderr,
         )
         return 2

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -47,6 +47,8 @@ class IPhonePage(Gtk.Box):
         self._applying_storage_policy = False
         self._storage_unlock_attempted = False
         self._pairing_issue_report = ""
+        self._compatibility_override = False
+        self._applying_pairing_mode = False
 
         page = Adw.PreferencesPage()
         self.append(page)
@@ -54,11 +56,11 @@ class IPhonePage(Gtk.Box):
         self._pairing_group = Adw.PreferencesGroup(
             title=_("Pair an iPhone"),
             description=_(
-                "Scan for and select your iPhone here, then choose Pair. On the "
-                "iPhone, open Settings → Bluetooth, find this computer under "
-                '"Other Devices", tap it, and approve the matching codes. Pairing '
-                "may appear idle for up to 15 seconds. While it does, return to "
-                "the Bluetooth device list and reopen this computer's ⓘ page a "
+                "Scan for and select your iPhone here, then choose Pair. When the "
+                "pairing request appears on the iPhone, approve it and confirm that "
+                "the codes match. Pairing may appear idle for up to 15 seconds. "
+                "After it completes, return to the Bluetooth device list and open "
+                "this computer's ⓘ page a "
                 "few times; turn on any new toggles that appear. System Notification "
                 "access is also how BlueFerry recognizes group text threads; "
                 "without it, a group text appears as a one-to-one conversation "
@@ -115,6 +117,35 @@ class IPhonePage(Gtk.Box):
         scan.add_suffix(self._scan_button)
         self._pairing_group.add(scan)
         self._pairing_group.add(self._device_row)
+
+        self._compatibility_row = Adw.ActionRow(
+            title=_("Compatibility pairing"),
+            subtitle=_(
+                "For iOS 18 or earlier: set up Messages and Contacts without "
+                "connecting ANCS"
+            ),
+        )
+        self._compatibility_switch = Gtk.Switch(valign=Gtk.Align.CENTER)
+        self._compatibility_switch.connect(
+            "notify::active", self._pairing_mode_changed
+        )
+        self._compatibility_row.add_suffix(self._compatibility_switch)
+        self._compatibility_row.set_activatable_widget(self._compatibility_switch)
+        self._pairing_group.add(self._compatibility_row)
+
+        self._explicit_pairing_row = Adw.ActionRow(
+            title=_("Use explicit Bluetooth pairing"),
+            subtitle=_(
+                "Skip the initial connection attempt for controllers that "
+                "cancel normal pairing"
+            ),
+        )
+        self._explicit_pairing_switch = Gtk.Switch(valign=Gtk.Align.CENTER)
+        self._explicit_pairing_row.add_suffix(self._explicit_pairing_switch)
+        self._explicit_pairing_row.set_activatable_widget(
+            self._explicit_pairing_switch
+        )
+        self._pairing_group.add(self._explicit_pairing_row)
 
         pair = Adw.ActionRow(
             title=_("2. Pair the Selected iPhone"),
@@ -336,6 +367,10 @@ class IPhonePage(Gtk.Box):
         notifications_supported = bool(
             self._compatibility and self._compatibility.notifications_supported
         )
+        if self._configuration and self._configuration.saved:
+            notifications_supported = (
+                notifications_supported and self._configuration.ancs_enabled
+            )
         remaining = set(
             remaining_iphone_setup_tasks(
                 self._last_status.verified_iphone_setup,
@@ -351,8 +386,23 @@ class IPhonePage(Gtk.Box):
         self._activate_button.set_sensitive(not busy)
         self._scan_button.set_sensitive(not busy)
         self._adapter_row.set_sensitive(not busy)
+        automatic_compatibility = bool(
+            self._compatibility
+            and not self._compatibility.notifications_supported
+        )
+        self._compatibility_switch.set_sensitive(
+            not busy and not automatic_compatibility
+        )
+        self._explicit_pairing_switch.set_sensitive(not busy)
         selected = self._selected_device()
-        pairing_ready = bool(self._compatibility and self._compatibility.pairing_ready)
+        pairing_ready = bool(
+            self._compatibility
+            and (
+                self._compatibility.messages_supported
+                if self._compatibility_switch.get_active()
+                else self._compatibility.pairing_ready
+            )
+        )
         self._pair_button.set_sensitive(not busy and pairing_ready and bool(selected))
         self._pair_button.set_label(
             _("Use Existing Pairing") if selected and selected.paired else _("Pair Selected iPhone")
@@ -363,6 +413,36 @@ class IPhonePage(Gtk.Box):
     def _selection_changed(self) -> None:
         self._set_pairing_busy(False)
         self._update_onboarding()
+
+    def _pairing_mode_changed(self, *_args) -> None:
+        if self._applying_pairing_mode:
+            return
+        self._compatibility_override = self._compatibility_switch.get_active()
+        self._set_pairing_busy(False)
+        if self._compatibility is not None:
+            self._apply_bluetooth_support_status(self._compatibility)
+        self._update_onboarding()
+
+    def _apply_bluetooth_support_status(self, compatibility) -> None:
+        active = compatibility.bearer_api_active
+        compatibility_mode = self._compatibility_switch.get_active()
+        if compatibility_mode:
+            self._bluez_row.set_subtitle(
+                _("Not required in compatibility mode")
+            )
+        elif not compatibility.notifications_supported:
+            self._bluez_row.set_subtitle(
+                _("Not required; per-app notifications are unsupported")
+            )
+        else:
+            self._bluez_row.set_subtitle(
+                _("Active") if active else _("A one-time Bluetooth restart is required")
+            )
+        self._activate_button.set_visible(
+            not compatibility_mode
+            and compatibility.notifications_supported
+            and not active
+        )
 
     def _selected_adapter_name(self) -> str:
         if self._compatibility is None:
@@ -400,18 +480,13 @@ class IPhonePage(Gtk.Box):
                 )
             )
         self._applying_adapter = False
-        active = compatibility.bearer_api_active
-        if not compatibility.notifications_supported:
-            self._bluez_row.set_subtitle(
-                _("Not required; per-app notifications are unsupported")
-            )
-        else:
-            self._bluez_row.set_subtitle(
-                _("Active") if active else _("A one-time Bluetooth restart is required")
-            )
-        self._activate_button.set_visible(
-            compatibility.notifications_supported and not active
+        self._applying_pairing_mode = True
+        self._compatibility_switch.set_active(
+            self._compatibility_override
+            or not compatibility.notifications_supported
         )
+        self._applying_pairing_mode = False
+        self._apply_bluetooth_support_status(compatibility)
 
     def _adapter_changed(self, *_args) -> None:
         if self._applying_adapter or self._compatibility is None:
@@ -628,12 +703,11 @@ class IPhonePage(Gtk.Box):
                 mac=device.mac,
                 adapter=device.adapter_path.rsplit("/", 1)[-1],
                 path="",
+                saved=True,
+                bonded=True,
+                ancs_enabled=result.ancs_enabled,
             )
-            if (
-                self._compatibility
-                and self._compatibility.notifications_supported
-                and not result.ancs_ready
-            ):
+            if result.ancs_enabled and not result.ancs_ready:
                 message = _(
                     "Pairing is complete; iPhone notification access is still "
                     "settling. Keep Bluetooth settings open."
@@ -703,6 +777,8 @@ class IPhonePage(Gtk.Box):
                 display=display,
                 adapter=device.adapter_path.rsplit("/", 1)[-1],
                 replace_saved_mac=replace_saved_mac,
+                compatibility_mode=self._compatibility_switch.get_active(),
+                explicit_pairing=self._explicit_pairing_switch.get_active(),
             ),
             completed,
         )
@@ -934,6 +1010,10 @@ class IPhonePage(Gtk.Box):
     def _update_onboarding(self) -> None:
         compatibility = self._compatibility.to_dict() if self._compatibility else {}
         configured = bool(self._configuration and self._configuration.configured)
+        if self._compatibility_switch.get_active() or (
+            configured and self._configuration and not self._configuration.ancs_enabled
+        ):
+            compatibility["notifications_supported"] = False
         stage = derive_stage(
             setup_loaded=self._setup_loaded,
             configured=configured,

--- a/tests/test_backend_lifecycle.py
+++ b/tests/test_backend_lifecycle.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from blueferry import backend_lifecycle
 
 
@@ -17,6 +19,16 @@ class _Iface:
 class _Bus:
     def get_object(self, _name, _path):
         return object()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_installed_build_and_systemctl(monkeypatch):
+    monkeypatch.setattr(backend_lifecycle, "installed_build_sha", lambda: None)
+
+    def unexpected_command(*_args, **_kwargs):
+        raise AssertionError("test attempted to run a real lifecycle command")
+
+    monkeypatch.setattr(backend_lifecycle, "run_command", unexpected_command)
 
 
 def _dbus(monkeypatch, statuses):
@@ -79,6 +91,36 @@ def test_release_mismatch_is_restarted(monkeypatch):
     status = backend_lifecycle.ensure_backend_current()
 
     assert status["backend_release"] == "0.6.0-6"
+
+
+def test_same_release_with_a_different_build_sha_is_restarted(monkeypatch):
+    old_build = "0.6.0-6+sha." + "a" * 12
+    new_build = "0.6.0-6+sha." + "b" * 12
+    _dbus(monkeypatch, [
+        {"backend_release": "0.6.0-6", "_build_id": old_build},
+        {"backend_release": "0.6.0-6", "_build_id": old_build},
+        {"backend_release": "0.6.0-6", "_build_id": new_build},
+    ])
+    monkeypatch.setattr(backend_lifecycle, "installed_release", lambda: "0.6.0-6")
+    monkeypatch.setattr(
+        backend_lifecycle,
+        "installed_build_sha",
+        lambda: "b" * 64,
+    )
+    calls = []
+    monkeypatch.setattr(
+        backend_lifecycle,
+        "run_command",
+        lambda args, **_kwargs: calls.append(args),
+    )
+
+    status = backend_lifecycle.ensure_backend_current()
+
+    assert status["_build_id"] == new_build
+    assert calls == [
+        ["/usr/bin/systemctl", "--user", "daemon-reload"],
+        ["/usr/bin/systemctl", "--user", "restart", "blueferry.service"],
+    ]
 
 
 def test_missing_package_marker_does_not_restart(monkeypatch):

--- a/tests/test_build_info.py
+++ b/tests/test_build_info.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from blueferry import build_info
+
+
+def test_installed_build_sha_is_validated(monkeypatch, tmp_path) -> None:
+    marker = tmp_path / "build-sha"
+    monkeypatch.setattr(build_info, "BUILD_SHA_PATH", marker)
+    marker.write_text("A" * 64 + "\n", encoding="utf-8")
+
+    assert build_info.installed_build_sha() == "a" * 64
+
+    marker.write_text("not-a-sha\n", encoding="utf-8")
+    assert build_info.installed_build_sha() is None
+
+
+def test_build_id_uses_a_short_private_sha() -> None:
+    assert build_info.build_id("0.6.3-1", "b" * 64) == (
+        "0.6.3-1+sha." + "b" * 12
+    )
+    assert build_info.build_id("0.6.3", None) == "0.6.3"

--- a/tests/test_cli_pairing.py
+++ b/tests/test_cli_pairing.py
@@ -16,13 +16,20 @@ def test_pair_setup_debug_enables_diagnostic_logging(monkeypatch):
     monkeypatch.setattr(
         pairing_cli,
         "run_wizard",
-        lambda *, verify_after: calls.append(("wizard", verify_after)) or 0,
+        lambda **kwargs: calls.append(("wizard", kwargs)) or 0,
     )
 
     result = CliRunner().invoke(cli.app, ["pair-setup", "--debug", "--no-verify"])
 
     assert result.exit_code == 0
-    assert calls == [("debug", True), ("wizard", False)]
+    assert calls == [
+        ("debug", True),
+        ("wizard", {
+            "verify_after": False,
+            "compatibility_mode": False,
+            "explicit_pairing": False,
+        }),
+    ]
 
 
 def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
@@ -35,7 +42,18 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
         def prepare_replacement(self, previous_mac, next_mac, *, adapter=None):
             observed.append(("replace", previous_mac, next_mac, adapter))
 
-        def complete(self, mac, *, confirmation, display, adapter=None):
+        def complete(
+            self,
+            mac,
+            *,
+            confirmation,
+            display,
+            adapter=None,
+            compatibility_mode=False,
+            explicit_pairing=False,
+        ):
+            assert compatibility_mode is False
+            assert explicit_pairing is False
             observed.append((mac, adapter, confirmation(12345)))
             return SimpleNamespace(to_dict=lambda: {"ok": True, "device": {"mac": mac}})
 
@@ -89,6 +107,32 @@ def test_pairing_complete_failure_includes_report_path(monkeypatch):
     assert payload["ok"] is False
     assert payload["error"] == "adapter setup failed"
     assert payload["report_path"] == "/tmp/quirks-fail.json"
+
+
+def test_pairing_complete_forwards_independent_pairing_modes(monkeypatch):
+    observed = []
+
+    class Setup:
+        @staticmethod
+        def complete(mac, **kwargs):
+            observed.append((mac, kwargs))
+            return SimpleNamespace(to_dict=lambda: {"ok": True})
+
+    monkeypatch.setattr(setup_client, "SetupClient", Setup)
+
+    result = CliRunner().invoke(
+        cli.app,
+        [
+            "pairing-complete",
+            "02:00:00:00:00:01",
+            "--compatibility-mode",
+            "--explicit-pairing",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert observed[0][1]["compatibility_mode"] is True
+    assert observed[0][1]["explicit_pairing"] is True
 
 
 def test_pairing_issue_prints_the_latest_report_without_opening(tmp_path, monkeypatch):

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -9,6 +9,11 @@ from blueferry import daemon as daemon_mod
 from blueferry.connectivity import Connectivity
 
 
+@pytest.fixture(autouse=True)
+def _ignore_the_hosts_installed_build_sha(monkeypatch):
+    monkeypatch.setattr(daemon_mod, "installed_build_sha", lambda: None)
+
+
 def _bare_daemon():
     instance = object.__new__(daemon_mod.Daemon)
     instance.sessions = object()
@@ -36,6 +41,8 @@ def _bare_daemon():
     instance._target_config_check_id = None
     instance._initializing = True
     instance._running_release = "0.6.0-6"
+    instance._running_build_sha = None
+    instance._running_build_id = "0.6.0-6"
     instance._release_missing_checks = 0
     instance._restart_after_upgrade = False
     return instance
@@ -135,6 +142,7 @@ def test_status_exposes_split_ancs_and_last_le_error(monkeypatch):
     assert status["le"] is False
     assert status["last_le_error"] == "org.bluez.Error.Failed"
     assert status["last_le_error_message"] == "le-connection-abort-by-local"
+    assert status["_build_id"] == "0.6.0-6"
 
 
 def test_failed_hardware_initialization_leaves_control_service_alive(monkeypatch):
@@ -196,6 +204,20 @@ def test_persistent_missing_release_marker_stops_cleanly(monkeypatch):
     assert instance._check_package_release() is True
     assert instance._check_package_release() is False
     assert instance._restart_after_upgrade is False
+    assert stopped == [True]
+
+
+def test_changed_build_sha_restarts_the_packaged_daemon(monkeypatch):
+    instance = _bare_daemon()
+    instance._running_build_sha = "a" * 64
+    instance._running_build_id = "0.6.0-6+sha." + "a" * 12
+    stopped = []
+    monkeypatch.setattr(daemon_mod, "installed_release", lambda: "0.6.0-6")
+    monkeypatch.setattr(daemon_mod, "installed_build_sha", lambda: "b" * 64)
+    monkeypatch.setattr(daemon_mod.main_loop, "quit", lambda: stopped.append(True))
+
+    assert instance._check_package_release() is False
+    assert instance._restart_after_upgrade is True
     assert stopped == [True]
 
 

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -1,0 +1,101 @@
+"""The persisted pairing policy controls long-lived ANCS work."""
+
+from blueferry import daemon
+
+
+class _Bearer:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def start(self):
+        self.calls.append("bearers-start")
+
+
+class _Events:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def setup(self):
+        self.calls.append("events-setup")
+
+    @staticmethod
+    def ancs(_event):
+        return None
+
+
+class _Profiles:
+    ready = True
+
+    def __init__(self, calls):
+        self.calls = calls
+
+    def start(self):
+        self.calls.append("profiles-start")
+
+
+def _daemon(calls):
+    value = daemon.Daemon.__new__(daemon.Daemon)
+    value.bearers = _Bearer(calls)
+    value.events = _Events(calls)
+    value.profiles = _Profiles(calls)
+    value.notification_policy = type("Policy", (), {"value": "messages"})()
+    value.ancs = None
+    value._watch_sleep_resume = lambda: calls.append("sleep-watch")
+    return value
+
+
+def _ready_bluetooth(monkeypatch, calls):
+    monkeypatch.setattr(daemon, "bond_status", lambda *_args: True)
+    monkeypatch.setattr(
+        daemon.bluez_setup,
+        "prepare",
+        lambda: calls.append("solicitation-prepare") or True,
+    )
+
+
+def test_compatibility_daemon_solicits_but_never_starts_ancs(monkeypatch):
+    calls = []
+    value = _daemon(calls)
+    _ready_bluetooth(monkeypatch, calls)
+    monkeypatch.setattr(daemon.config, "ANCS_ENABLED", False)
+    monkeypatch.setattr(
+        daemon,
+        "AncsClient",
+        lambda *_args, **_kwargs: calls.append("unexpected-ancs-client"),
+    )
+
+    value._initialize_bluetooth()
+
+    assert calls == [
+        "solicitation-prepare",
+        "bearers-start",
+        "sleep-watch",
+        "events-setup",
+        "profiles-start",
+    ]
+    assert value.ancs is None
+
+
+def test_full_daemon_starts_ancs_client(monkeypatch):
+    calls = []
+    value = _daemon(calls)
+    _ready_bluetooth(monkeypatch, calls)
+    monkeypatch.setattr(daemon.config, "ANCS_ENABLED", True)
+
+    class Ancs:
+        def __init__(self, *_args, **_kwargs):
+            calls.append("ancs-client")
+
+        def start(self):
+            calls.append("ancs-start")
+
+        def stop(self):
+            calls.append("ancs-stop")
+
+    monkeypatch.setattr(daemon, "AncsClient", Ancs)
+
+    value._initialize_bluetooth()
+
+    assert "ancs-client" in calls
+    assert "ancs-start" in calls
+    assert value.ancs is not None

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -29,25 +29,27 @@ def test_graphical_commands_follow_client_package_names() -> None:
     assert "blueferry-ui" not in project + pkgbuild + desktop
 
 
-def test_tui_entry_point_is_shipped_by_separate_arch_package() -> None:
+def test_tui_entry_point_is_shipped_by_arch_backend() -> None:
     project = (ROOT / "pyproject.toml").read_text()
     pkgbuild = (ROOT / "packaging" / "arch" / "PKGBUILD").read_text()
     backend = pkgbuild.split("package_blueferry-backend()", 1)[1].split(
         "package_blueferry-gtk()", 1
     )[0]
-    tui = pkgbuild.split("package_blueferry-tui()", 1)[1].split(
-        "package_blueferry-quickshell()", 1
-    )[0]
+    package_names = pkgbuild.split("pkgname=(", 1)[1].split("\n)", 1)[0]
 
     assert 'blueferry-tui = "blueferry.tui_launcher:main"' in project
     assert '"textual>=8.0"' in project
     assert '"blueferry" = ["tui.tcss"]' in project
-    assert "'python-textual>=8.0'" not in backend
-    assert "blueferry/tui.py" in backend
-    assert "blueferry/tui.tcss" in backend
-    assert "'python-textual>=8.0'" in tui
-    assert '$_stage/usr/bin/blueferry-tui' in tui
-    assert '$pkgdir/usr/bin/blueferry-tui' in tui
+    assert "blueferry-tui" not in package_names
+    assert "package_blueferry-tui()" not in pkgbuild
+    assert "conflicts=('blueferry-tui')" in backend
+    assert "provides=('blueferry-tui')" in backend
+    assert "replaces=('blueferry-tui')" in backend
+    assert "'python-textual>=8.0'" in backend
+    assert "blueferry/tui.py" not in backend
+    assert "blueferry/tui.tcss" not in backend
+    assert '$_stage/usr/bin/blueferry-tui' in backend
+    assert '$pkgdir/usr/bin/blueferry-tui' in backend
 
 
 def test_dbus_activation_and_systemd_publish_the_runtime_bus_name() -> None:
@@ -178,8 +180,34 @@ def test_gui_pairing_guidance_tells_users_to_recheck_iphone_toggles() -> None:
     )
 
     for client in clients:
-        assert "reopen this computer's ⓘ page a" in client
+        assert "this computer's ⓘ page a" in client
         assert "few times; turn on any new toggles that appear" in client
+
+
+def test_all_pairing_clients_expose_compatibility_mode() -> None:
+    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
+    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
+    quickshell = _qml_bundle(ROOT / "data/quickshell")
+
+    for client in (gtk, qt, quickshell):
+        assert "Compatibility pairing" in client
+        assert "iOS 18 or earlier" in client
+    assert "compatibility_mode=" in gtk
+    assert "compatibilityMode.checked" in qt
+    assert "text: compatibilityMode.checked" in qt
+    assert '"--compatibility-mode"' in quickshell
+
+
+def test_all_pairing_clients_expose_explicit_pairing_mode() -> None:
+    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
+    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
+    quickshell = _qml_bundle(ROOT / "data/quickshell")
+
+    for client in (gtk, qt, quickshell):
+        assert "Use explicit Bluetooth pairing" in client
+    assert "explicit_pairing=" in gtk
+    assert "explicitPairing.checked" in qt
+    assert '"--explicit-pairing"' in quickshell
 
 
 def test_gtk_connection_rows_all_have_status_icons() -> None:
@@ -336,15 +364,15 @@ def test_all_gui_clients_offer_a_pairing_issue_button() -> None:
     assert '"--print-url"' in quickshell
 
 
-def test_all_gui_clients_explain_phone_side_pairing_step() -> None:
+def test_all_gui_clients_explain_desktop_initiated_pairing() -> None:
     gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
     qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
     quickshell = _qml_bundle(ROOT / "data/quickshell")
 
     for client in (gtk, qt, quickshell):
-        assert "find this computer" in client
-        assert "Other Devices" in client
-        assert "tap it" in client
+        assert "select your iPhone here, then choose Pair" in client
+        assert "pairing request appears on the iPhone" in client
+        assert "Other Devices" not in client
 
 
 def test_all_gui_clients_explain_map_connection_refusal() -> None:

--- a/tests/test_native_packaging.py
+++ b/tests/test_native_packaging.py
@@ -21,6 +21,26 @@ def test_native_recipes_track_project_version() -> None:
     assert f"Version:        {version}\n" in rpm_spec
 
 
+def test_native_packages_bake_and_ship_a_source_build_sha() -> None:
+    scripts = [
+        (ROOT / "build.sh").read_text(),
+        (ROOT / "packaging/build-deb.sh").read_text(),
+        (ROOT / "packaging/build-rpm.sh").read_text(),
+    ]
+    arch = (ROOT / "packaging/arch/PKGBUILD").read_text()
+    deb_rules = (ROOT / "packaging/deb/rules").read_text()
+    deb_install = (ROOT / "packaging/deb/blueferry-backend.install").read_text()
+    rpm = (ROOT / "packaging/rpm/blueferry.spec").read_text()
+
+    for script in scripts:
+        assert ".blueferry-build-sha" in script
+        assert "sha256sum" in script
+    assert "usr/share/blueferry/build-sha" in arch
+    assert "usr/share/blueferry/build-sha" in deb_rules
+    assert "usr/share/blueferry/build-sha" in deb_install
+    assert "%{_datadir}/blueferry/build-sha" in rpm
+
+
 def test_notification_capable_native_families_use_their_own_bluetoothd_path() -> None:
     arch = (ROOT / "packaging/arch/blueferry-bluetooth.conf").read_text()
     rpm = (ROOT / "packaging/rpm/blueferry-bluetooth.conf").read_text()
@@ -115,7 +135,10 @@ def test_arch_snapshot_excludes_deb_rpm_only_vendor_bundle() -> None:
     arch_recipe = (ROOT / "packaging/arch/PKGBUILD").read_text()
 
     assert '[[ "$file" == packaging/vendor/textual/* ]]' in build_script
-    assert 'blueferry/__pycache__/tui."*.pyc' in arch_recipe
+    assert "packaging/vendor/textual" not in arch_recipe
+    assert build_script.index('rm -rf -- "$snapshot_work"') < build_script.index(
+        'exec makepkg --cleanbuild --force "$@"'
+    )
 
 
 def test_package_workflow_installs_identical_artifacts_on_targets() -> None:
@@ -138,10 +161,10 @@ def test_package_workflow_installs_identical_artifacts_on_targets() -> None:
     assert "name: packages-arch" in workflow
     assert "name: packages-deb" in workflow
     assert "name: packages-rpm" in workflow
-    assert "Smoke-test the backend-only Arch install" in workflow
-    assert "install the blueferry-tui package" in workflow
-    assert workflow.count("smoke_tui blueferry-tui") == 4
-    assert workflow.count("smoke_tui blueferry tui") == 4
+    assert "Smoke-test the Arch backend and bundled TUI" in workflow
+    assert "install the blueferry-tui package" not in workflow
+    assert workflow.count("smoke_tui blueferry-tui") == 6
+    assert workflow.count("smoke_tui blueferry tui") == 6
     assert workflow.count('gi.require_version("Secret", "1")') == 4
     assert workflow.count('safe.directory "$GITHUB_WORKSPACE"') == 2
     assert workflow.count("dnf install -y --allowerasing") == 2

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -212,6 +212,7 @@ def test_write_local_env_preserves_settings_and_is_private(tmp_path, monkeypatch
     assert destination.read_text() == (
         "BLUEFERRY_MAC=02:00:00:00:00:01\n"
         "BLUEFERRY_ADAPTER=hci7\n"
+        "BLUEFERRY_ANCS_ENABLED=true\n"
         "BLUEFERRY_SHOW_NOTIFICATION_CONTENT=false\n"
     )
     assert stat.S_IMODE(destination.stat().st_mode) == 0o600
@@ -226,11 +227,29 @@ def test_write_local_env_rejects_environment_injection(tmp_path, monkeypatch):
         pair_setup.write_local_env("02:00:00:00:00:01", "hci0\nEVIL=1")
 
 
+def test_write_local_env_persists_compatibility_ancs_policy(tmp_path, monkeypatch):
+    destination = tmp_path / "local.env"
+    monkeypatch.setattr(pair_setup, "LOCAL_ENV_PATH", destination)
+
+    pair_setup.write_local_env(
+        "02:00:00:00:00:01",
+        "hci0",
+        False,
+    )
+
+    assert destination.read_text() == (
+        "BLUEFERRY_MAC=02:00:00:00:00:01\n"
+        "BLUEFERRY_ADAPTER=hci0\n"
+        "BLUEFERRY_ANCS_ENABLED=false\n"
+    )
+
+
 def test_clear_local_target_preserves_unrelated_preferences(tmp_path, monkeypatch):
     destination = tmp_path / "local.env"
     destination.write_text(
         "BLUEFERRY_MAC=02:00:00:00:00:01\n"
         "BLUEFERRY_ADAPTER=hci7\n"
+        "BLUEFERRY_ANCS_ENABLED=false\n"
         "BLUEFERRY_HISTORY_RETENTION_DAYS=14\n"
         "BLUEFERRY_SHOW_NOTIFICATION_CONTENT=false\n"
     )
@@ -986,6 +1005,8 @@ def _compatible(monkeypatch, *, notifications: bool = True) -> None:
             "hardware_supported": True,
             "notifications_supported": notifications,
             "bearer_api_active": True,
+            "low_energy": True,
+            "advertising": True,
         },
     )
     monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
@@ -1378,7 +1399,7 @@ def test_complete_pairing_headless_pairs_from_linux(monkeypatch):
     assert result["ancs"] == "connected"
 
 
-def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
+def test_compatibility_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
     from blueferry import pairing_agent
 
     unpaired = _device(paired=False)
@@ -1386,8 +1407,8 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
     calls = []
 
     class Agent:
-        def __init__(self, path, confirmation, display):
-            calls.append(("agent", path, confirmation, display))
+        def __init__(self, path, confirmation, display, *, make_default):
+            calls.append(("agent", path, confirmation, display, make_default))
 
         def __enter__(self):
             calls.append("agent-enter")
@@ -1398,6 +1419,9 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
 
         def wait_for_pair(self, *, timeout):
             calls.append(("wait", timeout))
+
+        def pair(self, *, timeout):
+            pytest.fail(f"compatibility mode must not call Pair ({timeout})")
 
     def confirmation(_passkey):
         return True
@@ -1455,16 +1479,18 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
         unpaired.mac,
         confirmation=confirmation,
         display=display,
+        compatibility_mode=True,
     )
 
-    # Connecting the unpaired ACL makes iOS initiate pairing (and derive the
-    # LE keys); there must be no competing Linux-side Device1.Pair() call.
-    # Keep our agent default while the daemon makes the first MAP/PBAP attempt
-    # and only then enables LE.
+    # Compatibility mode uses Connect so iOS initiates authentication; there
+    # must be no competing Linux-side Device1.Pair() call. After the Classic
+    # bond is trusted and settled, the solicitation is advertised before the
+    # daemon's first MAP/PBAP attempt, while ANCS remains disabled.
     assert calls[0][0] == "agent"
     assert calls[0][1] == unpaired.device_path
     assert calls[0][2] is not confirmation
     assert calls[0][2](12) is True
+    assert calls[0][4] is True
     assert calls[1:] == [
         "agent-enter",
         ("connect", unpaired.device_path, 60.0),
@@ -1478,6 +1504,161 @@ def test_interactive_pairing_connects_and_lets_the_iphone_initiate(monkeypatch):
         "advert-exit",
         "agent-exit",
     ]
+
+
+def test_default_interactive_pairing_lets_the_iphone_initiate(monkeypatch):
+    from blueferry import pairing_agent
+
+    unpaired = _device(paired=False)
+    paired = _device(paired=True)
+    calls = []
+
+    class Agent:
+        def __init__(self, path, confirmation, display, *, make_default):
+            calls.append(("agent", path, make_default))
+
+        def __enter__(self):
+            calls.append("agent-enter")
+            return self
+
+        def __exit__(self, *_args):
+            calls.append("agent-exit")
+
+        def pair(self, *, timeout):
+            pytest.fail(f"successful Connect must not call Pair ({timeout})")
+
+        def wait_for_pair(self, *, timeout):
+            calls.append(("wait", timeout))
+
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: unpaired)
+    monkeypatch.setattr(
+        pair_setup,
+        "_wait_for_paired_device",
+        lambda _mac, **_kwargs: calls.append("settled") or paired,
+    )
+    _compatible(monkeypatch)
+    monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
+    monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        bluez_setup,
+        "unregister_advert",
+        lambda _adapter: calls.append("advert-exit"),
+    )
+    monkeypatch.setattr(pairing_agent, "RegisteredPairingAgent", Agent)
+    monkeypatch.setattr(
+        pair_setup,
+        "_connect_classic",
+        lambda path, **kwargs: calls.append(("connect", path, kwargs["timeout"])),
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_wait_for_classic_settled",
+        lambda path, **_kwargs: calls.append(("classic-settled", path)),
+    )
+    monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: calls.append("trust"))
+    monkeypatch.setattr(
+        pair_setup,
+        "_prefer_bredr",
+        lambda path: calls.append(("prefer-bredr", path)),
+    )
+    monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: calls.append("persist"))
+    monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: calls.append("daemon"))
+
+    pair_setup.complete_pairing(
+        unpaired.mac,
+        confirmation=lambda _passkey: True,
+    )
+
+    assert calls == [
+        ("agent", unpaired.device_path, True),
+        "agent-enter",
+        ("connect", unpaired.device_path, 60.0),
+        ("wait", 120.0),
+        "settled",
+        "trust",
+        ("prefer-bredr", paired.device_path),
+        ("classic-settled", paired.device_path),
+        "persist",
+        "daemon",
+        "advert-exit",
+        "agent-exit",
+    ]
+
+
+def test_interactive_pairing_can_use_explicit_pair_without_connecting(monkeypatch):
+    from blueferry import pairing_agent
+
+    unpaired = _device(paired=False)
+    paired = _device(paired=True)
+    calls = []
+
+    class Agent:
+        def __init__(self, path, confirmation, display, *, make_default):
+            calls.append(("agent", path, make_default))
+
+        def __enter__(self):
+            calls.append("agent-enter")
+            return self
+
+        def __exit__(self, *_args):
+            calls.append("agent-exit")
+
+        def pair(self, *, timeout):
+            calls.append(("pair", timeout))
+
+        def wait_for_pair(self, *, timeout):
+            pytest.fail(f"explicit pairing must not wait for peer pairing ({timeout})")
+
+    device_results = iter([unpaired])
+    monkeypatch.setattr(
+        pair_setup,
+        "_device",
+        lambda _mac, **_kwargs: next(device_results, paired),
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_wait_for_paired_device",
+        lambda _mac, **_kwargs: calls.append("settled") or paired,
+    )
+    _compatible(monkeypatch)
+    monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
+    monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        bluez_setup,
+        "unregister_advert",
+        lambda _adapter: calls.append("advert-exit"),
+    )
+    monkeypatch.setattr(pairing_agent, "RegisteredPairingAgent", Agent)
+    monkeypatch.setattr(
+        pair_setup,
+        "_connect_classic",
+        lambda *_args, **_kwargs: pytest.fail(
+            "explicit pairing must not call Connect"
+        ),
+    )
+    monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: calls.append("trust"))
+    monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: calls.append("persist"))
+    monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: calls.append("daemon"))
+
+    result = pair_setup.complete_pairing(
+        unpaired.mac,
+        confirmation=lambda _passkey: True,
+        explicit_pairing=True,
+    )
+
+    assert result["ok"] is True
+    assert calls[:5] == [
+        ("agent", unpaired.device_path, False),
+        "agent-enter",
+        ("pair", 120.0),
+        "settled",
+        "trust",
+    ]
+    report = pair_setup.quirks_report.issue_report()
+    assert report is not None
+    payload = report.read_text()
+    assert '"pairing_transaction": "explicit-device-pair"' in payload
+    assert '"event": "pair_fallback"' not in payload
 
 
 def test_peer_initiated_pairing_is_allowed_to_finish(monkeypatch):
@@ -1571,22 +1752,19 @@ def test_pairing_without_bearer_api_continues_with_map_and_pbap(monkeypatch):
     monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: device)
     _compatible(monkeypatch, notifications=False)
     monkeypatch.setattr(bluez_setup, "prepare_classic", lambda **_kwargs: True)
+    adverts = []
     monkeypatch.setattr(
         bluez_setup,
         "register_advert",
-        lambda *_args, **_kwargs: pytest.fail("ANCS advert must not be registered"),
+        lambda *_args, **_kwargs: adverts.append("registered") or True,
     )
     monkeypatch.setattr(
         bluez_setup,
         "unregister_advert",
-        lambda *_args: pytest.fail("absent ANCS advert must not be removed"),
+        lambda *_args: adverts.append("removed"),
     )
     monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: None)
-    monkeypatch.setattr(
-        pair_setup,
-        "_prefer_bredr",
-        lambda *_args: pytest.fail("PreferredBearer must not be used"),
-    )
+    monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda *_args: None)
     monkeypatch.setattr(
         pair_setup,
         "_wait_for_daemon_transports",
@@ -1603,5 +1781,7 @@ def test_pairing_without_bearer_api_continues_with_map_and_pbap(monkeypatch):
     result = pair_setup.complete_pairing(device.mac)
 
     assert saved == [True]
-    assert result["ancs"] == "unsupported"
+    assert adverts == ["registered", "removed"]
+    assert result["ancs"] == "disabled"
+    assert result["ancs_enabled"] is False
     assert result["ancs_ready"] is False

--- a/tests/test_pairing_agent.py
+++ b/tests/test_pairing_agent.py
@@ -115,6 +115,7 @@ def test_registered_agent_is_default_only_for_context_lifetime(caplog):
     registered._agent = Agent()
     registered._registered = False
     registered._expected_device = "/device"
+    registered._make_default = True
 
     with registered:
         calls.append("pairing")
@@ -159,6 +160,7 @@ def test_registered_agent_cleans_up_when_default_request_fails():
     registered._agent = Agent()
     registered._registered = False
     registered._expected_device = "/device"
+    registered._make_default = True
 
     with pytest.raises(pairing_agent.PairingError, match="not authorized"):
         registered.__enter__()
@@ -205,3 +207,117 @@ def test_registered_agent_cleans_up_when_registration_fails():
         "removed",
     ]
     assert registered._registered is False
+
+
+def test_registered_agent_does_not_replace_default_for_explicit_pairing():
+    calls = []
+
+    class Manager:
+        def RegisterAgent(self, path, capability, **_kwargs):
+            calls.append(("register", str(path), capability))
+
+        def RequestDefaultAgent(self, _path, **_kwargs):
+            calls.append("unexpected-default")
+
+        def UnregisterAgent(self, path, **_kwargs):
+            calls.append(("unregister", str(path)))
+
+    class Agent:
+        def remove_from_connection(self):
+            calls.append("removed")
+
+    registered = pairing_agent.RegisteredPairingAgent.__new__(
+        pairing_agent.RegisteredPairingAgent
+    )
+    registered._manager = Manager()
+    registered._agent = Agent()
+    registered._registered = False
+    registered._expected_device = "/device"
+    registered._make_default = False
+
+    with registered:
+        calls.append("pairing")
+
+    assert calls == [
+        ("register", pairing_agent.AGENT_PATH, "DisplayYesNo"),
+        "pairing",
+        ("unregister", pairing_agent.AGENT_PATH),
+        "removed",
+    ]
+
+
+def test_registered_agent_pairs_asynchronously_on_its_own_bus(monkeypatch):
+    calls = []
+
+    class Loop:
+        def run(self):
+            calls.append("loop-run")
+
+        def quit(self):
+            calls.append("loop-quit")
+
+    class Device:
+        def Pair(self, **kwargs):
+            calls.append(("pair", kwargs["timeout"]))
+            kwargs["reply_handler"]()
+
+    class Bus:
+        def get_object(self, service, path):
+            calls.append(("object", service, path))
+            return object()
+
+    monkeypatch.setattr(pairing_agent.GLib, "MainLoop", Loop)
+    monkeypatch.setattr(pairing_agent.GLib, "timeout_add", lambda *_args: 7)
+    monkeypatch.setattr(
+        pairing_agent.GLib,
+        "source_remove",
+        lambda source: calls.append(("source-remove", source)),
+    )
+    monkeypatch.setattr(pairing_agent.dbus, "Interface", lambda *_args: Device())
+    registered = pairing_agent.RegisteredPairingAgent.__new__(
+        pairing_agent.RegisteredPairingAgent
+    )
+    registered._bus = Bus()
+    registered._expected_device = "/device"
+
+    registered.pair(timeout=42.0)
+
+    assert calls == [
+        ("object", "org.bluez", "/device"),
+        ("pair", 42.0),
+        "loop-quit",
+        "loop-run",
+        ("source-remove", 7),
+    ]
+
+
+def test_registered_agent_propagates_async_pairing_failure(monkeypatch):
+    error = dbus.exceptions.DBusException(
+        "rejected", name="org.bluez.Error.AuthenticationRejected"
+    )
+
+    class Loop:
+        def run(self):
+            pass
+
+        def quit(self):
+            pass
+
+    class Device:
+        def Pair(self, **kwargs):
+            kwargs["error_handler"](error)
+
+    monkeypatch.setattr(pairing_agent.GLib, "MainLoop", Loop)
+    monkeypatch.setattr(pairing_agent.GLib, "timeout_add", lambda *_args: 7)
+    monkeypatch.setattr(pairing_agent.GLib, "source_remove", lambda _source: None)
+    monkeypatch.setattr(pairing_agent.dbus, "Interface", lambda *_args: Device())
+    registered = pairing_agent.RegisteredPairingAgent.__new__(
+        pairing_agent.RegisteredPairingAgent
+    )
+    registered._bus = type("Bus", (), {"get_object": lambda *_args: object()})()
+    registered._expected_device = "/device"
+
+    with pytest.raises(dbus.exceptions.DBusException) as raised:
+        registered.pair()
+
+    assert raised.value is error

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -12,6 +12,7 @@ def test_verified_cli_setup_omits_the_iphone_section(capsys) -> None:
         frozenset(),
         remaining=(),
         notifications_supported=True,
+        ancs_enabled=True,
         ancs_ready=True,
     )
 
@@ -23,6 +24,7 @@ def test_cli_setup_always_prints_required_bluetooth_toggles(capsys) -> None:
         frozenset(),
         remaining=(CONTACTS,),
         notifications_supported=True,
+        ancs_enabled=True,
         ancs_ready=True,
     )
 
@@ -39,6 +41,7 @@ def test_cli_explains_group_threads_need_notification_access(capsys) -> None:
         frozenset(),
         remaining=("notification-access",),
         notifications_supported=True,
+        ancs_enabled=True,
         ancs_ready=False,
     )
 
@@ -46,6 +49,22 @@ def test_cli_explains_group_threads_need_notification_access(capsys) -> None:
         "Without System Notification access, group texts appear as individual "
         "conversations with their sender."
     ) in capsys.readouterr().out
+
+
+def test_cli_compatibility_mode_does_not_claim_the_controller_lacks_ancs(
+    capsys,
+) -> None:
+    _print_iphone_steps(
+        frozenset(),
+        remaining=(CONTACTS,),
+        notifications_supported=True,
+        ancs_enabled=False,
+        ancs_ready=False,
+    )
+
+    output = capsys.readouterr().out
+    assert "Without System Notification access" in output
+    assert "controller supports Messages and Contacts, but not" not in output
 
 
 def test_cli_just_works_pairing_still_requires_confirmation(monkeypatch) -> None:
@@ -60,6 +79,17 @@ def test_cli_just_works_pairing_still_requires_confirmation(monkeypatch) -> None
     assert prompts == [
         ("Approve this Bluetooth pairing request?", {"default": False})
     ]
+
+
+def test_cli_verification_distinguishes_compatibility_mode_from_missing_ancs() -> None:
+    assert pairing_cli._verification_detail(
+        ancs_ready=False,
+        compatibility_mode=True,
+    ) == "messages and contacts; ANCS was disabled by compatibility mode"
+    assert pairing_cli._verification_detail(
+        ancs_ready=False,
+        compatibility_mode=False,
+    ) == "messages and contacts; this controller has no ANCS support"
 
 
 def test_cli_requires_phone_side_forget_before_clearing_saved_target(
@@ -137,7 +167,17 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> No
             return SimpleNamespace(saved=False, mac="")
 
         @staticmethod
-        def complete(mac, *, confirmation, display, adapter=None):
+        def complete(
+            mac,
+            *,
+            confirmation,
+            display,
+            adapter=None,
+            compatibility_mode=False,
+            explicit_pairing=False,
+        ):
+            assert compatibility_mode is False
+            assert explicit_pairing is False
             observed.append((mac, adapter, confirmation(12345)))
             display(12345)
             return SimpleNamespace(device=device, ancs_ready=True)
@@ -204,7 +244,17 @@ def test_cli_wizard_points_at_pairing_issue_when_ancs_stays_down(
             return SimpleNamespace(saved=False, mac="")
 
         @staticmethod
-        def complete(mac, *, confirmation, display, adapter=None):
+        def complete(
+            mac,
+            *,
+            confirmation,
+            display,
+            adapter=None,
+            compatibility_mode=False,
+            explicit_pairing=False,
+        ):
+            assert compatibility_mode is False
+            assert explicit_pairing is False
             return SimpleNamespace(
                 device=device,
                 ancs_ready=False,

--- a/tests/test_pairing_policy.py
+++ b/tests/test_pairing_policy.py
@@ -1,0 +1,77 @@
+"""Pairing policy keeps ANCS capability separate from solicitation."""
+
+from blueferry.pairing_policy import PairingMode, resolve_pairing_policy
+
+
+def _capabilities(*, notifications: bool = True) -> dict[str, bool]:
+    return {
+        "notifications_supported": notifications,
+        "low_energy": True,
+        "advertising": True,
+    }
+
+
+def test_ancs_capable_adapter_lets_the_iphone_initiate() -> None:
+    policy = resolve_pairing_policy(_capabilities())
+
+    assert policy.mode is PairingMode.FULL
+    assert policy.pairing_strategy == "iphone-initiated-connect"
+    assert policy.ancs_enabled is True
+    assert policy.solicitation_enabled is True
+    assert policy.reason == "ancs-available"
+
+
+def test_user_override_keeps_connect_first_in_compatibility_mode() -> None:
+    policy = resolve_pairing_policy(
+        _capabilities(),
+        force_compatibility=True,
+    )
+
+    assert policy.mode is PairingMode.COMPATIBILITY
+    assert policy.pairing_strategy == "iphone-initiated-connect"
+    assert policy.ancs_enabled is False
+    assert policy.solicitation_enabled is True
+    assert policy.user_forced is True
+
+
+def test_missing_ancs_capability_selects_compatibility_but_keeps_soliciting() -> None:
+    policy = resolve_pairing_policy(_capabilities(notifications=False))
+
+    assert policy.mode is PairingMode.COMPATIBILITY
+    assert policy.pairing_strategy == "iphone-initiated-connect"
+    assert policy.ancs_enabled is False
+    assert policy.solicitation_enabled is True
+    assert policy.reason == "ancs-unavailable"
+
+
+def test_adapter_without_le_advertising_cannot_solicit() -> None:
+    policy = resolve_pairing_policy({
+        "notifications_supported": False,
+        "low_energy": False,
+        "advertising": False,
+    })
+
+    assert policy.mode is PairingMode.COMPATIBILITY
+    assert policy.solicitation_enabled is False
+
+
+def test_headless_compatibility_uses_explicit_pair_fallback() -> None:
+    policy = resolve_pairing_policy(
+        _capabilities(notifications=False),
+        interactive=False,
+    )
+
+    assert policy.mode is PairingMode.COMPATIBILITY
+    assert policy.pairing_strategy == "explicit-device-pair"
+    assert policy.ancs_enabled is False
+
+
+def test_user_can_force_explicit_pairing_independently_of_compatibility() -> None:
+    policy = resolve_pairing_policy(
+        _capabilities(),
+        force_explicit_pairing=True,
+    )
+
+    assert policy.mode is PairingMode.FULL
+    assert policy.pairing_strategy == "explicit-device-pair"
+    assert policy.ancs_enabled is True

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -275,6 +275,128 @@ def test_pairing_rejects_when_confirmation_is_declined(monkeypatch):
     assert observed == [False]
 
 
+def test_pairing_forwards_independent_pairing_modes(monkeypatch):
+    from types import SimpleNamespace
+
+    observed = []
+
+    class Setup:
+        def complete_isolated(self, _mac, **kwargs):
+            observed.append((
+                kwargs.get("compatibility_mode"),
+                kwargs.get("explicit_pairing"),
+            ))
+            return SimpleNamespace(ancs_enabled=False)
+
+    controller = BridgeController(
+        backend=_Backend(),
+        setup=Setup(),
+        subscribe=False,
+        autostart=False,
+    )
+    monkeypatch.setattr(
+        controller,
+        "_run",
+        lambda operation, on_done=None, *_args, **_kwargs: (
+            on_done(operation()) if on_done is not None else operation()
+        ),
+    )
+    monkeypatch.setattr(controller, "loadDevices", lambda _scan: None)
+    monkeypatch.setattr(controller, "loadSetupState", lambda: None)
+    monkeypatch.setattr(controller, "refresh", lambda: None)
+
+    controller._compatibility = {
+        "adapter": "hci0",
+        "notifications_supported": True,
+    }
+    controller.completePairing("02:00:00:00:00:01", True, True)
+
+    assert observed == [(True, True)]
+    assert controller.compatibility["notifications_supported"] is True
+
+
+def test_saved_pairing_policy_does_not_overwrite_adapter_capability(monkeypatch):
+    from types import SimpleNamespace
+
+    class Setup:
+        @staticmethod
+        def compatibility(_adapter=None):
+            return SimpleNamespace(
+                to_dict=lambda: {
+                    "adapter": "hci0",
+                    "hardware_supported": True,
+                    "messages_supported": True,
+                    "notifications_supported": True,
+                    "pairing_ready": True,
+                    "bearer_api_active": True,
+                },
+                bearer_api_active=True,
+            )
+
+        @staticmethod
+        def configuration():
+            return SimpleNamespace(
+                configured=False,
+                saved=True,
+                bonded=False,
+                mac="02:00:00:00:00:01",
+                adapter="hci0",
+                pairing_issue_report="",
+                ancs_enabled=False,
+            )
+
+    controller = BridgeController(
+        backend=_Backend(),
+        setup=Setup(),
+        subscribe=False,
+        autostart=False,
+    )
+    monkeypatch.setattr(
+        controller,
+        "_run",
+        lambda operation, on_done=None, *_args, **_kwargs: (
+            on_done(operation()) if on_done is not None else operation()
+        ),
+    )
+
+    controller.loadSetupState()
+
+    assert controller.targetSaved is True
+    assert controller.configured is False
+    assert controller.compatibility["notifications_supported"] is True
+
+
+def test_compatibility_pairing_adjusts_only_the_qt_onboarding_view():
+    controller = BridgeController(
+        backend=_Backend(),
+        setup=object(),
+        subscribe=False,
+        autostart=False,
+    )
+    controller._compatibility = {
+        "hardware_supported": True,
+        "messages_supported": True,
+        "notifications_supported": True,
+        "bearer_api_active": True,
+    }
+    controller._configured = True
+    controller._target_saved = True
+    controller._ancs_enabled = False
+    controller._setup_loaded = True
+    controller._status = {
+        "daemon": True,
+        "map": True,
+        "pbap": True,
+        "verified_iphone_setup": ["message-notifications", "contacts"],
+    }
+
+    controller._update_onboarding_stage()
+
+    assert controller.compatibility["notifications_supported"] is True
+    assert controller.onboardingCompatibility["notifications_supported"] is False
+    assert controller.onboardingStage == "ready-without-ancs"
+
+
 def test_replacing_saved_target_is_forwarded_to_pairing_helper(monkeypatch):
     observed = []
 

--- a/tests/test_quirks_report.py
+++ b/tests/test_quirks_report.py
@@ -41,6 +41,16 @@ def test_issue_instructions_ask_for_iphone_model_and_ios_version() -> None:
     assert "blueferry pairing-issue" in quirks_report.cli_issue_hint()
 
 
+def test_pairing_report_includes_the_running_build_sha(monkeypatch) -> None:
+    monkeypatch.setattr(quirks_report, "running_build_sha", lambda: "a" * 64)
+    monkeypatch.setattr(quirks_report, "installed_release", lambda: "0.6.3-1")
+
+    attempt = quirks_report.start_attempt(interactive=True)
+
+    assert attempt["blueferry_sha"] == "a" * 64
+    assert attempt["blueferry_build"] == "0.6.3-1+sha." + "a" * 12
+
+
 def test_issue_url_labels_a_pairing_issue_with_adapter_and_outcome() -> None:
     url = quirks_report.issue_url(
         {
@@ -416,6 +426,15 @@ def test_complete_pairing_writes_a_scrubbed_success_report(
     assert "id" not in parsed["phone"]
     assert parsed["phone"]["likely_iphone"] is True
     assert parsed["controller"]["name"] == "hci0"
+    assert parsed["pairing_policy"] == {
+        "ancs_capable": True,
+        "ancs_enabled": True,
+        "mode": "full",
+        "pairing_strategy": "explicit-device-pair",
+        "reason": "ancs-available",
+        "solicitation_enabled": True,
+        "user_forced": False,
+    }
     assert "adapter" not in parsed
     assert "compatibility" not in parsed
     assert Path(result["quirks_report"]).is_relative_to(report_dir)

--- a/tests/test_setup_client.py
+++ b/tests/test_setup_client.py
@@ -222,3 +222,38 @@ def test_isolated_pairing_preserves_report_path_on_failure(monkeypatch):
 
     assert raised.value.report_path == "/tmp/quirks-test.json"
     assert str(raised.value) == "Bluetooth confirmation did not complete"
+
+
+def test_isolated_pairing_adds_pairing_mode_helper_flags(monkeypatch):
+    device = _device()
+    commands = []
+
+    class Process:
+        stdin = io.StringIO()
+        stdout = iter([
+            '{"ok":true,"device":' + json.dumps(device.to_dict()) + "}\n",
+        ])
+
+        @staticmethod
+        def wait(*_args, **_kwargs):
+            return 0
+
+        @staticmethod
+        def poll():
+            return 0
+
+    monkeypatch.setattr(
+        setup_client.subprocess,
+        "Popen",
+        lambda command, **_kwargs: commands.append(command) or Process(),
+    )
+
+    setup_client.SetupClient().complete_isolated(
+        device.mac,
+        confirmation=lambda _passkey: True,
+        compatibility_mode=True,
+        explicit_pairing=True,
+    )
+
+    assert "--compatibility-mode" in commands[0]
+    assert commands[0][-1] == "--explicit-pairing"

--- a/tests/test_tui_launcher.py
+++ b/tests/test_tui_launcher.py
@@ -73,7 +73,7 @@ def test_launcher_drops_every_module_shadowed_by_the_vendor_bundle(monkeypatch) 
     assert set(modules) == {"blueferry", "typer"}
 
 
-def test_missing_arch_tui_returns_an_install_hint(monkeypatch, capsys) -> None:
+def test_missing_packaged_tui_returns_a_reinstall_hint(monkeypatch, capsys) -> None:
     real_import = builtins.__import__
 
     def missing_tui(name, *args, **kwargs):
@@ -87,10 +87,10 @@ def test_missing_arch_tui_returns_an_install_hint(monkeypatch, capsys) -> None:
     monkeypatch.setattr(builtins, "__import__", missing_tui)
 
     assert tui_launcher.main() == 2
-    assert "install the blueferry-tui package" in capsys.readouterr().err
+    assert "reinstall blueferry-backend" in capsys.readouterr().err
 
 
-def test_backend_cli_reports_how_to_install_the_arch_tui(monkeypatch) -> None:
+def test_backend_cli_reports_how_to_restore_a_missing_tui(monkeypatch) -> None:
     real_import = builtins.__import__
 
     def missing_tui(name, *args, **kwargs):
@@ -106,4 +106,4 @@ def test_backend_cli_reports_how_to_install_the_arch_tui(monkeypatch) -> None:
     result = CliRunner().invoke(cli.app, ["tui"])
 
     assert result.exit_code == 2
-    assert "install the blueferry-tui package" in result.output
+    assert "reinstall blueferry-backend" in result.output


### PR DESCRIPTION
## Summary

- add policy-driven compatibility pairing that preserves MAP/PBAP behavior when ANCS is unavailable or intentionally disabled
- add an independent explicit-pairing option for controllers that cannot use the normal connect-first flow
- carry package release and source SHA as a private build ID so clients restart stale same-version daemons and pairing reports identify the exact build
- ship the terminal client in every native backend package, folding the Arch TUI into `blueferry-backend` with native Textual dependencies
- update Qt, GTK/status, Quickshell, CLI guidance, architecture, protocol, packaging documentation, and native-package smoke coverage

## Testing

- `PYTHONPATH=src pytest -q` — 580 passed, 3 skipped
- focused namespace/native-package/launcher tests — 53 passed
- `bash -n packaging/arch/PKGBUILD build.sh`
- `makepkg --printsrcinfo`
- `git diff --check`