### PR TITLE
Type empty advertisement options for D-Bus

### DIFF
--- a/src/blueferry/bluez_setup.py
+++ b/src/blueferry/bluez_setup.py
@@ -203,8 +203,8 @@ def register_advert(
         # timeout, then observe the actual controller state instead of making
         # pairing wait for a reply that may never arrive.
         ad_mgr.RegisterAdvertisement(
-            _AncsAdvert.PATH,
-            {},
+            dbus.ObjectPath(_AncsAdvert.PATH),
+            dbus.Dictionary({}, signature="sv"),
             timeout=float(ADVERT_DBUS_TIMEOUT_SECONDS),
         )
         _advert_registered = True

--- a/tests/test_bluez_setup.py
+++ b/tests/test_bluez_setup.py
@@ -118,6 +118,9 @@ def test_pairing_advert_settles_after_activation_is_observed(
     monkeypatch.setattr(bluez_setup.time, "sleep", sleep)
 
     assert bluez_setup.register_advert("hci7", settle_for_pairing=True) is True
+    assert isinstance(calls[0][0], dbus.ObjectPath)
+    assert isinstance(calls[0][1], dbus.Dictionary)
+    assert calls[0][1].signature == "sv"
     assert calls[0][2]["timeout"] == 1.0
     assert sleeps == [0.25, 0.25, bluez_setup.PAIRING_ADVERT_SETTLE_SECONDS]
     assert elapsed < bluez_setup.ADVERT_ACTIVATION_TIMEOUT_SECONDS


### PR DESCRIPTION
Fixes #32.

BlueFerry passed a plain empty Python dictionary to RegisterAdvertisement and relied on D-Bus introspection to infer the a{sv} signature. On the reporter's Fedora setup, dbus-python could not infer that signature after Classic pairing completed.

Pass an explicit D-Bus object path and typed a{sv} dictionary, and assert both types in the advertisement regression test.

Verification:
- 600 passed, 3 skipped
- git diff --check