### PR TITLE
Fix tagged release publication

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -309,6 +309,7 @@ jobs:
       - name: Create or update the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           if ! gh release view "$GITHUB_REF_NAME"; then
             gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag

--- a/tests/test_native_packaging.py
+++ b/tests/test_native_packaging.py
@@ -171,3 +171,4 @@ def test_package_workflow_installs_identical_artifacts_on_targets() -> None:
     assert workflow.count(
         "systemd-analyze verify --man=no bluetooth.service"
     ) == 3
+    assert "GH_REPO: ${{ github.repository }}" in workflow


### PR DESCRIPTION
## Summary

- provide `GH_REPO` to the checkout-free tagged-release job
- let GitHub CLI create and upload release assets without requiring local Git metadata
- add a native-packaging regression assertion for the repository context

## Testing

- `PYTHONPATH=src pytest -q tests/test_native_packaging.py` — 9 passed
- `git diff --check`

This fixes the publication-only failure observed after every v0.7.0 package build and target install passed. The v0.7.0 release itself was published with those exact tested workflow artifacts using the same explicit repository context.