### PR TITLE
Recover ANCS automatically after BlueZ restarts

### DIFF
--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -1445,6 +1445,17 @@ ShellRoot {
             Layout.fillWidth: true
           }
           FerryLabel {
+            visible: root.configured
+              && onboarding.notificationsSupported
+              && root.backendStatus.map
+              && root.backendStatus.pbap
+              && !root.backendStatus.ancs
+            text: "FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Before re-pairing, run sudo systemctl restart bluetooth.service, then forget this computer on the iPhone and pair again. This briefly disconnects all Bluetooth devices."
+            color: theme.warning
+            wrapMode: Text.Wrap
+            Layout.fillWidth: true
+          }
+          FerryLabel {
             text: !root.notificationsSupported
               ? "Bluetooth bearer API: not required"
               : root.bluezActive

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -67,6 +67,11 @@ REQUEST_TIMEOUT_SECONDS = 15
 DBUS_CALL_TIMEOUT_SECONDS = 10
 SUBSCRIBE_RETRY_SECONDS = 2
 AUTHORIZATION_RETRY_SECONDS = 5
+MANAGER_RETRY_SECONDS = 2
+
+_BLUEZ_BUS_NAME = "org.bluez"
+_DBUS_BUS_NAME = "org.freedesktop.DBus"
+_DBUS_INTERFACE = "org.freedesktop.DBus"
 
 
 @dataclass(slots=True)
@@ -136,7 +141,13 @@ class AncsClient:
         # subscriptions are shorter-lived and are rebuilt as one unit whenever
         # BlueZ removes any part of the ANCS service.
         self._manager_signal_matches: list = []
+        self._owner_signal_match = None
         self._characteristic_signal_matches: list = []
+        self._bluez_owner_generation = 0
+        self._bluez_owner_available = True
+        self._manager_bind_in_progress = False
+        self._manager_rebind_pending = False
+        self._manager_retry_id: int | None = None
         self._subscribe_retry_id: int | None = None
         self._authorization_retry_id: int | None = None
         self._started = False
@@ -147,8 +158,55 @@ class AncsClient:
         if self._started:
             return
         log.info("ANCS client starting; watching %s", self.device_path)
+        bus = get_system_bus()
+        owner_match = bus.add_signal_receiver(
+            self._on_bluez_owner_changed,
+            dbus_interface=_DBUS_INTERFACE,
+            signal_name="NameOwnerChanged",
+            bus_name=_DBUS_BUS_NAME,
+            arg0=_BLUEZ_BUS_NAME,
+        )
+        self._owner_signal_match = owner_match
+        self._bluez_owner_available = True
+        self._started = True
+        try:
+            self._bind_manager_and_rescan()
+        except Exception:
+            self._started = False
+            self._owner_signal_match = None
+            try:
+                owner_match.remove()
+            except Exception:
+                log.debug("could not remove partial BlueZ owner watch", exc_info=True)
+            raise
+
+    def _bind_manager_and_rescan(self) -> None:
+        """Reconnect ObjectManager signals and sweep the current object tree."""
+        if self._manager_bind_in_progress:
+            self._manager_rebind_pending = True
+            return
+        self._manager_bind_in_progress = True
+        try:
+            while self._started and self._bluez_owner_available:
+                self._manager_rebind_pending = False
+                generation = self._bluez_owner_generation
+                try:
+                    self._bind_manager_once(generation)
+                except Exception:
+                    if generation == self._bluez_owner_generation:
+                        raise
+                if (
+                    not self._manager_rebind_pending
+                    and generation == self._bluez_owner_generation
+                ):
+                    return
+        finally:
+            self._manager_bind_in_progress = False
+
+    def _bind_manager_once(self, generation: int) -> None:
+        self._remove_manager_watches()
         om = dbus.Interface(
-            get_system_bus().get_object("org.bluez", "/"),
+            get_system_bus().get_object(_BLUEZ_BUS_NAME, "/"),
             "org.freedesktop.DBus.ObjectManager",
         )
         matches = []
@@ -169,10 +227,104 @@ class AncsClient:
                 except Exception:
                     log.debug("could not remove partial ANCS manager watch", exc_info=True)
             raise
+        if (
+            generation != self._bluez_owner_generation
+            or not self._bluez_owner_available
+        ):
+            for match in matches:
+                try:
+                    match.remove()
+                except Exception:
+                    log.debug("could not remove stale ANCS manager watch", exc_info=True)
+            return
         self._manager_signal_matches = matches
-        self._started = True
         for path, ifaces in managed.items():
             self._on_iface_added(path, ifaces)
+        if (
+            generation != self._bluez_owner_generation
+            or not self._bluez_owner_available
+        ):
+            self._remove_manager_watches()
+            self._cancel_subscribe_retry()
+            self._clear_characteristic_subscription(stop_notify=False)
+            self._ns_path = self._ds_path = self._cp_path = None
+
+    def _remove_manager_watches(self) -> None:
+        for match in self._manager_signal_matches:
+            try:
+                match.remove()
+            except Exception:
+                log.debug("could not remove ANCS manager watch", exc_info=True)
+        self._manager_signal_matches = []
+
+    def _on_bluez_owner_changed(self, _name, old_owner, new_owner) -> None:
+        """Rebuild discovery when bluetoothd replaces its D-Bus owner.
+
+        BlueZ can recreate cached GATT objects before dbus-python retargets an
+        existing well-known-name signal match.  Connecting fresh manager
+        watches and then sweeping GetManagedObjects closes both sides of that
+        race.
+        """
+        if not self._started:
+            return
+        self._bluez_owner_generation += 1
+        self._bluez_owner_available = bool(new_owner)
+        if self._manager_bind_in_progress:
+            self._manager_rebind_pending = True
+        if old_owner:
+            was_connected = self.connected
+            log.info("BlueZ owner disappeared; resetting ANCS discovery")
+            self._cancel_manager_retry()
+            self._remove_manager_watches()
+            self._cancel_subscribe_retry()
+            self._clear_characteristic_subscription(stop_notify=False)
+            self._ns_path = self._ds_path = self._cp_path = None
+            if was_connected and self.on_status is not None:
+                self.on_status()
+        if not new_owner:
+            return
+        log.info("BlueZ owner available; rebuilding ANCS discovery")
+        if self._manager_bind_in_progress:
+            log.debug("deferring ANCS discovery rebuild until the current sweep finishes")
+            return
+        try:
+            self._bind_manager_and_rescan()
+        except Exception as error:
+            log.warning(
+                "could not rebuild ANCS discovery after BlueZ restart: %s; "
+                "retrying in %ds",
+                error,
+                MANAGER_RETRY_SECONDS,
+            )
+            self._schedule_manager_retry()
+
+    def _schedule_manager_retry(self) -> None:
+        if not self._started or self._manager_retry_id is not None:
+            return
+        self._manager_retry_id = self._schedule(
+            MANAGER_RETRY_SECONDS,
+            self._retry_manager_bind,
+        )
+
+    def _retry_manager_bind(self) -> bool:
+        self._manager_retry_id = None
+        if not self._started:
+            return False
+        try:
+            self._bind_manager_and_rescan()
+        except Exception as error:
+            log.warning("ANCS discovery rebuild still unavailable: %s", error)
+            self._schedule_manager_retry()
+        return False
+
+    def _cancel_manager_retry(self) -> None:
+        if self._manager_retry_id is None:
+            return
+        try:
+            self._cancel(self._manager_retry_id)
+        except Exception:
+            log.debug("could not remove ANCS manager retry", exc_info=True)
+        self._manager_retry_id = None
 
     @property
     def subscribed(self) -> bool:
@@ -194,16 +346,20 @@ class AncsClient:
     def stop(self) -> None:
         log.info("ANCS client stopping")
         was_connected = self.connected
+        self._started = False
+        self._bluez_owner_available = False
+        self._manager_rebind_pending = False
+        self._cancel_manager_retry()
         self._cancel_subscribe_retry()
         self._cancel_authorization_retry()
         self._clear_characteristic_subscription()
-        for m in self._manager_signal_matches:
+        self._remove_manager_watches()
+        if self._owner_signal_match is not None:
             try:
-                m.remove()
+                self._owner_signal_match.remove()
             except Exception:
-                log.debug("could not remove ANCS manager watch", exc_info=True)
-        self._manager_signal_matches = []
-        self._started = False
+                log.debug("could not remove BlueZ owner watch", exc_info=True)
+            self._owner_signal_match = None
         self._ns_path = self._ds_path = self._cp_path = None
         if was_connected and self.on_status is not None:
             self.on_status()
@@ -245,7 +401,7 @@ class AncsClient:
                     self.on_status()
                 break
 
-    def _clear_characteristic_subscription(self) -> None:
+    def _clear_characteristic_subscription(self, *, stop_notify: bool = True) -> None:
         """Remove receivers and notification ownership before rediscovery."""
         self._cancel_authorization_retry()
         for match in self._characteristic_signal_matches:
@@ -254,7 +410,7 @@ class AncsClient:
             except Exception:
                 log.debug("could not remove ANCS characteristic watch", exc_info=True)
         self._characteristic_signal_matches = []
-        if self._notify_started:
+        if self._notify_started and stop_notify:
             for path in (self._ns_path, self._ds_path):
                 if path:
                     try:
@@ -273,6 +429,20 @@ class AncsClient:
             return
         if not (self._ns_path and self._ds_path and self._cp_path):
             return
+        generation = self._bluez_owner_generation
+        ns_path = self._ns_path
+        ds_path = self._ds_path
+
+        def current_attempt() -> bool:
+            return self._started and generation == self._bluez_owner_generation
+
+        def remove_attempt_matches(matches) -> None:
+            for match in matches:
+                try:
+                    match.remove()
+                except Exception:
+                    log.debug("could not remove stale ANCS signal watch", exc_info=True)
+
         # Install receivers before StartNotify so the first value cannot arrive
         # in the gap between notification activation and signal registration.
         matches = []
@@ -284,28 +454,38 @@ class AncsClient:
                 dbus_interface="org.freedesktop.DBus.Properties",
                 signal_name="PropertiesChanged",
                 bus_name="org.bluez",
-                path=self._ns_path,
+                path=ns_path,
             ))
             matches.append(bus.add_signal_receiver(
                 self._on_ds_changed,
                 dbus_interface="org.freedesktop.DBus.Properties",
                 signal_name="PropertiesChanged",
                 bus_name="org.bluez",
-                path=self._ds_path,
+                path=ds_path,
             ))
+            if not current_attempt():
+                remove_attempt_matches(matches)
+                return
             ns = dbus.Interface(
-                bus.get_object("org.bluez", self._ns_path),
+                bus.get_object("org.bluez", ns_path),
                 "org.bluez.GattCharacteristic1",
             )
             ds = dbus.Interface(
-                bus.get_object("org.bluez", self._ds_path),
+                bus.get_object("org.bluez", ds_path),
                 "org.bluez.GattCharacteristic1",
             )
             ns.StartNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
             started.append(ns)
+            if not current_attempt():
+                remove_attempt_matches(matches)
+                return
             ds.StartNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
             started.append(ds)
         except dbus.exceptions.DBusException as e:
+            if not current_attempt():
+                remove_attempt_matches(matches)
+                log.debug("discarded stale ANCS subscribe attempt after BlueZ changed owner")
+                return
             log.warning("ANCS StartNotify failed: %s", e.get_dbus_name())
             for characteristic in started:
                 try:
@@ -318,6 +498,9 @@ class AncsClient:
                 except Exception:
                     log.debug("could not roll back ANCS signal watch", exc_info=True)
             self._schedule_subscribe_retry()
+            return
+        if not current_attempt():
+            remove_attempt_matches(matches)
             return
         self._cancel_subscribe_retry()
         self._characteristic_signal_matches = matches
@@ -478,11 +661,21 @@ class AncsClient:
             return
         if not self._cp_path:
             return
+        generation = self._bluez_owner_generation
+        cp_path = self._cp_path
         request = self._request_queue.popleft()
         self._active_request = request
+
+        def current_attempt() -> bool:
+            return (
+                self._started
+                and generation == self._bluez_owner_generation
+                and self._active_request is request
+            )
+
         try:
             dbus.Interface(
-                get_system_bus().get_object("org.bluez", self._cp_path),
+                get_system_bus().get_object("org.bluez", cp_path),
                 "org.bluez.GattCharacteristic1",
             ).WriteValue(
                 [dbus.Byte(value) for value in request.packet],
@@ -490,12 +683,18 @@ class AncsClient:
                 timeout=DBUS_CALL_TIMEOUT_SECONDS,
             )
         except dbus.exceptions.DBusException as error:
+            if not current_attempt():
+                log.debug("discarded stale ANCS write failure after BlueZ changed owner")
+                return
             name = error.get_dbus_name() or type(error).__name__
             detail = error.get_dbus_message() or str(error)
             log.warning("ANCS CP WriteValue failed: %s: %s", name, detail)
             self._abandon_request(request)
             self._active_request = None
             self._pump_requests()
+            return
+        if not current_attempt():
+            log.debug("discarded stale ANCS write completion after BlueZ changed owner")
             return
         self._request_timeout_id = GLib.timeout_add_seconds(
             REQUEST_TIMEOUT_SECONDS, self._request_timed_out

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import time
+from collections import Counter
 from collections.abc import Callable
 from contextlib import ExitStack
 from pathlib import Path
@@ -14,13 +16,14 @@ from gi.repository import GLib
 
 from blueferry import bluetooth_capabilities as capabilities
 from blueferry import config, quirks_report
+from blueferry.ancs.constants import ANCS_CHAR_UUIDS, ANCS_SERVICE_UUID
 from blueferry.bearer_supervisor import preferred_bearer_unavailable
 from blueferry.bluetooth_devices import PairedDevice
 from blueferry.bus import get_session_bus, get_system_bus
 from blueferry.commands import run_command
 from blueferry.errors import CommandError, PairingError
 from blueferry.pairing_policy import resolve_pairing_policy
-from blueferry.private_files import atomic_write_private_text
+from blueferry.private_files import atomic_write_private_text, read_private_text
 from blueferry.setup_verification import clear_setup_verification
 
 log = logging.getLogger(__name__)
@@ -35,6 +38,8 @@ _SESSION_BLUETOOTH_NAMES = (
     "org.gnome.SettingsDaemon.Rfkill",
 )
 CLASSIC_SETTLE_SECONDS = 3.0
+BLUEZ_SNAPSHOT_TIMEOUT_SECONDS = 5.0
+BLUEZ_TRACE_POLL_SECONDS = 2.0
 # One BR/EDR inquiry is 10.24s. USB dongles also need a moment to start
 # after another adapter is stopped; 8s was aborting mid-inquiry.
 DISCOVERY_SECONDS = 24
@@ -42,6 +47,13 @@ MAX_DISCOVERY_SECONDS = 30
 
 ConfirmationCallback = Callable[[int | None], bool]
 DisplayCallback = Callable[[int], None]
+
+
+# Quickshell runs forget and pair in separate helper processes.
+_pending_teardown_traces: dict[str, dict[str, object]] = {}
+_TEARDOWN_TRACE_FILE = "pairing-teardown.json"
+_TEARDOWN_TRACE_MAX_BYTES = 16 * 1024
+_TEARDOWN_TRACE_MAX_AGE_SECONDS = 60 * 60
 
 
 def configuration_status() -> dict:
@@ -108,6 +120,201 @@ def _object_manager():
         get_system_bus().get_object("org.bluez", "/"),
         "org.freedesktop.DBus.ObjectManager",
     )
+
+
+def _bluez_device_snapshot(device_path: str) -> dict[str, object]:
+    """Return a public, bounded snapshot of one BlueZ device subtree.
+
+    Object paths and addresses are intentionally omitted.  The report needs
+    to distinguish a retained Device1/Battery1/GATT tree from a newly
+    discovered one, but it does not need the phone's Bluetooth address.
+    """
+    snapshot: dict[str, object] = {
+        "object_present": False,
+        "device_present": False,
+        "child_objects": 0,
+        "root_interfaces": [],
+        "child_interfaces": {},
+        "device": {
+            "paired": False,
+            "trusted": False,
+            "connected": False,
+            "services_resolved": False,
+            "ancs_uuid": False,
+            "uuid_count": 0,
+        },
+        "bearers": {
+            "bredr": {"present": False},
+            "le": {"present": False},
+        },
+        "gatt": {
+            "services": 0,
+            "characteristics": 0,
+            "ancs_service": False,
+            "ancs_characteristics": [],
+        },
+        "battery_objects": 0,
+    }
+    try:
+        objects = _object_manager().GetManagedObjects(
+            timeout=BLUEZ_SNAPSHOT_TIMEOUT_SECONDS,
+        )
+    except Exception as error:
+        snapshot["error"] = type(error).__name__
+        return snapshot
+
+    root_ifaces: dict = {}
+    subtree: list[tuple[str, dict]] = []
+    prefix = f"{device_path}/"
+    for raw_path, raw_ifaces in objects.items():
+        path = str(raw_path)
+        if path == device_path:
+            root_ifaces = raw_ifaces
+        if path == device_path or path.startswith(prefix):
+            subtree.append((path, raw_ifaces))
+
+    snapshot["object_present"] = bool(root_ifaces)
+    snapshot["child_objects"] = sum(path != device_path for path, _ in subtree)
+    snapshot["root_interfaces"] = sorted(str(name) for name in root_ifaces)
+    child_interfaces: Counter[str] = Counter()
+    service_uuids: set[str] = set()
+    characteristic_uuids: set[str] = set()
+    battery_objects = 0
+    for path, ifaces in subtree:
+        if path != device_path:
+            child_interfaces.update(str(name) for name in ifaces)
+        if "org.bluez.Battery1" in ifaces:
+            battery_objects += 1
+        service = ifaces.get("org.bluez.GattService1")
+        if service is not None:
+            uuid = str(service.get("UUID", "")).casefold()
+            if uuid:
+                service_uuids.add(uuid)
+        characteristic = ifaces.get("org.bluez.GattCharacteristic1")
+        if characteristic is not None:
+            uuid = str(characteristic.get("UUID", "")).casefold()
+            if uuid:
+                characteristic_uuids.add(uuid)
+
+    device = root_ifaces.get("org.bluez.Device1")
+    snapshot["device_present"] = device is not None
+    if device is not None:
+        uuids = sorted({str(value).casefold() for value in device.get("UUIDs", ())})
+        snapshot["device"] = {
+            "paired": bool(device.get("Paired", False)),
+            "trusted": bool(device.get("Trusted", False)),
+            "connected": bool(device.get("Connected", False)),
+            "services_resolved": bool(device.get("ServicesResolved", False)),
+            "ancs_uuid": ANCS_SERVICE_UUID in uuids,
+            "uuid_count": len(uuids),
+        }
+
+    bearers: dict[str, dict[str, object]] = {}
+    for label, interface in (
+        ("bredr", "org.bluez.Bearer.BREDR1"),
+        ("le", "org.bluez.Bearer.LE1"),
+    ):
+        bearer = root_ifaces.get(interface)
+        state: dict[str, object] = {"present": bearer is not None}
+        if bearer is not None:
+            for field in ("Paired", "Bonded", "Connected"):
+                if field in bearer:
+                    state[field.casefold()] = bool(bearer[field])
+        bearers[label] = state
+    snapshot["bearers"] = bearers
+    snapshot["child_interfaces"] = dict(sorted(child_interfaces.items()))
+    snapshot["battery_objects"] = battery_objects
+    snapshot["gatt"] = {
+        "services": child_interfaces["org.bluez.GattService1"],
+        "characteristics": child_interfaces["org.bluez.GattCharacteristic1"],
+        "ancs_service": ANCS_SERVICE_UUID in service_uuids,
+        "ancs_characteristics": sorted(ANCS_CHAR_UUIDS & characteristic_uuids),
+    }
+    return snapshot
+
+
+def _trace_time(attempt: dict) -> float:
+    origin = attempt.get("_t0")
+    if not isinstance(origin, (int, float)):
+        return 0.0
+    return round(time.monotonic() - origin, 3)
+
+
+def _record_bluez_state(
+    attempt: dict | None,
+    device_path: str | None,
+    phase: str,
+    *,
+    force: bool = False,
+) -> None:
+    """Append a BlueZ snapshot when the device subtree changes."""
+    if attempt is None or not device_path:
+        return
+    snapshot = _bluez_device_snapshot(device_path)
+    trace = attempt.setdefault("bluez_trace", [])
+    if not isinstance(trace, list):
+        return
+    if trace and not force and trace[-1].get("state") == snapshot:
+        return
+    trace.append({"t": _trace_time(attempt), "phase": phase, "state": snapshot})
+    # Bound pathological churn while retaining both the beginning and the
+    # most recent transitions that explain the final outcome.
+    if len(trace) > 32:
+        del trace[1]
+    log.debug("BlueZ device state (%s): %s", phase, snapshot)
+
+
+def _teardown_trace_path() -> Path:
+    return config.STATE_DIR / _TEARDOWN_TRACE_FILE
+
+
+def _save_pending_teardown(adapter: str, trace: dict[str, object]) -> None:
+    """Retain teardown diagnostics across Quickshell helper processes."""
+    _pending_teardown_traces[adapter] = trace
+    payload = json.dumps(
+        {
+            "adapter": adapter,
+            "recorded_at": time.time(),
+            "trace": trace,
+        },
+        sort_keys=True,
+    )
+    try:
+        atomic_write_private_text(
+            _teardown_trace_path(),
+            payload,
+            maximum_bytes=_TEARDOWN_TRACE_MAX_BYTES,
+        )
+    except (OSError, ValueError):
+        log.debug("could not persist BlueZ teardown trace", exc_info=True)
+
+
+def _take_pending_teardown(adapter: str) -> dict[str, object] | None:
+    """Consume a recent teardown trace for the adapter being paired."""
+    trace = _pending_teardown_traces.pop(adapter, None)
+    path = _teardown_trace_path()
+    if trace is None:
+        try:
+            payload = json.loads(
+                read_private_text(path, maximum_bytes=_TEARDOWN_TRACE_MAX_BYTES)
+            )
+            age = time.time() - float(payload.get("recorded_at", 0))
+            candidate = payload.get("trace")
+            if (
+                payload.get("adapter") == adapter
+                and 0 <= age <= _TEARDOWN_TRACE_MAX_AGE_SECONDS
+                and isinstance(candidate, dict)
+            ):
+                trace = candidate
+                trace["capture_age_s"] = round(age, 3)
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            log.debug("could not load BlueZ teardown trace", exc_info=True)
+    if trace is not None:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            log.debug("could not consume BlueZ teardown trace", exc_info=True)
+    return trace
 
 
 def bond_status(mac: str, adapter: str) -> bool | None:
@@ -498,14 +705,20 @@ def _wait_for_daemon_transports(
     timeout: float = 45.0,
     attempt: dict | None = None,
     notifications_supported: bool = True,
+    device_path: str | None = None,
 ) -> tuple[bool, bool, bool]:
     """Observe the daemon while the pairing advert and agent remain active."""
     from blueferry.client import BackendClient, BackendError
 
     deadline = time.monotonic() + timeout
+    next_bluez_snapshot = 0.0
     previous: tuple[bool, bool, bool] | None = None
     quirks_report.mark(attempt, "waiting_for_transports")
     while time.monotonic() < deadline:
+        now = time.monotonic()
+        if now >= next_bluez_snapshot:
+            _record_bluez_state(attempt, device_path, "transport_wait")
+            next_bluez_snapshot = now + BLUEZ_TRACE_POLL_SECONDS
         try:
             status = BackendClient().status()
         except BackendError:
@@ -1086,8 +1299,13 @@ def _execute_pairing(
     session = attempt.setdefault("session", quirks_report.session_environment())
     if isinstance(session, dict):
         session["bluetooth_owners"] = _bluetooth_session_owners()
+    teardown = _take_pending_teardown(adapter)
+    if teardown is not None:
+        teardown["before_new_pairing"] = _bluez_device_snapshot(device.device_path)
+        attempt["previous_teardown"] = teardown
     quirks_report.mark(attempt, "device_loaded", already_paired=device.paired)
     _snapshot_phone(attempt, device)
+    _record_bluez_state(attempt, device.device_path, "device_loaded", force=True)
     compatibility = bluetooth_compatibility(adapter)
     attempt["controller"] = _controller_snapshot(adapter, compatibility)
     quirks_report.mark(attempt, "compatibility_ready")
@@ -1210,6 +1428,7 @@ def _execute_pairing(
             device = _wait_for_paired_device(mac, adapter=adapter)
             quirks_report.mark(attempt, "paired")
             _snapshot_phone(attempt, device)
+            _record_bluez_state(attempt, device.device_path, "paired", force=True)
         log.debug("setting Device1.Trusted=true for %s", device.device_path)
         trust_device(device.mac, device.adapter_path)
         quirks_report.mark(attempt, "trusted")
@@ -1220,6 +1439,9 @@ def _execute_pairing(
         # second generic Device1.Connect can wander into LE, so only require
         # that the existing ACL settle.
         _wait_for_classic_settled(device.device_path, attempt=attempt)
+        _record_bluez_state(
+            attempt, device.device_path, "classic_settled", force=True,
+        )
 
         # Keep ANCS solicitation active because iOS 26 testing found that it
         # surfaced the MAP/PBAP permission toggles.  It is a pairing signal,
@@ -1232,6 +1454,9 @@ def _execute_pairing(
                 raise PairingError("The ANCS advertisement did not activate")
             advert_registered = True
             quirks_report.mark(attempt, "advert_ready")
+            _record_bluez_state(
+                attempt, device.device_path, "advert_ready", force=True,
+            )
         else:
             log.info(
                 "the controller cannot advertise ANCS solicitation; "
@@ -1250,9 +1475,13 @@ def _execute_pairing(
         quirks_report.mark(attempt, "daemon_restart_sent")
         _restart_user_service()
         quirks_report.mark(attempt, "daemon_restarted")
+        _record_bluez_state(
+            attempt, device.device_path, "daemon_restarted", force=True,
+        )
         map_ready, pbap_ready, ancs_ready = _wait_for_daemon_transports(
             attempt=attempt,
             notifications_supported=policy.ancs_enabled,
+            device_path=device.device_path,
         )
         if not policy.ancs_enabled:
             ancs = "disabled"
@@ -1274,6 +1503,9 @@ def _execute_pairing(
                 log.debug("removing ANCS solicitation advertisement from %s", adapter)
                 bluez_setup.unregister_advert(adapter)
                 quirks_report.mark(attempt, "advert_removed")
+                _record_bluez_state(
+                    attempt, device.device_path, "advert_removed", force=True,
+                )
         finally:
             pairing_agents.close()
             if agent_registered:
@@ -1281,6 +1513,7 @@ def _execute_pairing(
 
     device = _device(mac, adapter=adapter)
     _snapshot_phone(attempt, device)
+    _record_bluez_state(attempt, device.device_path, "finished", force=True)
     return {
         "ok": True,
         "device": device.to_dict(),
@@ -1305,6 +1538,22 @@ def forget_device(mac: str, *, adapter: str | None = None) -> None:
     if not config.is_valid_mac(normalized):
         raise PairingError("invalid Bluetooth device address")
     device = _find_device(normalized, adapter=adapter)
+    adapter_name = (
+        device.adapter_path.rsplit("/", 1)[-1]
+        if device is not None
+        else (adapter or config.ADAPTER)
+    )
+    device_path = (
+        device.device_path
+        if device is not None
+        else f"/org/bluez/{adapter_name}/dev_{normalized.replace(':', '_')}"
+    )
+    teardown: dict[str, object] = {
+        "reason": "forget_device",
+        "remove_requested": device is not None,
+        "before_remove": _bluez_device_snapshot(device_path),
+    }
+    started = time.monotonic()
     log.info("stopping the user service before forgetting target %s", normalized)
     _stop_user_service()
     if device is not None:
@@ -1314,13 +1563,25 @@ def forget_device(mac: str, *, adapter: str | None = None) -> None:
                 get_system_bus().get_object("org.bluez", device.adapter_path),
                 "org.bluez.Adapter1",
             ).RemoveDevice(dbus.ObjectPath(device.device_path), timeout=30.0)
+            teardown["remove_result"] = "replied"
         except dbus.exceptions.DBusException as error:
             if error.get_dbus_name() != "org.bluez.Error.DoesNotExist":
+                teardown["remove_result"] = "failed"
+                teardown["remove_error"] = error.get_dbus_name() or type(error).__name__
+                teardown["after_remove_reply"] = _bluez_device_snapshot(device_path)
+                teardown["remove_elapsed_s"] = round(time.monotonic() - started, 3)
+                _save_pending_teardown(adapter_name, teardown)
                 raise PairingError(
                     error.get_dbus_message() or error.get_dbus_name() or str(error)
                 ) from error
+            teardown["remove_result"] = "already_absent"
     else:
         log.debug("no BlueZ device record remains for %s", normalized)
+        teardown["remove_result"] = "not_found"
+    teardown["after_remove_reply"] = _bluez_device_snapshot(device_path)
+    teardown["remove_elapsed_s"] = round(time.monotonic() - started, 3)
+    _save_pending_teardown(adapter_name, teardown)
+    log.debug("BlueZ teardown trace: %s", teardown)
     clear_local_target()
     log.info("cleared configured BlueFerry target %s", normalized)
 
@@ -1341,6 +1602,23 @@ def prepare_target_replacement(
     # this attempt. Removing that BlueZ object would also remove the scan
     # result before complete_pairing() can address it.
     _stop_user_service()
+    adapter_name = (
+        device.adapter_path.rsplit("/", 1)[-1]
+        if device is not None
+        else (adapter or config.ADAPTER)
+    )
+    device_path = (
+        device.device_path
+        if device is not None
+        else f"/org/bluez/{adapter_name}/dev_{previous.replace(':', '_')}"
+    )
+    teardown = {
+        "reason": "same_unpaired_scan_result_retained",
+        "remove_requested": False,
+        "before_clear": _bluez_device_snapshot(device_path),
+    }
+    _save_pending_teardown(adapter_name, teardown)
+    log.debug("BlueZ teardown trace: %s", teardown)
     clear_local_target()
     log.info("cleared stale BlueFerry target %s before pairing", previous)
 

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -39,6 +39,19 @@ def _verification_detail(*, ancs_ready: bool, compatibility_mode: bool) -> str:
     return "messages and contacts; this controller has no ANCS support"
 
 
+def _print_ancs_repair_hint() -> None:
+    typer.echo(
+        typer.style(
+            "\nFYI: If ANCS remains unavailable after setup, BlueZ may be "
+            "retaining stale Bluetooth state.",
+            fg=typer.colors.YELLOW,
+        )
+    )
+    typer.echo("Before re-pairing, run: sudo systemctl restart bluetooth.service")
+    typer.echo("Then forget this computer on the iPhone and pair again.")
+    typer.echo("This briefly disconnects all Bluetooth devices.")
+
+
 def run_wizard(
     *,
     verify_after: bool = True,
@@ -246,6 +259,8 @@ def run_wizard(
         ancs_enabled=ancs_enabled,
         ancs_ready=result.ancs_ready,
     )
+    if ancs_enabled and not result.ancs_ready:
+        _print_ancs_repair_hint()
 
     prompt = (
         "Have you completed the remaining iPhone steps? Verify the connection now?"

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -1185,6 +1185,17 @@ Kirigami.ApplicationWindow {
                         text: root.bridge.status.ancs ? qsTr("Connected") : qsTr("Unavailable")
                     }
                     Controls.Label {
+                        Kirigami.FormData.label: qsTr("ANCS Recovery:")
+                        Layout.fillWidth: true
+                        visible: root.bridge.configured
+                            && root.bridge.onboardingCompatibility.notifications_supported
+                            && root.bridge.status.map
+                            && root.bridge.status.pbap
+                            && !root.bridge.status.ancs
+                        wrapMode: Text.Wrap
+                        text: qsTr("FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Before re-pairing, run sudo systemctl restart bluetooth.service, then forget this computer on the iPhone and pair again. This briefly disconnects all Bluetooth devices.")
+                    }
+                    Controls.Label {
                         Kirigami.FormData.label: qsTr("Contact Destinations:")
                         text: root.bridge.status.contacts || "0"
                     }

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -19,6 +19,7 @@ from textual.message import Message
 from textual.screen import ModalScreen
 from textual.widgets import Button, Footer, Input, ListItem, ListView, Static, TextArea
 
+from blueferry import config
 from blueferry.backend_lifecycle import BackendLifecycleError, ensure_backend_current
 from blueferry.bus import get_session_bus
 from blueferry.client import BackendClient, BackendError
@@ -693,7 +694,8 @@ class BlueFerryApp(App[None]):
             await self._render_conversation()
         if self.state.status != previous_status:
             self._update_status()
-        if self.state.error != previous_error:
+            self._update_notice()
+        elif self.state.error != previous_error:
             self._update_notice()
         if threads_changed:
             self._warn_about_roster_changes()
@@ -862,6 +864,19 @@ class BlueFerryApp(App[None]):
         elif self.state.notice:
             notice.update(f"✓  {self.state.notice}")
             notice.set_classes("success")
+        elif (
+            config.ANCS_ENABLED
+            and self.state.status.map
+            and self.state.status.pbap
+            and not self.state.status.ancs
+        ):
+            notice.update(
+                "FYI: If ANCS remains unavailable, BlueZ may be retaining stale "
+                "Bluetooth state. Before re-pairing, run sudo systemctl restart "
+                "bluetooth.service, then forget this computer on the iPhone and "
+                "pair again. This briefly disconnects all Bluetooth devices."
+            )
+            notice.set_classes("warn")
         else:
             notice.update("Ready  ·  Ctrl+P: Help")
             notice.set_classes("")

--- a/src/blueferry/tui.tcss
+++ b/src/blueferry/tui.tcss
@@ -408,7 +408,8 @@ ConversationItem.-highlight .avatar {
 }
 
 #notice-bar {
-    height: 2;
+    height: auto;
+    min-height: 2;
     padding: 0 2;
     content-align-vertical: middle;
     background: #0d1425;
@@ -417,6 +418,11 @@ ConversationItem.-highlight .avatar {
 
 #notice-bar.success {
     color: #86efac;
+}
+
+#notice-bar.warn {
+    background: #403313;
+    color: #fde68a;
 }
 
 #notice-bar.error {

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -269,8 +269,25 @@ class IPhonePage(Gtk.Box):
         self._ancs_row = Adw.ActionRow(title=_("iPhone Notifications"))
         self._ancs_icon = Gtk.Image()
         self._ancs_row.add_suffix(self._ancs_icon)
+        self._ancs_recovery_label = Gtk.Label(
+            label=_(
+                "FYI: If ANCS remains unavailable, BlueZ may be retaining stale "
+                "Bluetooth state. Before re-pairing, run sudo systemctl restart "
+                "bluetooth.service, then forget this computer on the iPhone and "
+                "pair again. This briefly disconnects all Bluetooth devices."
+            ),
+            selectable=True,
+            wrap=True,
+            xalign=0,
+        )
+        self._ancs_recovery_label.set_margin_start(12)
+        self._ancs_recovery_label.set_margin_end(12)
+        self._ancs_recovery_label.set_margin_top(6)
+        self._ancs_recovery_label.set_margin_bottom(6)
+        self._ancs_recovery_label.set_visible(False)
         daemon_group.add(self._pbap_row)
         daemon_group.add(self._ancs_row)
+        daemon_group.add(self._ancs_recovery_label)
         page.add(daemon_group)
 
         notification_group = Adw.PreferencesGroup(
@@ -580,6 +597,9 @@ class IPhonePage(Gtk.Box):
             self._apply_compatibility(compatibility)
             self._set_pairing_busy(False)
             self._update_phone_controls()
+            # Configuration and daemon status load independently. Re-render
+            # status-dependent setup guidance after both sides are available.
+            self._apply_status(self._last_status)
             self._update_onboarding()
             self._refresh_issue_offer(configuration.pairing_issue_report)
             if scan_after or not self._devices:
@@ -869,15 +889,31 @@ class IPhonePage(Gtk.Box):
             "emblem-ok-symbolic" if healthy else "dialog-warning-symbolic"
         )
 
-        for row, icon, key in (
-            (self._pbap_row, self._pbap_icon, "pbap"),
-            (self._ancs_row, self._ancs_icon, "ancs"),
-        ):
-            connected = bool(values.get(key))
-            row.set_subtitle(_("Connected") if connected else _("Unavailable"))
-            icon.set_from_icon_name(
-                "emblem-ok-symbolic" if connected else "dialog-warning-symbolic"
+        pbap_connected = bool(values.get("pbap"))
+        self._pbap_row.set_subtitle(_("Connected") if pbap_connected else _("Unavailable"))
+        self._pbap_icon.set_from_icon_name(
+            "emblem-ok-symbolic" if pbap_connected else "dialog-warning-symbolic"
+        )
+
+        ancs_connected = bool(values.get("ancs"))
+        ancs_expected = bool(
+            self._configuration
+            and self._configuration.configured
+            and self._configuration.ancs_enabled
+            and (
+                self._compatibility is None
+                or self._compatibility.notifications_supported
             )
+        )
+        show_ancs_recovery = bool(
+            status.map and status.pbap and not ancs_connected and ancs_expected
+        )
+        ancs_subtitle = _("Connected") if ancs_connected else _("Unavailable")
+        self._ancs_row.set_subtitle(ancs_subtitle)
+        self._ancs_icon.set_from_icon_name(
+            "emblem-ok-symbolic" if ancs_connected else "dialog-warning-symbolic"
+        )
+        self._ancs_recovery_label.set_visible(show_ancs_recovery)
         self._contacts_row.set_subtitle(str(status.contacts))
         self._events_row.set_subtitle(str(status.events))
         policy = status.notification_policy

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -5,7 +5,15 @@ import struct
 
 from blueferry.ancs import client as client_module
 from blueferry.ancs.client import AncsClient
-from blueferry.ancs.constants import MESSAGES_APP_ID, CommandID, EventFlag, EventID
+from blueferry.ancs.constants import (
+    CONTROL_POINT_CHAR,
+    DATA_SOURCE_CHAR,
+    MESSAGES_APP_ID,
+    NOTIFICATION_SOURCE_CHAR,
+    CommandID,
+    EventFlag,
+    EventID,
+)
 from blueferry.ancs.parsers import Notification
 
 
@@ -173,8 +181,10 @@ class _Match:
 
 
 class _ObjectManager:
-    def __init__(self) -> None:
+    def __init__(self, managed=None) -> None:
         self.matches = []
+        self.managed = managed or {}
+        self.sweeps = 0
 
     def connect_to_signal(self, _name, _callback):
         match = _Match()
@@ -182,12 +192,24 @@ class _ObjectManager:
         return match
 
     def GetManagedObjects(self, **_kwargs):
-        return {}
+        self.sweeps += 1
+        return self.managed
 
 
 class _Bus:
     def __init__(self, manager) -> None:
         self.manager = manager
+        self.owner_callback = None
+        self.owner_match = None
+
+    def add_signal_receiver(self, callback, **kwargs):
+        assert kwargs["dbus_interface"] == "org.freedesktop.DBus"
+        assert kwargs["signal_name"] == "NameOwnerChanged"
+        assert kwargs["bus_name"] == "org.freedesktop.DBus"
+        assert kwargs["arg0"] == "org.bluez"
+        self.owner_callback = callback
+        self.owner_match = _Match()
+        return self.owner_match
 
     def get_object(self, _name, path):
         assert path == "/"
@@ -207,7 +229,8 @@ class _CharacteristicBus:
 
 def test_start_is_idempotent(monkeypatch) -> None:
     manager = _ObjectManager()
-    monkeypatch.setattr(client_module, "get_system_bus", lambda: _Bus(manager))
+    bus = _Bus(manager)
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
     monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
     client = AncsClient("/device", lambda _event: None)
 
@@ -217,6 +240,129 @@ def test_start_is_idempotent(monkeypatch) -> None:
     assert len(manager.matches) == 2
     client.stop()
     assert all(match.removed for match in manager.matches)
+    assert bus.owner_match.removed is True
+
+
+def test_bluez_restart_rebinds_manager_and_rescans_cached_ancs_objects(
+    monkeypatch,
+) -> None:
+    paths = {
+        "/device/service0023/char0024": {
+            "org.bluez.GattCharacteristic1": {"UUID": CONTROL_POINT_CHAR},
+        },
+        "/device/service0023/char0027": {
+            "org.bluez.GattCharacteristic1": {"UUID": NOTIFICATION_SOURCE_CHAR},
+        },
+        "/device/service0023/char002a": {
+            "org.bluez.GattCharacteristic1": {"UUID": DATA_SOURCE_CHAR},
+        },
+    }
+    old_manager = _ObjectManager()
+    new_manager = _ObjectManager(paths)
+    bus = _Bus(old_manager)
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    statuses = []
+    client = AncsClient("/device", lambda _event: None, on_status=lambda: statuses.append(True))
+    monkeypatch.setattr(client, "_try_subscribe", lambda: None)
+
+    client.start()
+    client._notify_started = True
+    client._authorized = True
+    characteristic_matches = [_Match(), _Match()]
+    client._characteristic_signal_matches = characteristic_matches
+
+    assert bus.owner_callback is not None
+    bus.owner_callback("org.bluez", ":1.10", "")
+
+    assert client.connected is False
+    assert client._ns_path is None
+    assert client._ds_path is None
+    assert client._cp_path is None
+    assert all(match.removed for match in old_manager.matches)
+    assert all(match.removed for match in characteristic_matches)
+    assert statuses == [True]
+
+    bus.manager = new_manager
+    bus.owner_callback("org.bluez", "", ":1.11")
+
+    assert new_manager.sweeps == 1
+    assert len(new_manager.matches) == 2
+    assert client._ns_path == "/device/service0023/char0027"
+    assert client._ds_path == "/device/service0023/char002a"
+    assert client._cp_path == "/device/service0023/char0024"
+
+
+def test_bluez_restart_retries_when_object_manager_is_not_ready(monkeypatch) -> None:
+    scheduled = []
+
+    class _UnavailableManager(_ObjectManager):
+        def GetManagedObjects(self, **_kwargs):
+            raise RuntimeError("ObjectManager is not ready")
+
+    old_manager = _ObjectManager()
+    bus = _Bus(old_manager)
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 17,
+    )
+    client.start()
+
+    bus.manager = _UnavailableManager()
+    assert bus.owner_callback is not None
+    bus.owner_callback("org.bluez", ":1.10", ":1.11")
+
+    assert scheduled[0][0] == client_module.MANAGER_RETRY_SECONDS
+    assert client._manager_retry_id == 17
+
+    ready_manager = _ObjectManager()
+    bus.manager = ready_manager
+    assert scheduled[0][1]() is False
+
+    assert client._manager_retry_id is None
+    assert ready_manager.sweeps == 1
+    assert len(ready_manager.matches) == 2
+
+
+def test_nested_owner_change_cannot_restore_the_losing_owner_objects(monkeypatch) -> None:
+    stale_paths = {
+        "/device/service-old/char-old": {
+            "org.bluez.GattCharacteristic1": {"UUID": CONTROL_POINT_CHAR},
+        },
+    }
+    current_paths = {
+        "/device/service-new/char-new": {
+            "org.bluez.GattCharacteristic1": {"UUID": CONTROL_POINT_CHAR},
+        },
+    }
+    current_manager = _ObjectManager(current_paths)
+
+    class _ReentrantManager(_ObjectManager):
+        def GetManagedObjects(self, **_kwargs):
+            bus.manager = current_manager
+            assert bus.owner_callback is not None
+            bus.owner_callback("org.bluez", ":1.10", ":1.11")
+            return stale_paths
+
+    initial_manager = _ObjectManager()
+    bus = _Bus(initial_manager)
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    client = AncsClient("/device", lambda _event: None)
+    monkeypatch.setattr(client, "_try_subscribe", lambda: None)
+    client.start()
+
+    bus.manager = _ReentrantManager()
+    assert bus.owner_callback is not None
+    bus.owner_callback("org.bluez", "", ":1.10")
+
+    assert current_manager.sweeps == 1
+    assert client._cp_path == "/device/service-new/char-new"
+    assert client._cp_path != "/device/service-old/char-old"
+    assert len(client._manager_signal_matches) == 2
 
 
 def test_characteristic_removal_discards_all_characteristic_receivers(
@@ -320,6 +466,89 @@ def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
     assert client.connected is True
     assert ns.start_calls == 2
     assert ds.start_calls == 1
+
+
+def test_owner_change_during_start_notify_preserves_new_subscription(
+    monkeypatch,
+) -> None:
+    outer_matches = []
+    replacement_matches = [_Match(), _Match()]
+
+    class _Characteristic:
+        def __init__(self, *, changes_owner=False) -> None:
+            self.changes_owner = changes_owner
+            self.start_calls = 0
+
+        def StartNotify(self, **_kwargs) -> None:
+            self.start_calls += 1
+            if self.changes_owner:
+                client._bluez_owner_generation += 1
+                client._characteristic_signal_matches = replacement_matches
+                client._notify_started = True
+
+    ns = _Characteristic(changes_owner=True)
+    ds = _Characteristic()
+
+    class _SubscribeBus:
+        @staticmethod
+        def add_signal_receiver(*_args, **_kwargs):
+            match = _Match()
+            outer_matches.append(match)
+            return match
+
+        @staticmethod
+        def get_object(_name, path):
+            return {"/device/ns": ns, "/device/ds": ds}[path]
+
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: _SubscribeBus())
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    client = AncsClient("/device", lambda _event: None)
+    client._started = True
+    client._ns_path = "/device/ns"
+    client._ds_path = "/device/ds"
+    client._cp_path = "/device/cp"
+
+    client._try_subscribe()
+
+    assert ns.start_calls == 1
+    assert ds.start_calls == 0
+    assert all(match.removed for match in outer_matches)
+    assert client._characteristic_signal_matches == replacement_matches
+    assert client.subscribed is True
+
+
+def test_owner_change_during_control_point_write_preserves_new_request(
+    monkeypatch,
+) -> None:
+    timeout_calls = []
+    replacement_request = object()
+
+    class _ControlPoint:
+        @staticmethod
+        def WriteValue(_value, _options, **_kwargs) -> None:
+            client._bluez_owner_generation += 1
+            client._request_queue.clear()
+            client._active_request = replacement_request
+            client._request_timeout_id = 91
+
+    bus = _CharacteristicBus({"/device/cp": _ControlPoint()})
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda *args: timeout_calls.append(args) or 92,
+    )
+    client = AncsClient("/device", lambda _event: None)
+    client._started = True
+    client._notify_started = True
+    client._cp_path = "/device/cp"
+
+    client._queue_authorization_probe()
+
+    assert client._active_request is replacement_request
+    assert client._request_timeout_id == 91
+    assert timeout_calls == []
 
 
 def test_control_point_failure_keeps_ancs_unready_and_retries(

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -184,6 +184,24 @@ def test_gui_pairing_guidance_tells_users_to_recheck_iphone_toggles() -> None:
         assert "few times; turn on any new toggles that appear" in client
 
 
+def test_all_clients_offer_bluez_restart_as_ancs_repair_recovery() -> None:
+    clients = (
+        (ROOT / "src/blueferry/ui/status.py").read_text(),
+        _qml_bundle(ROOT / "src/blueferry/qt/qml"),
+        _qml_bundle(ROOT / "data/quickshell"),
+        (ROOT / "src/blueferry/tui.py").read_text(),
+        (ROOT / "src/blueferry/pairing_cli.py").read_text(),
+    )
+
+    for client in clients:
+        assert "ANCS remains unavailable" in client
+        assert "sudo systemctl restart " in client
+        assert "bluetooth.service" in client
+        assert "forget this computer on the iPhone and" in client
+        assert "pair again" in client
+        assert "briefly disconnects all Bluetooth devices" in client
+
+
 def test_all_pairing_clients_expose_compatibility_mode() -> None:
     gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
     qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
@@ -216,6 +234,9 @@ def test_gtk_connection_rows_all_have_status_icons() -> None:
     for profile in ("daemon", "map", "pbap", "ancs"):
         assert f"self._{profile}_icon = Gtk.Image()" in gtk
         assert f"self._{profile}_row.add_suffix(self._{profile}_icon)" in gtk
+    assert "self._ancs_recovery_label = Gtk.Label(" in gtk
+    assert "self._ancs_recovery_label.set_visible(show_ancs_recovery)" in gtk
+    assert "self._apply_status(self._last_status)" in gtk
 
 
 def test_qt_message_bubbles_do_not_use_full_selection_color() -> None:

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -10,6 +10,8 @@ import pytest
 from blueferry import bluez_setup, config, pair_setup
 from blueferry.bluetooth_devices import iphone_candidates
 
+_BLUEZ_DEVICE_SNAPSHOT = pair_setup._bluez_device_snapshot
+
 
 @pytest.fixture(autouse=True)
 def _pairing_reports_in_tmp(tmp_path, monkeypatch):
@@ -24,6 +26,12 @@ def _pairing_reports_in_tmp(tmp_path, monkeypatch):
         lambda _path: {
             "present": False, "paired": False, "bonded": False, "connected": False,
         },
+    )
+    pair_setup._pending_teardown_traces.clear()
+    monkeypatch.setattr(
+        pair_setup,
+        "_bluez_device_snapshot",
+        lambda _path: {"device_present": False},
     )
 
 
@@ -283,6 +291,11 @@ def test_replacing_stale_target_keeps_selected_unpaired_scan_result(monkeypatch)
     pair_setup.prepare_target_replacement(device.mac, device.mac)
 
     assert calls == ["stop", "clear"]
+    assert pair_setup._pending_teardown_traces["hci0"] == {
+        "reason": "same_unpaired_scan_result_retained",
+        "remove_requested": False,
+        "before_clear": {"device_present": False},
+    }
 
 
 def test_replacing_a_different_target_removes_its_bluez_device(monkeypatch):
@@ -321,6 +334,183 @@ def test_find_device_stays_on_the_requested_adapter(monkeypatch):
     assert pair_setup._find_device(leftover.mac, adapter="hci1") == phone
     assert pair_setup._find_device(leftover.mac, adapter="hci2") is None
     assert pair_setup._device(leftover.mac, adapter="hci1") == phone
+
+
+def test_bluez_device_snapshot_captures_bearers_battery_and_ancs(monkeypatch):
+    device = _device(paired=True)
+    objects = {
+        device.device_path: {
+            "org.bluez.Device1": {
+                "Paired": True,
+                "Trusted": True,
+                "Connected": True,
+                "ServicesResolved": False,
+                "UUIDs": [config.ANCS_SOLICIT_UUID, "0000180f-0000-1000-8000-00805f9b34fb"],
+            },
+            "org.bluez.Bearer.BREDR1": {"Connected": True},
+            "org.bluez.Bearer.LE1": {
+                "Paired": True, "Bonded": True, "Connected": True,
+            },
+        },
+        f"{device.device_path}/service0010": {
+            "org.bluez.GattService1": {"UUID": config.ANCS_SOLICIT_UUID},
+        },
+        f"{device.device_path}/service0010/char0011": {
+            "org.bluez.GattCharacteristic1": {
+                "UUID": "69d1d8f3-45e1-49a8-9821-9bbdfdaad9d9",
+            },
+        },
+        f"{device.device_path}/battery": {
+            "org.bluez.Battery1": {"Percentage": 75},
+        },
+        "/org/bluez/hci0/dev_FF_FF_FF_FF_FF_FF": {
+            "org.bluez.Device1": {"Paired": False},
+        },
+    }
+
+    class Manager:
+        @staticmethod
+        def GetManagedObjects(*, timeout):
+            assert timeout == pair_setup.BLUEZ_SNAPSHOT_TIMEOUT_SECONDS
+            return objects
+
+    monkeypatch.setattr(pair_setup, "_object_manager", lambda: Manager())
+
+    snapshot = _BLUEZ_DEVICE_SNAPSHOT(device.device_path)
+
+    assert snapshot["object_present"] is True
+    assert snapshot["device"]["ancs_uuid"] is True
+    assert snapshot["bearers"]["bredr"] == {
+        "present": True, "connected": True,
+    }
+    assert snapshot["bearers"]["le"] == {
+        "present": True, "paired": True, "bonded": True, "connected": True,
+    }
+    assert snapshot["battery_objects"] == 1
+    assert snapshot["gatt"]["services"] == 1
+    assert snapshot["gatt"]["characteristics"] == 1
+    assert snapshot["gatt"]["ancs_service"] is True
+    assert snapshot["gatt"]["ancs_characteristics"] == [
+        "69d1d8f3-45e1-49a8-9821-9bbdfdaad9d9",
+    ]
+
+
+def test_forget_records_bluez_state_before_and_after_remove(monkeypatch):
+    device = _device(paired=True)
+    snapshots = iter([
+        {"device_present": True, "battery_objects": 1},
+        {"device_present": False, "battery_objects": 0},
+    ])
+
+    class Bus:
+        @staticmethod
+        def get_object(_service, _path):
+            return object()
+
+    class Adapter:
+        @staticmethod
+        def RemoveDevice(_path, *, timeout):
+            assert timeout == 30.0
+
+    monkeypatch.setattr(pair_setup, "_find_device", lambda _mac, **_kwargs: device)
+    monkeypatch.setattr(pair_setup, "_stop_user_service", lambda: None)
+    monkeypatch.setattr(pair_setup, "clear_local_target", lambda: None)
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Adapter())
+    monkeypatch.setattr(pair_setup, "_bluez_device_snapshot", lambda _path: next(snapshots))
+
+    pair_setup.forget_device(device.mac, adapter="hci0")
+
+    trace = pair_setup._pending_teardown_traces["hci0"]
+    assert trace["reason"] == "forget_device"
+    assert trace["remove_requested"] is True
+    assert trace["remove_result"] == "replied"
+    assert trace["before_remove"] == {"device_present": True, "battery_objects": 1}
+    assert trace["after_remove_reply"] == {
+        "device_present": False, "battery_objects": 0,
+    }
+    assert trace["remove_elapsed_s"] >= 0
+
+
+def test_bluez_trace_records_only_state_transitions(monkeypatch):
+    states = iter([
+        {"device_present": True, "device": {"ancs_uuid": False}},
+        {"device_present": True, "device": {"ancs_uuid": False}},
+        {"device_present": True, "device": {"ancs_uuid": True}},
+    ])
+    monkeypatch.setattr(pair_setup, "_bluez_device_snapshot", lambda _path: next(states))
+    monkeypatch.setattr(pair_setup.time, "monotonic", lambda: 12.5)
+    attempt = {"_t0": 10.0}
+
+    pair_setup._record_bluez_state(attempt, "/device", "waiting")
+    pair_setup._record_bluez_state(attempt, "/device", "waiting")
+    pair_setup._record_bluez_state(attempt, "/device", "waiting")
+
+    assert attempt["bluez_trace"] == [
+        {
+            "t": 2.5,
+            "phase": "waiting",
+            "state": {"device_present": True, "device": {"ancs_uuid": False}},
+        },
+        {
+            "t": 2.5,
+            "phase": "waiting",
+            "state": {"device_present": True, "device": {"ancs_uuid": True}},
+        },
+    ]
+
+
+def test_transport_wait_samples_bluez_at_a_bounded_rate(monkeypatch):
+    from blueferry.models import BackendStatus
+
+    now = [0.0]
+    statuses = [
+        BackendStatus(map=True, pbap=True, ancs=False)
+        for _index in range(5)
+    ] + [BackendStatus(map=True, pbap=True, ancs=True)]
+    snapshots = []
+
+    class FakeClient:
+        @staticmethod
+        def status():
+            return statuses.pop(0)
+
+    monkeypatch.setattr("blueferry.client.BackendClient", FakeClient)
+    monkeypatch.setattr(pair_setup.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(pair_setup.time, "sleep", lambda seconds: now.__setitem__(0, now[0] + seconds))
+    monkeypatch.setattr(
+        pair_setup,
+        "_record_bluez_state",
+        lambda _attempt, _path, _phase: snapshots.append(now[0]),
+    )
+
+    result = pair_setup._wait_for_daemon_transports(
+        timeout=10,
+        attempt={},
+        device_path="/device",
+    )
+
+    assert result == (True, True, True)
+    assert snapshots == [0.0, 2.0]
+
+
+def test_teardown_trace_survives_quickshell_helper_processes(monkeypatch):
+    now = iter([100.0, 105.25])
+    monkeypatch.setattr(pair_setup.time, "time", lambda: next(now))
+    trace = {
+        "reason": "forget_device",
+        "after_remove_reply": {"device_present": False},
+    }
+
+    pair_setup._save_pending_teardown("hci0", trace)
+    pair_setup._pending_teardown_traces.clear()
+    restored = pair_setup._take_pending_teardown("hci0")
+
+    assert restored == {
+        **trace,
+        "capture_age_s": 5.25,
+    }
+    assert not pair_setup._teardown_trace_path().exists()
 
 
 def test_forget_stops_backend_removes_bond_and_clears_target(monkeypatch):

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 from blueferry import pairing_cli
 from blueferry.bluetooth_devices import PairedDevice
-from blueferry.pairing_cli import _print_iphone_steps
+from blueferry.pairing_cli import _print_ancs_repair_hint, _print_iphone_steps
 from blueferry.setup_client import DISCOVERY_SECONDS
 from blueferry.setup_verification import CONTACTS
 
@@ -17,6 +17,16 @@ def test_verified_cli_setup_omits_the_iphone_section(capsys) -> None:
     )
 
     assert capsys.readouterr().out == ""
+
+
+def test_cli_ancs_repair_hint_restarts_bluez_before_repairing(capsys) -> None:
+    _print_ancs_repair_hint()
+
+    output = capsys.readouterr().out
+    assert "If ANCS remains unavailable after setup" in output
+    assert "sudo systemctl restart bluetooth.service" in output
+    assert "forget this computer on the iPhone and pair again" in output
+    assert "briefly disconnects all Bluetooth devices" in output
 
 
 def test_cli_setup_always_prints_required_bluetooth_toggles(capsys) -> None:
@@ -275,3 +285,4 @@ def test_cli_wizard_points_at_pairing_issue_when_ancs_stays_down(
     output = capsys.readouterr().out
     assert "blueferry pairing-issue" in output
     assert "GitHub issue" not in output
+    assert "sudo systemctl restart bluetooth.service" in output

--- a/tests/test_quirks_report.py
+++ b/tests/test_quirks_report.py
@@ -11,6 +11,16 @@ from blueferry import bluez_setup, config, pair_setup, quirks_report
 from blueferry.quirks_report import MAX_REPORTS
 
 
+@pytest.fixture(autouse=True)
+def _pairing_diagnostics(monkeypatch):
+    pair_setup._pending_teardown_traces.clear()
+    monkeypatch.setattr(
+        pair_setup,
+        "_bluez_device_snapshot",
+        lambda _path: {"device_present": False},
+    )
+
+
 @pytest.fixture
 def report_dir(tmp_path, monkeypatch):
     state = tmp_path / "blueferry-state"
@@ -398,6 +408,13 @@ def test_complete_pairing_writes_a_scrubbed_success_report(
             "present": True, "paired": True, "bonded": True, "connected": True,
         },
     )
+    pair_setup._pending_teardown_traces["hci0"] = {
+        "reason": "forget_device",
+        "remove_requested": True,
+        "remove_result": "replied",
+        "before_remove": {"device_present": True, "battery_objects": 1},
+        "after_remove_reply": {"device_present": False, "battery_objects": 0},
+    }
 
     result = pair_setup.complete_pairing(device.mac)
     payload = Path(result["quirks_report"]).read_text()
@@ -426,6 +443,14 @@ def test_complete_pairing_writes_a_scrubbed_success_report(
     assert "id" not in parsed["phone"]
     assert parsed["phone"]["likely_iphone"] is True
     assert parsed["controller"]["name"] == "hci0"
+    assert parsed["previous_teardown"] == {
+        "reason": "forget_device",
+        "remove_requested": True,
+        "remove_result": "replied",
+        "before_remove": {"device_present": True, "battery_objects": 1},
+        "after_remove_reply": {"device_present": False, "battery_objects": 0},
+        "before_new_pairing": {"device_present": False},
+    }
     assert parsed["pairing_policy"] == {
         "ancs_capable": True,
         "ancs_enabled": True,

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -288,6 +288,28 @@ def test_textual_app_renders_status_threads_and_messages() -> None:
     _run_headless(scenario())
 
 
+def test_textual_warns_about_bluez_restart_when_only_ancs_is_missing(
+    monkeypatch,
+) -> None:
+    class MissingAncsBackend(_Backend):
+        @staticmethod
+        def status() -> BackendStatus:
+            return BackendStatus(daemon=True, map=True, pbap=True, ancs=False)
+
+    async def scenario() -> None:
+        app = BlueFerryApp(TuiState(MissingAncsBackend()), monitor_factory=lambda: None)
+
+        async with app.run_test(size=(70, 36)) as pilot:
+            await _wait_for_threads(app, pilot, 2)
+            notice = app.query_one("#notice-bar", Static)
+            assert "sudo systemctl restart bluetooth.service" in notice.render().plain
+            assert notice.has_class("warn")
+            assert notice.region.height >= 3
+
+    monkeypatch.setattr(tui_module.config, "ANCS_ENABLED", True)
+    _run_headless(scenario())
+
+
 def test_unchanged_poll_does_not_rebuild_the_terminal_view() -> None:
     async def scenario() -> None:
         state = TuiState(_Backend())

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -173,7 +173,7 @@ def test_message_sender_metadata_is_sanitized() -> None:
         async with app.run_test(size=(120, 36)) as pilot:
             await _wait_for_threads(app, pilot, 2)
             app.action_next_thread()
-            await pilot.pause(0.1)
+            await _wait_for_conversation_title(app, pilot, "Friends  ·  Group")
             meta = app.query_one(MessageRow).query_one(".message-meta", Static)
             assert meta.render().plain.startswith("Beau�[31m� forged  ·  ")
 
@@ -255,6 +255,17 @@ async def _wait_for_threads(app: BlueFerryApp, pilot, count: int) -> None:
     assert len(app.query(ConversationItem)) == count
 
 
+async def _wait_for_conversation_title(
+    app: BlueFerryApp, pilot, expected: str,
+) -> None:
+    title = app.query_one("#conversation-title", Static)
+    for _attempt in range(30):
+        if title.render().plain == expected:
+            return
+        await pilot.pause(0.05)
+    assert title.render().plain == expected
+
+
 def _run_headless(coroutine: Coroutine[Any, Any, None]) -> None:
     # Python 3.14's asyncio.Runner waits unnecessarily for Textual's already
     # drained async generators. A directly-owned loop is deterministic here;
@@ -279,7 +290,7 @@ def test_textual_app_renders_status_threads_and_messages() -> None:
             assert len(app.query(MessageRow)) == 1
 
             app.action_next_thread()
-            await pilot.pause(0.1)
+            await _wait_for_conversation_title(app, pilot, "Friends  ·  Group")
             assert state.selected_key == "group"
             assert app.query_one("#conversation-title").render().plain == "Friends  ·  Group"
             meta = app.query_one(MessageRow).query_one(".message-meta", Static)


### PR DESCRIPTION
## Summary

- record bounded, scrubbed BlueZ device and teardown transitions in pairing issue reports
- detect org.bluez owner replacement, rebuild ObjectManager discovery, and automatically resubscribe ANCS
- guard blocking discovery, StartNotify, and Control Point writes against nested owner-change races
- show conditional bluetooth.service recovery guidance in GTK, Qt, Quickshell, TUI, and pair-setup
- bound diagnostic snapshots with a five-second D-Bus timeout and two-second polling interval

## Root cause

Restarting bluetoothd removes and recreates the cached GATT object tree. BlueFerry retained its old ANCS discovery and subscription state and could miss the replacement objects if they appeared during D-Bus name-owner retargeting or another blocking GATT call.

The ANCS client now watches the stable bus daemon for org.bluez owner changes, discards work from older owner generations, reconnects manager signals before sweeping current objects, and retries while ObjectManager is unavailable.

## Validation

- 593 tests passed: 591 standard tests plus 2 isolated QML presenter tests
- Ruff passed
- QML lint passed
- git diff checks passed
- confirmed on hardware: ANCS reconnects after restarting bluetooth.service without restarting the BlueFerry daemon