### PR TITLE
Release BlueFerry 0.7.0

### DIFF
--- a/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
@@ -40,6 +40,13 @@
   </developer>
 
   <releases>
+    <release version="0.7.0" date="2026-08-14">
+      <description>
+        <p>Adds native Linux packages, compatibility and explicit pairing
+        modes, build-aware daemon restarts, and ANCS recovery after BlueZ
+        restarts.</p>
+      </description>
+    </release>
     <release version="0.6.3" date="2026-08-13">
       <description>
         <p>Lets you pick a Bluetooth controller when more than one is present

--- a/data/io.weirdware.BlueFerry.Qt.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Qt.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.7.0" date="2026-08-14"><description><p>Adds native Linux packages, compatibility and explicit pairing modes, build-aware daemon restarts, and ANCS recovery after BlueZ restarts.</p></description></release>
     <release version="0.6.3" date="2026-08-13"><description><p>Lets you pick a Bluetooth controller when more than one is present and keeps pairing, scanning, and forget on that radio.</p></description></release>
     <release version="0.6.2" date="2026-08-10"><description><p>Improves interactive Bluetooth pairing, diagnostics, and forgotten-device handling.</p></description></release>
     <release version="0.6.1" date="2026-08-10"><description><p>Adds KDE tray integration and notification deep links.</p></description></release>

--- a/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.7.0" date="2026-08-14"><description><p>Adds native Linux packages, compatibility and explicit pairing modes, build-aware daemon restarts, and ANCS recovery after BlueZ restarts.</p></description></release>
     <release version="0.6.3" date="2026-08-13"><description><p>Lets you pick a Bluetooth controller when more than one is present and keeps pairing, scanning, and forget on that radio.</p></description></release>
     <release version="0.6.2" date="2026-08-10"><description><p>Improves interactive Bluetooth pairing, diagnostics, and forgotten-device handling.</p></description></release>
     <release version="0.6.1" date="2026-08-10"><description><p>Adds notification deep links and backend upgrade handling.</p></description></release>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   blueferry-qt
   blueferry-quickshell
 )
-pkgver=0.6.3
+pkgver=0.7.0
 pkgrel=1
 pkgdesc='BlueFerry Bluetooth bridge from iPhone to Linux'
 arch=('any')

--- a/packaging/deb/changelog
+++ b/packaging/deb/changelog
@@ -1,6 +1,15 @@
+blueferry (0.7.0-1) unstable; urgency=medium
+
+  * Add native packages for supported Arch, Debian, and Fedora systems.
+  * Add compatibility and explicit iPhone pairing modes.
+  * Restart stale backend builds and recover ANCS after BlueZ restarts.
+  * Ship the terminal client as part of every backend package.
+
+ -- BlueFerry Contributors <blueferry@weirdware.io>  Fri, 14 Aug 2026 00:00:00 -0400
+
 blueferry (0.6.3-1) unstable; urgency=medium
 
   * Initial native package scaffold.
   * Support MAP and PBAP without changing the system Bluetooth service.
 
- -- BlueFerry Contributors <noreply@weirdware.io>  Thu, 13 Aug 2026 00:00:00 -0400
+ -- BlueFerry Contributors <blueferry@weirdware.io>  Thu, 13 Aug 2026 00:00:00 -0400

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -1,7 +1,7 @@
 Source: blueferry
 Section: utils
 Priority: optional
-Maintainer: BlueFerry Contributors <noreply@weirdware.io>
+Maintainer: BlueFerry Contributors <blueferry@weirdware.io>
 Build-Depends:
  debhelper-compat (= 13),
  dh-sequence-python3,

--- a/packaging/rpm/blueferry.spec
+++ b/packaging/rpm/blueferry.spec
@@ -1,5 +1,5 @@
 Name:           blueferry-backend
-Version:        0.6.3
+Version:        0.7.0
 Release:        1%{?dist}
 Summary:        iPhone Bluetooth bridge backend, daemon, and CLI
 License:        GPL-2.0-only AND MIT AND BSD-2-Clause AND PSF-2.0
@@ -188,5 +188,11 @@ fi
 %{_metainfodir}/io.weirdware.BlueFerry.Qt.metainfo.xml
 
 %changelog
-* Thu Aug 13 2026 BlueFerry Contributors <noreply@weirdware.io> - 0.6.3-1
+* Fri Aug 14 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.0-1
+- Add native packages for supported Arch, Debian, and Fedora systems.
+- Add compatibility and explicit iPhone pairing modes.
+- Restart stale backend builds and recover ANCS after BlueZ restarts.
+- Ship the terminal client as part of every backend package.
+
+* Thu Aug 13 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.6.3-1
 - Initial Fedora package scaffold with private Textual runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueferry"
-version = "0.6.3"
+version = "0.7.0"
 description = "BlueFerry brings iPhone messages, notifications, and contacts to Linux"
 authors = [
   {name = "Erik Bourget", email = "erik@ebourget.net"},

--- a/src/blueferry/__init__.py
+++ b/src/blueferry/__init__.py
@@ -1,3 +1,3 @@
 """BlueFerry — Bluetooth bridge from a paired iPhone to Linux desktop."""
 
-__version__ = "0.6.3"
+__version__ = "0.7.0"


### PR DESCRIPTION
## Summary

- bump Python, Arch, Debian, and RPM release metadata to 0.7.0
- add 0.7.0 AppStream release entries for GTK, Qt, and Quickshell
- document native packaging, pairing modes, build-aware lifecycle, and ANCS recovery in DEB/RPM changelogs
- update the native package maintainer address to blueferry@weirdware.io

## Local verification

- Ruff, Bandit, and mypy pass
- 593 tests pass, 3 skip in the direct suite
- AppStream validation passes for all three clients
- Qt and Quickshell QML lint passes
- complete Arch 0.7.0-1 build passes its package checks: 594 tests plus 2 isolated QML presenter tests
- all four Arch package artifacts produced; backend contents include the TUI and build identity files

The native-package workflow will build the DEB/RPM artifacts and install the exact artifacts across the full supported target matrix before this is tagged.