### PR TITLE
Make Bluetooth capability checks advisory

### DIFF
--- a/data/quickshell/OnboardingState.qml
+++ b/data/quickshell/OnboardingState.qml
@@ -1,14 +1,12 @@
 import QtQuick
 
 QtObject {
-  required property bool hardwareSupported
   required property bool notificationsSupported
   required property bool bluezActive
   required property bool configured
   required property var backendStatus
 
   readonly property string stage: {
-    if (!hardwareSupported) return "incompatible"
     if (notificationsSupported && !bluezActive) return "activate-bluetooth"
     if (!configured) return "select-device"
     if (backendStatus.map && backendStatus.pbap) {

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -25,10 +25,9 @@ ShellRoot {
   property string pairingStatus: "Step 1: scan for the iPhone. Scanning does not pair it."
   property bool bluezActive: false
   property bool hardwareSupported: false
-  property bool messagesSupported: false
   property bool notificationsSupported: false
+  property bool compatibilityLoaded: false
   property bool ancsEnabled: true
-  property bool pairingReady: false
   property bool compatibilityModeOverride: false
   property bool explicitPairingOverride: false
   property bool configured: false
@@ -57,7 +56,6 @@ ShellRoot {
   Theme { id: theme }
   OnboardingState {
     id: onboarding
-    hardwareSupported: root.hardwareSupported
     notificationsSupported: root.notificationsSupported
                             && root.ancsEnabled
                             && !root.compatibilityModeOverride
@@ -177,6 +175,7 @@ ShellRoot {
 
   function loadCompatibility(adapter) {
     if (compatibilityProcess.running) return
+    compatibilityLoaded = false
     compatibilityProcess.command = adapter
       ? ["/usr/bin/blueferry", "pairing-compatibility-json", "--adapter", adapter]
       : ["/usr/bin/blueferry", "pairing-compatibility-json"]
@@ -229,9 +228,8 @@ ShellRoot {
 
   function markCompatibilityUnavailable(message) {
     hardwareSupported = false
-    messagesSupported = false
     notificationsSupported = false
-    pairingReady = false
+    compatibilityLoaded = true
     bluezActive = false
     adapterName = ""
     pairingStatus = message
@@ -321,9 +319,8 @@ ShellRoot {
         try {
           var parsed = JSON.parse(text)
           root.hardwareSupported = parsed.hardware_supported === true
-          root.messagesSupported = parsed.messages_supported === true
           root.notificationsSupported = parsed.notifications_supported === true
-          root.pairingReady = parsed.pairing_ready === true
+          root.compatibilityLoaded = true
           root.bluezActive = parsed.bearer_api_active === true
           root.adapterName = parsed.adapter || ""
           root.adapters = Array.isArray(parsed.adapters) ? parsed.adapters : []
@@ -335,7 +332,10 @@ ShellRoot {
               }
             }
           }
-          if (!root.hardwareSupported) root.pairingStatus = parsed.issue || "Bluetooth controller is incompatible."
+          if (!root.hardwareSupported) {
+            root.pairingStatus = (parsed.issue || "Bluetooth controller capabilities could not be verified.")
+              + " Pairing is still available in compatibility mode."
+          }
           var scan = root.scanAfterCompatibility
           root.scanAfterCompatibility = false
           root.loadPairingDevices(scan)
@@ -1313,8 +1313,10 @@ ShellRoot {
             id: compatibilityMode
             visible: !root.configured
             text: "Compatibility pairing for iOS 18 or earlier"
-            checked: !root.notificationsSupported || root.compatibilityModeOverride
-            enabled: root.notificationsSupported && !pairProcess.running
+            checked: root.compatibilityLoaded
+                     && (!root.notificationsSupported || root.compatibilityModeOverride)
+            enabled: root.compatibilityLoaded && root.notificationsSupported
+                     && !pairProcess.running
             onClicked: root.compatibilityModeOverride = checked
           }
           FerryCheckBox {
@@ -1337,8 +1339,7 @@ ShellRoot {
               : root.selectedPairingDevice() && root.selectedPairingDevice().paired
                 ? "Use existing pairing" : "2. Pair Selected iPhone"
             enabled: root.selectedPairingDevice() !== null
-                     && (compatibilityMode.checked
-                         ? root.messagesSupported : root.pairingReady)
+                     && root.compatibilityLoaded
                      && !deviceProcess.running && !pairProcess.running
             onClicked: {
               var device = root.selectedPairingDevice()

--- a/src/blueferry/bluetooth_capabilities.py
+++ b/src/blueferry/bluetooth_capabilities.py
@@ -471,9 +471,9 @@ def _profile_fields(
         "notifications_supported": notifications_supported,
         "bearer_api_supported": bearer_supported,
         "bearer_api_active": bearer_active,
-        "pairing_ready": messages_supported and (
-            bearer_active or not notifications_supported
-        ),
+        # Capability discovery selects a mode; the pairing transaction decides
+        # whether the adapter actually works.
+        "pairing_ready": True,
         "issue": issue,
         "supported_settings": sorted(supported),
         "current_settings": sorted(current),

--- a/src/blueferry/onboarding.py
+++ b/src/blueferry/onboarding.py
@@ -11,7 +11,6 @@ from blueferry.setup_verification import remaining_iphone_setup_tasks
 
 class OnboardingStage(str, Enum):
     CHECKING = "checking"
-    INCOMPATIBLE = "incompatible"
     ACTIVATE_BLUETOOTH = "activate-bluetooth"
     SELECT_DEVICE = "select-device"
     STARTING = "starting"
@@ -34,8 +33,6 @@ def derive_stage(
     status_values = status.to_dict() if isinstance(status, BackendStatus) else status
     if not setup_loaded:
         return OnboardingStage.CHECKING
-    if not compatibility.get("hardware_supported"):
-        return OnboardingStage.INCOMPATIBLE
     if compatibility.get("notifications_supported") and not compatibility.get("bearer_api_active"):
         return OnboardingStage.ACTIVATE_BLUETOOTH
     if not configured:

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -1310,7 +1310,12 @@ def _execute_pairing(
     attempt["controller"] = _controller_snapshot(adapter, compatibility)
     quirks_report.mark(attempt, "compatibility_ready")
     if not compatibility["hardware_supported"]:
-        raise PairingError(compatibility["issue"] or "Bluetooth controller is incompatible")
+        issue = compatibility["issue"] or "Controller capabilities could not be verified"
+        log.warning(
+            "controller capability advisory: %s; continuing with pairing",
+            issue,
+        )
+        quirks_report.mark(attempt, "compatibility_advisory", issue=issue)
     policy = resolve_pairing_policy(
         compatibility,
         force_compatibility=compatibility_mode,

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -121,26 +121,34 @@ def run_wizard(
     if not compatibility.hardware_supported:
         typer.echo(
             typer.style(
-                compatibility.issue or "Bluetooth controller is incompatible.",
-                fg=typer.colors.RED,
-            )
-        )
-        return 1
-    typer.echo(
-        typer.style(
-            "✓ Controller supports Messages and Contacts over BR/EDR",
-            fg=typer.colors.GREEN,
-        )
-    )
-    if not compatibility.notifications_supported:
-        typer.echo(
-            typer.style(
-                "⚠ This controller cannot provide per-app iPhone notifications",
+                "⚠ "
+                + (
+                    compatibility.issue
+                    or "Bluetooth controller capabilities could not be verified."
+                )
+                + " Pairing will still be attempted in compatibility mode.",
                 fg=typer.colors.YELLOW,
             )
         )
+    else:
+        typer.echo(
+            typer.style(
+                "✓ Controller supports Messages and Contacts over BR/EDR",
+                fg=typer.colors.GREEN,
+            )
+        )
+    if not compatibility.notifications_supported:
+        typer.echo(
+            typer.style(
+                "⚠ Per-app iPhone notifications are unavailable; pairing will use "
+                "Messages and Contacts compatibility mode",
+                fg=typer.colors.YELLOW,
+            )
+        )
+    automatic_compatibility = not compatibility.notifications_supported
+    effective_compatibility_mode = compatibility_mode or automatic_compatibility
     if (
-        not compatibility_mode
+        not effective_compatibility_mode
         and compatibility.notifications_supported
         and not compatibility.bearer_api_active
     ):
@@ -220,6 +228,11 @@ def run_wizard(
             "Compatibility mode: BlueFerry will set up Messages and Contacts "
             "without connecting ANCS."
         )
+    elif automatic_compatibility:
+        typer.echo(
+            "Automatic compatibility mode: ANCS support was not detected; "
+            "BlueFerry will still try Messages and Contacts."
+        )
     if explicit_pairing:
         typer.echo("Explicit pairing: skipping the initial Device1.Connect attempt.")
     try:
@@ -228,7 +241,7 @@ def run_wizard(
             adapter=compatibility.adapter,
             confirmation=_confirm_pairing,
             display=_display_pairing_code,
-            compatibility_mode=compatibility_mode,
+            compatibility_mode=effective_compatibility_mode,
             explicit_pairing=explicit_pairing,
         )
     except PairingError as error:
@@ -246,7 +259,7 @@ def run_wizard(
     ancs_enabled = getattr(
         result,
         "ancs_enabled",
-        compatibility.notifications_supported and not compatibility_mode,
+        compatibility.notifications_supported and not effective_compatibility_mode,
     )
     remaining = remaining_iphone_setup_tasks(
         verified,
@@ -337,8 +350,8 @@ def _print_iphone_steps(
     if not notifications_supported:
         typer.echo(
             typer.style(
-                "\n⚠ This controller supports Messages and Contacts, but not "
-                "per-app iPhone notifications.",
+                "\n⚠ Per-app iPhone notifications were not enabled for this "
+                "pairing.",
                 fg=typer.colors.YELLOW,
             )
         )

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -137,6 +137,26 @@ class BridgeController(QObject):
     def compatibility(self):
         return self._compatibility
 
+    @Property(bool, notify=compatibilityChanged)
+    def compatibilityLoaded(self) -> bool:
+        return bool(self._compatibility)
+
+    def _set_compatibility_unavailable(self, adapter: str | None, message: str) -> None:
+        self._compatibility = {
+            "adapter": adapter or "",
+            "available": False,
+            "hardware_supported": False,
+            "messages_supported": False,
+            "notifications_supported": False,
+            "bearer_api_active": False,
+            "pairing_ready": True,
+            "issue": message,
+            "adapters": [],
+        }
+        self.compatibilityChanged.emit()
+        self._update_onboarding_stage()
+        self._operation_failed(message)
+
     def _onboarding_compatibility(self) -> dict:
         compatibility = dict(self._compatibility)
         if self._target_saved and not self._ancs_enabled:
@@ -327,6 +347,8 @@ class BridgeController(QObject):
 
     def _reload_setup_state(self, *, scan_after: bool = False) -> None:
         selected = str(self._compatibility.get("adapter", "")).strip() or None
+        self._compatibility = {}
+        self.compatibilityChanged.emit()
 
         def operation():
             return self._setup.compatibility(selected), self._setup.configuration()
@@ -352,7 +374,12 @@ class BridgeController(QObject):
             elif self._devices:
                 self.loadDevices(False)
 
-        self._run(operation, completed, busy=False)
+        def failed(message: str) -> None:
+            self._set_compatibility_unavailable(selected, message)
+            if scan_after:
+                self.loadDevices(True)
+
+        self._run(operation, completed, failed, busy=False)
 
     @Slot(str)
     def selectAdapter(self, name: str) -> None:
@@ -362,6 +389,8 @@ class BridgeController(QObject):
         if self._devices:
             self._devices = []
             self.devicesChanged.emit()
+        self._compatibility = {}
+        self.compatibilityChanged.emit()
 
         def completed(value: object) -> None:
             compatibility = value
@@ -372,7 +401,11 @@ class BridgeController(QObject):
             self._update_onboarding_stage()
             self.loadDevices(False)
 
-        self._run(lambda: self._setup.compatibility(selected), completed)
+        def failed(message: str) -> None:
+            self._set_compatibility_unavailable(selected, message)
+            self.loadDevices(False)
+
+        self._run(lambda: self._setup.compatibility(selected), completed, failed)
 
     def _snapshot(self) -> dict:
         def safely(operation, fallback):

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -985,21 +985,25 @@ Kirigami.ApplicationWindow {
 
                     Controls.Label {
                         Kirigami.FormData.label: qsTr("Hardware:")
-                        text: root.bridge.compatibility.hardware_supported
-                            ? qsTr("Compatible")
-                            : qsTr("Unsupported")
+                        text: !root.bridge.compatibilityLoaded
+                            ? qsTr("Checking…")
+                            : root.bridge.compatibility.available !== true
+                            ? qsTr("Could Not Verify — Pairing Still Available")
+                            : root.bridge.compatibility.hardware_supported
+                                ? qsTr("Compatible")
+                                : qsTr("Compatibility Warning — Pairing Still Available")
                     }
 
                     Controls.Label {
                         Kirigami.FormData.label: qsTr("Messages and Contacts:")
                         text: root.bridge.compatibility.messages_supported
-                            ? qsTr("Supported") : qsTr("Unsupported")
+                            ? qsTr("Supported") : qsTr("Not Detected")
                     }
 
                     Controls.Label {
                         Kirigami.FormData.label: qsTr("iPhone Notifications:")
                         text: root.bridge.compatibility.notifications_supported
-                            ? qsTr("Supported") : qsTr("Unsupported")
+                            ? qsTr("Supported") : qsTr("Unavailable")
                     }
 
                     Controls.Label {
@@ -1069,9 +1073,11 @@ Kirigami.ApplicationWindow {
                     Layout.fillWidth: true
                     visible: !root.bridge.configured
                     text: qsTr("Compatibility pairing for iOS 18 or earlier")
-                    checked: root.bridge.compatibility.notifications_supported !== true
-                        || iphonePage.compatibilityModeOverride
-                    enabled: root.bridge.compatibility.notifications_supported === true
+                    checked: root.bridge.compatibilityLoaded
+                        && (root.bridge.compatibility.notifications_supported !== true
+                            || iphonePage.compatibilityModeOverride)
+                    enabled: root.bridge.compatibilityLoaded
+                        && root.bridge.compatibility.notifications_supported === true
                         && !root.bridge.busy
                     onClicked: iphonePage.compatibilityModeOverride = checked
                     Accessible.description: qsTr("Sets up Messages and Contacts without connecting ANCS.")
@@ -1093,9 +1099,7 @@ Kirigami.ApplicationWindow {
                             ? qsTr("Use Existing Pairing") : qsTr("2. Pair Selected iPhone")
                         icon.name: "network-connect"
                         enabled: iphonePage.device !== null
-                            && (compatibilityMode.checked
-                                ? root.bridge.compatibility.messages_supported
-                                : root.bridge.compatibility.pairing_ready)
+                            && root.bridge.compatibilityLoaded
                             && !root.bridge.busy
                         onClicked: {
                             if (!iphonePage.device.paired && root.bridge.targetSaved) {

--- a/src/blueferry/qt/qml/OnboardingSummary.qml
+++ b/src/blueferry/qt/qml/OnboardingSummary.qml
@@ -10,11 +10,9 @@ Kirigami.InlineMessage {
 
     visible: true
     text: htmlEscape(titleForStage()) + "\n" + htmlEscape(detailForStage())
-    type: stage === "incompatible"
-        ? Kirigami.MessageType.Warning
-        : stage === "ready" || stage === "ready-without-ancs"
-            ? Kirigami.MessageType.Positive
-            : Kirigami.MessageType.Information
+    type: stage === "ready" || stage === "ready-without-ancs"
+        ? Kirigami.MessageType.Positive
+        : Kirigami.MessageType.Information
 
     function htmlEscape(value) {
         return String(value || "")
@@ -49,7 +47,6 @@ Kirigami.InlineMessage {
     function titleForStage() {
         const titles = {
             "checking": qsTr("Checking Bluetooth Support"),
-            "incompatible": qsTr("Bluetooth Controller Is Not Compatible"),
             "activate-bluetooth": qsTr("Activate Bluetooth Support"),
             "select-device": qsTr("Pair an iPhone"),
             "starting": qsTr("Starting the Background Service"),
@@ -63,7 +60,6 @@ Kirigami.InlineMessage {
     function detailForStage() {
         const details = {
             "checking": qsTr("Inspecting the selected Bluetooth controller without changing it."),
-            "incompatible": compatibility.issue || qsTr("A controller with BR/EDR and secure pairing is required."),
             "activate-bluetooth": qsTr("The packaged BlueZ bearer support needs one authorized Bluetooth restart."),
             "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. When the pairing request appears on the iPhone, approve it and confirm that the codes match. Pairing may appear idle for up to 15 seconds. After it completes, return to the Bluetooth device list and open this computer's ⓘ page a few times; turn on any new toggles that appear. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."),
             "starting": qsTr("The configured backend is starting. This normally takes a few seconds."),

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -412,15 +412,7 @@ class IPhonePage(Gtk.Box):
         )
         self._explicit_pairing_switch.set_sensitive(not busy)
         selected = self._selected_device()
-        pairing_ready = bool(
-            self._compatibility
-            and (
-                self._compatibility.messages_supported
-                if self._compatibility_switch.get_active()
-                else self._compatibility.pairing_ready
-            )
-        )
-        self._pair_button.set_sensitive(not busy and pairing_ready and bool(selected))
+        self._pair_button.set_sensitive(not busy and bool(selected))
         self._pair_button.set_label(
             _("Use Existing Pairing") if selected and selected.paired else _("Pair Selected iPhone")
         )
@@ -484,8 +476,10 @@ class IPhonePage(Gtk.Box):
         else:
             self._adapter_row.set_visible(False)
             self._hardware_row.set_visible(True)
-            if not compatibility.hardware_supported:
-                hardware = _("Unsupported")
+            if not compatibility.available:
+                hardware = _("Capabilities could not be verified; pairing is still available")
+            elif not compatibility.hardware_supported:
+                hardware = _("Compatibility warning; pairing is still available")
             elif compatibility.notifications_supported:
                 hardware = _("Compatible")
             else:

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -228,6 +228,30 @@ def test_all_pairing_clients_expose_explicit_pairing_mode() -> None:
     assert '"--explicit-pairing"' in quickshell
 
 
+def test_capability_checks_do_not_disable_pairing_buttons() -> None:
+    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
+    qt = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
+    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+
+    assert "self._pair_button.set_sensitive(not busy and bool(selected))" in gtk
+    assert "root.bridge.compatibility.pairing_ready" not in qt
+    assert "root.bridge.compatibility.messages_supported" not in qt.split(
+        'text: iphonePage.device !== null', 1
+    )[1].split("onClicked:", 1)[0]
+    assert "root.bridge.compatibilityLoaded" in qt.split(
+        'text: iphonePage.device !== null', 1
+    )[1].split("onClicked:", 1)[0]
+    assert "root.pairingReady" not in quickshell.split(
+        'text: pairProcess.running ? "Pairing…"', 1
+    )[1].split("onClicked:", 1)[0]
+    assert "root.messagesSupported" not in quickshell.split(
+        'text: pairProcess.running ? "Pairing…"', 1
+    )[1].split("onClicked:", 1)[0]
+    assert "root.compatibilityLoaded" in quickshell.split(
+        'text: pairProcess.running ? "Pairing…"', 1
+    )[1].split("onClicked:", 1)[0]
+
+
 def test_gtk_connection_rows_all_have_status_icons() -> None:
     gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -24,6 +24,22 @@ def test_unconfigured_compatible_install_requests_a_device() -> None:
     )
 
 
+def test_unverified_controller_still_requests_a_device() -> None:
+    assert (
+        derive_stage(
+            setup_loaded=True,
+            configured=False,
+            compatibility={
+                "hardware_supported": False,
+                "notifications_supported": False,
+                "bearer_api_active": False,
+            },
+            status={},
+        )
+        is OnboardingStage.SELECT_DEVICE
+    )
+
+
 def test_optional_ancs_transport_controls_activation_step() -> None:
     inactive = {**COMPATIBLE, "bearer_api_active": False}
     assert (

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -972,7 +972,37 @@ def test_compatibility_explains_missing_classic_transport(monkeypatch):
     status = pair_setup.bluetooth_compatibility("hci0")
 
     assert status["hardware_supported"] is False
+    assert status["pairing_ready"] is True
     assert "BR/EDR" in status["issue"]
+
+
+def test_btmgmt_timeout_is_advisory_and_keeps_pairing_available(monkeypatch):
+    class Manager:
+        @staticmethod
+        def GetManagedObjects():
+            return {"/org/bluez/hci0": {"org.bluez.Adapter1": {}}}
+
+    def controller_info(command, **_kwargs):
+        if command[0] == "bluetoothctl":
+            return type(
+                "Result",
+                (),
+                {"returncode": 0, "stdout": "bluetoothctl: 5.87\n", "stderr": ""},
+            )()
+        raise pair_setup.CommandError(tuple(command), "btmgmt timed out")
+
+    monkeypatch.setattr(pair_setup, "_object_manager", Manager)
+    monkeypatch.setattr(pair_setup, "run_command", controller_info)
+    monkeypatch.setattr(pair_setup, "bluez_support_status", lambda: {"active": True})
+
+    status = pair_setup.bluetooth_compatibility("hci0")
+
+    assert status["available"] is False
+    assert status["hardware_supported"] is False
+    assert status["notifications_supported"] is False
+    assert status["pairing_ready"] is True
+    assert status["issue"] == "btmgmt timed out"
+    assert status["adapters"][0]["pairing_ready"] is True
 
 
 def test_classic_only_controller_supports_core_without_ancs(monkeypatch):
@@ -1187,16 +1217,23 @@ def test_backend_restart_does_not_create_per_user_enablement(monkeypatch):
     ]
 
 
-def _compatible(monkeypatch, *, notifications: bool = True) -> None:
+def _compatible(
+    monkeypatch,
+    *,
+    notifications: bool = True,
+    hardware: bool = True,
+    issue: str = "",
+) -> None:
     monkeypatch.setattr(
         pair_setup,
         "bluetooth_compatibility",
         lambda _adapter: {
-            "hardware_supported": True,
+            "hardware_supported": hardware,
             "notifications_supported": notifications,
             "bearer_api_active": True,
             "low_energy": True,
             "advertising": True,
+            "issue": issue,
         },
     )
     monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
@@ -1258,6 +1295,32 @@ def test_complete_pairing_starts_profiles_while_pairing_advert_is_active(monkeyp
         "restart",
         ("unregister", "hci0"),
     ]
+
+
+def test_unverified_controller_reaches_the_real_pairing_transaction(
+    monkeypatch,
+    caplog,
+):
+    device = _device(paired=True)
+    monkeypatch.setattr(pair_setup, "_device", lambda _mac, **_kwargs: device)
+    _compatible(
+        monkeypatch,
+        notifications=False,
+        hardware=False,
+        issue="btmgmt timed out",
+    )
+    monkeypatch.setattr(
+        bluez_setup,
+        "prepare_classic",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            pair_setup.PairingError("real Bluetooth operation failed")
+        ),
+    )
+
+    with pytest.raises(pair_setup.PairingError, match="real Bluetooth operation failed"):
+        pair_setup.complete_pairing(device.mac)
+
+    assert "continuing with pairing" in caplog.text
 
 
 def test_complete_pairing_prepares_the_selected_adapter_not_a_leftover_bond(

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from blueferry import pairing_cli
 from blueferry.bluetooth_devices import PairedDevice
 from blueferry.pairing_cli import _print_ancs_repair_hint, _print_iphone_steps
@@ -139,7 +141,21 @@ def test_cli_requires_phone_side_forget_before_clearing_saved_target(
     assert "Forget This Device" in output
 
 
-def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> None:
+@pytest.mark.parametrize(
+    ("hardware_supported", "notifications_supported", "issue", "expected_mode"),
+    [
+        (True, True, "", False),
+        (False, False, "btmgmt timed out", True),
+    ],
+)
+def test_cli_wizard_supplies_its_own_pairing_agent_ui(
+    monkeypatch,
+    capsys,
+    hardware_supported,
+    notifications_supported,
+    issue,
+    expected_mode,
+) -> None:
     prompts = []
     observed = []
     device = PairedDevice(
@@ -155,9 +171,9 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> No
     )
     compatibility = SimpleNamespace(
         adapter="hci0",
-        hardware_supported=True,
-        issue="",
-        notifications_supported=True,
+        hardware_supported=hardware_supported,
+        issue=issue,
+        notifications_supported=notifications_supported,
         bearer_api_active=True,
         adapters=(),
     )
@@ -186,7 +202,7 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> No
             compatibility_mode=False,
             explicit_pairing=False,
         ):
-            assert compatibility_mode is False
+            assert compatibility_mode is expected_mode
             assert explicit_pairing is False
             observed.append((mac, adapter, confirmation(12345)))
             display(12345)
@@ -215,6 +231,10 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(monkeypatch, capsys) -> No
     output = capsys.readouterr().out
     assert "Bluetooth pairing code: 012345" in output
     assert "pairing-issue" not in output
+    if not hardware_supported:
+        assert "btmgmt timed out" in output
+        assert "Pairing will still be attempted in compatibility mode" in output
+        assert "Automatic compatibility mode" in output
 
 
 def test_cli_wizard_points_at_pairing_issue_when_ancs_stays_down(

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -42,7 +42,6 @@ def _component(engine: QQmlEngine, relative_path: str) -> QQmlComponent:
 def test_quickshell_onboarding_state_derives_ready_stage(qml_engine) -> None:
     component = _component(qml_engine, "data/quickshell/OnboardingState.qml")
     presenter = component.createWithInitialProperties({
-        "hardwareSupported": True,
         "notificationsSupported": True,
         "bluezActive": True,
         "configured": True,
@@ -58,6 +57,22 @@ def test_quickshell_onboarding_state_derives_ready_stage(qml_engine) -> None:
 
     assert presenter is not None
     assert presenter.property("stage") == "ready"
+    presenter.deleteLater()
+
+
+def test_quickshell_unverified_controller_still_reaches_device_selection(
+    qml_engine,
+) -> None:
+    component = _component(qml_engine, "data/quickshell/OnboardingState.qml")
+    presenter = component.createWithInitialProperties({
+        "notificationsSupported": False,
+        "bluezActive": False,
+        "configured": False,
+        "backendStatus": {},
+    })
+
+    assert presenter is not None
+    assert presenter.property("stage") == "select-device"
     presenter.deleteLater()
 
 

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -57,6 +57,29 @@ def test_snapshot_converts_typed_client_models_for_qml():
     assert snapshot["threads"][0]["key"] == "address:email:test@example.com"
 
 
+def test_failed_capability_probe_is_loaded_and_pairable(monkeypatch):
+    controller = BridgeController(
+        backend=_Backend(),
+        setup=object(),
+        subscribe=False,
+        autostart=False,
+    )
+    monkeypatch.setattr(
+        controller,
+        "_run",
+        lambda _operation, _done, failed, **_kwargs: failed("probe failed"),
+    )
+
+    assert controller.compatibilityLoaded is False
+
+    controller.loadSetupState()
+
+    assert controller.compatibilityLoaded is True
+    assert controller.compatibility["pairing_ready"] is True
+    assert controller.compatibility["notifications_supported"] is False
+    assert controller.compatibility["issue"] == "probe failed"
+
+
 def test_onboarding_stage_signal_only_fires_when_stage_changes():
     controller = BridgeController(
         backend=_Backend(),


### PR DESCRIPTION
Make compatibility probes more robust; also make them not block the ability to attempt pairing. Issue #28 