### PR TITLE
Use systemd for privileged Bluetooth setup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,7 @@ Quickshell client ┘                         │
   operations for Quickshell. `pairing_policy` resolves controller capability
   and user overrides into one concrete recipe. Setup discovers and pairs
   devices, writes the selected MAC and ANCS policy to the user's configuration,
-  and requests explicit Polkit authorization for system-level setup operations.
+  and asks systemd to authorize and run system-level setup operations.
 - `onboarding` derives a toolkit-neutral first-run stage from configuration,
   controller capabilities, the selected bond, and backend status. Controller
   support is detected from read-only capabilities instead of vendor names. A

--- a/README.md
+++ b/README.md
@@ -242,9 +242,8 @@ BlueFerry uses three standard Bluetooth services:
   display information.
 
 One unprivileged per-user backend owns those connections and exposes a small
-session D-Bus API to the clients. Pairing uses normal Bluetooth confirmation
-and Polkit for the one system-level setup step; there is no sudoers rule or
-hidden Apple protocol.
+session D-Bus API to the clients. Pairing uses normal Bluetooth confirmation;
+there is no hidden Apple protocol.
 
 The deeper design and protocol notes live in
 [ARCHITECTURE.md](ARCHITECTURE.md), [PROTOCOL.md](PROTOCOL.md), and

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -108,6 +108,7 @@ package_blueferry-backend() {
     'python-gobject'
     'python-textual>=8.0'
     'python-typer>=0.12'
+    'systemd'
   )
   cd "$pkgbase-$pkgver"
   install -d "$pkgdir/$_site"
@@ -120,6 +121,8 @@ package_blueferry-backend() {
 
   install -Dm644 systemd/blueferry.service \
     "$pkgdir/usr/lib/systemd/user/blueferry.service"
+  install -Dm644 systemd/blueferry-btmgmt-set-class@.service \
+    "$pkgdir/usr/lib/systemd/system/blueferry-btmgmt-set-class@.service"
   install -d "$pkgdir/usr/lib/systemd/user/default.target.wants"
   ln -s ../blueferry.service \
     "$pkgdir/usr/lib/systemd/user/default.target.wants/blueferry.service"

--- a/packaging/deb/blueferry-backend.install
+++ b/packaging/deb/blueferry-backend.install
@@ -9,6 +9,7 @@ usr/lib/python3*/dist-packages/blueferry-*.dist-info
 usr/lib/blueferry/vendor
 usr/lib/systemd/user/blueferry.service
 usr/lib/systemd/user/default.target.wants/blueferry.service
+usr/lib/systemd/system/blueferry-btmgmt-set-class@.service
 usr/share/blueferry/package-release
 usr/share/blueferry/build-sha
 usr/share/dbus-1/interfaces/io.weirdware.BlueFerry.xml

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -34,11 +34,12 @@ Depends:
  dbus,
  gir1.2-secret-1,
  libsecret-1-0,
- pkexec,
+ polkitd,
  python3-cryptography (>= 41),
  python3-dbus,
  python3-gi,
  python3-typer (>= 0.9),
+ systemd,
 Recommends: gnome-keyring | keepassxc
 Description: iPhone Bluetooth bridge backend, daemon, and CLI
  BlueFerry connects an iPhone to a Linux desktop over Bluetooth for messages

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -27,6 +27,8 @@ override_dh_auto_install:
 	done
 	install -Dm644 systemd/blueferry.service \
 		debian/tmp/usr/lib/systemd/user/blueferry.service
+	install -Dm644 systemd/blueferry-btmgmt-set-class@.service \
+		debian/tmp/usr/lib/systemd/system/blueferry-btmgmt-set-class@.service
 	install -d debian/tmp/usr/lib/systemd/user/default.target.wants
 	ln -s ../blueferry.service \
 		debian/tmp/usr/lib/systemd/user/default.target.wants/blueferry.service

--- a/packaging/rpm/blueferry.spec
+++ b/packaging/rpm/blueferry.spec
@@ -32,6 +32,7 @@ Requires:       python3-dbus
 Requires:       python3-gobject
 Requires:       python3dist(cryptography) >= 41
 Requires:       python3dist(typer) >= 0.9
+Requires:       systemd
 Recommends:     gnome-keyring
 Provides:       bundled(python3dist(linkify-it-py)) = 2.1.0
 Provides:       bundled(python3dist(markdown-it-py)) = 4.2.0
@@ -90,6 +91,8 @@ done
 
 install -Dm0644 systemd/blueferry.service \
     %{buildroot}%{_userunitdir}/blueferry.service
+install -Dm0644 systemd/blueferry-btmgmt-set-class@.service \
+    %{buildroot}%{_unitdir}/blueferry-btmgmt-set-class@.service
 install -d %{buildroot}%{_userunitdir}/default.target.wants
 ln -s ../blueferry.service \
     %{buildroot}%{_userunitdir}/default.target.wants/blueferry.service
@@ -165,6 +168,7 @@ fi
 %{_prefix}/lib/blueferry/vendor
 %{_userunitdir}/blueferry.service
 %{_userunitdir}/default.target.wants/blueferry.service
+%{_unitdir}/blueferry-btmgmt-set-class@.service
 %{_unitdir}/bluetooth.service.d/blueferry.conf
 %{_datadir}/blueferry/package-release
 %{_datadir}/blueferry/build-sha

--- a/src/blueferry/bluetooth_capabilities.py
+++ b/src/blueferry/bluetooth_capabilities.py
@@ -588,10 +588,10 @@ def activate_bluez_support(
     *,
     status: Callable[[], dict],
     run_command: RunCommand,
-    pkexec_path: Path = Path("/usr/bin/pkexec"),
+    systemctl_path: Path = Path("/usr/bin/systemctl"),
     sleep: Callable[[float], None] = time.sleep,
 ) -> dict:
-    """Restart Bluetooth through Polkit so the packaged drop-in takes effect."""
+    """Restart Bluetooth through systemd so the packaged drop-in takes effect."""
     current = status()
     if current["active"]:
         return current
@@ -599,11 +599,11 @@ def activate_bluez_support(
         raise PairingError(
             "The blueferry-backend Bluetooth service drop-in is not installed."
         )
-    if not pkexec_path.is_file() or not pkexec_path.stat().st_mode & 0o111:
-        raise PairingError("Polkit's pkexec command is unavailable")
+    if not systemctl_path.is_file() or not systemctl_path.stat().st_mode & 0o111:
+        raise PairingError("systemctl is unavailable")
     try:
         run_command(
-            [str(pkexec_path), "/usr/bin/systemctl", "restart", "bluetooth.service"],
+            [str(systemctl_path), "restart", "bluetooth.service"],
             timeout=120,
         )
     except CommandError as error:

--- a/src/blueferry/bluez_setup.py
+++ b/src/blueferry/bluez_setup.py
@@ -11,7 +11,7 @@ the Linux side:
 
 This module owns those three concerns. The daemon may verify them on startup,
 but privileged Class-of-Device changes are limited to the explicit pairing
-flow and authorized through Polkit.
+flow and run through a packaged systemd service after Polkit authorization.
 """
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ import dbus.service
 from blueferry import config
 from blueferry.bus import bluez, get_system_bus
 from blueferry.commands import run_command
-from blueferry.errors import CommandError
+from blueferry.errors import CommandError, PairingError
 
 log = logging.getLogger(__name__)
 
@@ -35,6 +35,18 @@ ADVERT_DBUS_TIMEOUT_SECONDS = 1
 ADVERT_ACTIVATION_TIMEOUT_SECONDS = 15
 ADVERT_POLL_INTERVAL_SECONDS = 0.25
 PAIRING_ADVERT_SETTLE_SECONDS = 5
+POLKIT_UNAVAILABLE_MESSAGE = (
+    "No Polkit authentication is available to set device class, "
+    "please use the blueferry pair-setup command from a terminal"
+)
+DEVICE_CLASS_SERVICE_MISSING_MESSAGE = (
+    "The BlueFerry device-class service is not installed; "
+    "install blueferry-backend before pairing."
+)
+_POLKIT_UNAVAILABLE_MARKERS = (
+    "interactive authentication required",
+    "no authentication agent",
+)
 
 
 # ---- Class-of-Device ----------------------------------------------------
@@ -62,41 +74,67 @@ def desired_cod_matches(cod: int | None) -> bool:
     return major == config.COD_MAJOR and (minor << 2) == config.COD_MINOR
 
 
+def _polkit_authentication_unavailable(output: str) -> bool:
+    normalized = output.casefold()
+    return any(marker in normalized for marker in _POLKIT_UNAVAILABLE_MARKERS)
+
+
 def set_cod(
     *,
     adapter: str | None = None,
     authorize: bool = False,
     dry_run: bool = False,
 ) -> bool:
-    """Apply the required CoD, optionally requesting Polkit authorization."""
+    """Apply the required CoD, optionally requesting system authorization."""
     adapter = adapter or config.ADAPTER
+    if not config.is_valid_adapter(adapter):
+        log.error("invalid Bluetooth adapter name: %s", adapter)
+        return False
+    index = adapter.removeprefix("hci")
     cmd = [
-        "/usr/bin/btmgmt", "--index", adapter.removeprefix("hci"), "class",
+        "/usr/bin/btmgmt", "--index", index, "class",
         str(config.COD_MAJOR), str(config.COD_MINOR),
     ]
     if os.geteuid() != 0:
         if not authorize:
             log.warning("adapter CoD differs; pairing setup must authorize the change")
             return False
-        pkexec = "/usr/bin/pkexec"
-        if not os.path.isfile(pkexec) or not os.access(pkexec, os.X_OK):
-            log.error("pkexec is unavailable; cannot authorize adapter setup")
+        systemctl = "/usr/bin/systemctl"
+        if not os.path.isfile(systemctl) or not os.access(systemctl, os.X_OK):
+            log.error("systemctl is unavailable; cannot authorize adapter setup")
             return False
-        cmd = [pkexec, *cmd]
+        cmd = [
+            systemctl,
+            "start",
+            f"blueferry-btmgmt-set-class@{index}.service",
+        ]
     log.info("setting adapter CoD via: %s", " ".join(cmd))
     if dry_run:
         return True
     try:
         r = run_command(
-            cmd, timeout=120 if authorize else 10, check=False
+            cmd,
+            timeout=120 if authorize else 10,
+            check=False,
+            env={**os.environ, "LC_ALL": "C"},
         )
     except CommandError as e:
         log.error("btmgmt failed: %s", e)
         return False
     if r.returncode != 0:
+        output = r.stderr.strip() or r.stdout.strip()
+        if cmd[0] == "/usr/bin/systemctl":
+            if _polkit_authentication_unavailable(output):
+                raise PairingError(POLKIT_UNAVAILABLE_MESSAGE)
+            normalized = output.casefold()
+            if (
+                "blueferry-btmgmt-set-class@" in normalized
+                and "not found" in normalized
+            ):
+                raise PairingError(DEVICE_CLASS_SERVICE_MISSING_MESSAGE)
         log.error("btmgmt class %d %d failed (rc=%d): %s",
                   config.COD_MAJOR, config.COD_MINOR, r.returncode,
-                  r.stderr.strip() or r.stdout.strip())
+                  output)
         return False
     log.info("CoD set ok: %s", r.stdout.strip())
     return True

--- a/src/blueferry/cli.py
+++ b/src/blueferry/cli.py
@@ -51,6 +51,7 @@ def doctor(verbose: bool = typer.Option(False, "-v", "--verbose")):
     log = logging.getLogger("doctor")
 
     ok = True
+    warnings = False
 
     # BLUEFERRY_MAC configured?
     if config.IPHONE_MAC.upper() in ("AA:BB:CC:DD:EE:FF", ""):
@@ -85,10 +86,10 @@ def doctor(verbose: bool = typer.Option(False, "-v", "--verbose")):
         else:
             log.warning(
                 "Adapter CoD = 0x%06x — not A/V Hands-Free. "
-                "Complete pairing in one of the graphical clients.",
+                "Pair in a graphical client or with blueferry pair-setup.",
                 cod,
             )
-            ok = False
+            warnings = True
 
     # State dir writable
     try:
@@ -98,11 +99,15 @@ def doctor(verbose: bool = typer.Option(False, "-v", "--verbose")):
         log.error("State dir not writable: %s", e)
         ok = False
 
-    if ok:
-        typer.echo(typer.style("All checks passed.", fg=typer.colors.GREEN))
-    else:
+    if not ok:
         typer.echo(typer.style("One or more checks FAILED.", fg=typer.colors.RED))
         raise typer.Exit(code=1)
+    if warnings:
+        typer.echo(
+            typer.style("Checks completed with warnings.", fg=typer.colors.YELLOW)
+        )
+    else:
+        typer.echo(typer.style("All checks passed.", fg=typer.colors.GREEN))
 
 
 @app.command()
@@ -232,7 +237,7 @@ def pairing_configuration_json() -> None:
 
 @app.command("pairing-activate-bluez", hidden=True)
 def pairing_activate_bluez() -> None:
-    """Activate the package's BlueZ drop-in through Polkit."""
+    """Activate the package's BlueZ drop-in through systemd."""
     import json
 
     from blueferry.errors import PairingError

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -108,7 +108,7 @@ def bluez_support_status(*, proc_root: Path = Path("/proc")) -> dict:
 
 
 def activate_bluez_support() -> dict:
-    """Restart Bluetooth via Polkit so the packaged drop-in takes effect."""
+    """Restart Bluetooth via systemd so the packaged drop-in takes effect."""
     return capabilities.activate_bluez_support(
         status=bluez_support_status,
         run_command=run_command,

--- a/systemd/blueferry-btmgmt-set-class@.service
+++ b/systemd/blueferry-btmgmt-set-class@.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=BlueFerry set Bluetooth adapter hci%i class with btmgmt
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/btmgmt --index %i class 4 8

--- a/tests/test_bluez_setup.py
+++ b/tests/test_bluez_setup.py
@@ -63,7 +63,7 @@ def test_cod_change_requires_explicit_authorization(monkeypatch):
     assert calls == []
 
 
-def test_authorized_cod_change_uses_polkit_and_fixed_command(monkeypatch):
+def test_authorized_cod_change_uses_packaged_systemd_unit(monkeypatch):
     calls = []
     monkeypatch.setattr(bluez_setup.os, "geteuid", lambda: 1000)
     monkeypatch.setattr(bluez_setup.os.path, "isfile", lambda _path: True)
@@ -77,9 +77,100 @@ def test_authorized_cod_change_uses_polkit_and_fixed_command(monkeypatch):
 
     assert bluez_setup.set_cod(adapter="hci7", authorize=True) is True
     assert calls[0][0] == [
-        "/usr/bin/pkexec", "/usr/bin/btmgmt", "--index", "7", "class", "4", "8",
+        "/usr/bin/systemctl",
+        "start",
+        "blueferry-btmgmt-set-class@7.service",
     ]
     assert calls[0][1]["timeout"] == 120
+    assert calls[0][1]["env"]["LC_ALL"] == "C"
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "Failed to start unit: Interactive authentication required.",
+        "Error: No authentication agent found.",
+    ],
+)
+def test_cod_change_explains_when_polkit_authentication_is_unavailable(
+    monkeypatch, stderr,
+):
+    monkeypatch.setattr(bluez_setup.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(bluez_setup.os.path, "isfile", lambda _path: True)
+    monkeypatch.setattr(bluez_setup.os, "access", lambda _path, _mode: True)
+    monkeypatch.setattr(
+        bluez_setup,
+        "run_command",
+        lambda _args, **_kwargs: type(
+            "Result",
+            (),
+            {"returncode": 1, "stdout": "", "stderr": stderr},
+        )(),
+    )
+
+    with pytest.raises(
+        bluez_setup.PairingError,
+        match="No Polkit authentication is available to set device class",
+    ) as failure:
+        bluez_setup.set_cod(adapter="hci7", authorize=True)
+
+    assert str(failure.value) == bluez_setup.POLKIT_UNAVAILABLE_MESSAGE
+
+
+def test_cod_change_explains_when_the_packaged_systemd_unit_is_missing(monkeypatch):
+    monkeypatch.setattr(bluez_setup.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(bluez_setup.os.path, "isfile", lambda _path: True)
+    monkeypatch.setattr(bluez_setup.os, "access", lambda _path, _mode: True)
+    monkeypatch.setattr(
+        bluez_setup,
+        "run_command",
+        lambda _args, **_kwargs: type(
+            "Result",
+            (),
+            {
+                "returncode": 1,
+                "stdout": "",
+                "stderr": (
+                    "Failed to start blueferry-btmgmt-set-class@7.service: "
+                    "Unit blueferry-btmgmt-set-class@7.service not found."
+                ),
+            },
+        )(),
+    )
+
+    with pytest.raises(bluez_setup.PairingError) as failure:
+        bluez_setup.set_cod(adapter="hci7", authorize=True)
+
+    assert str(failure.value) == bluez_setup.DEVICE_CLASS_SERVICE_MISSING_MESSAGE
+
+
+def test_cod_change_does_not_mislabel_an_unrelated_systemctl_failure(monkeypatch):
+    monkeypatch.setattr(bluez_setup.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(bluez_setup.os.path, "isfile", lambda _path: True)
+    monkeypatch.setattr(bluez_setup.os, "access", lambda _path, _mode: True)
+    monkeypatch.setattr(
+        bluez_setup,
+        "run_command",
+        lambda _args, **_kwargs: type(
+            "Result",
+            (),
+            {"returncode": 1, "stdout": "", "stderr": "Job failed"},
+        )(),
+    )
+
+    assert bluez_setup.set_cod(adapter="hci7", authorize=True) is False
+
+
+def test_cod_change_rejects_an_invalid_adapter(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        bluez_setup,
+        "run_command",
+        lambda args, **_kwargs: calls.append(args),
+    )
+
+    assert bluez_setup.set_cod(adapter="hci0/../../evil", authorize=True) is False
+    assert calls == []
 
 
 def test_pairing_advert_settles_after_activation_is_observed(

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from blueferry import cli, config
+
+
+def _healthy_non_cod_checks(monkeypatch) -> None:
+    monkeypatch.setattr(cli, "_setup_logging", lambda _verbose: None)
+    monkeypatch.setattr(config, "IPHONE_MAC", "02:00:00:00:00:01")
+    monkeypatch.setattr(cli, "_find_obexd", lambda: "/usr/lib/bluetooth/obexd")
+    monkeypatch.setattr(config, "ensure_dirs", lambda: None)
+
+
+def test_doctor_treats_an_unset_device_class_as_advisory(monkeypatch) -> None:
+    _healthy_non_cod_checks(monkeypatch)
+    monkeypatch.setattr(cli.bluez_setup, "current_cod", lambda: 0)
+
+    result = CliRunner().invoke(cli.app, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "Checks completed with warnings." in result.output
+    assert "FAILED" not in result.output
+
+
+def test_doctor_still_fails_when_the_adapter_is_unreachable(monkeypatch) -> None:
+    _healthy_non_cod_checks(monkeypatch)
+    monkeypatch.setattr(cli.bluez_setup, "current_cod", lambda: None)
+
+    result = CliRunner().invoke(cli.app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "One or more checks FAILED." in result.output

--- a/tests/test_controller_hardware.py
+++ b/tests/test_controller_hardware.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from blueferry.bluetooth_capabilities import (
+    activate_bluez_support,
     bluez_bearer_api_supported,
     bluez_stack,
     controller_hardware,
 )
+from blueferry.errors import PairingError
 
 
 def _btmgmt(stdout: str):
@@ -154,3 +156,43 @@ def test_controller_hardware_ignores_invalid_adapter_names(tmp_path) -> None:
         sys_root=tmp_path,
     )
     assert identity == {"name": "../etc"}
+
+
+def test_activate_bluez_support_delegates_authorization_to_systemctl(tmp_path) -> None:
+    systemctl = tmp_path / "systemctl"
+    systemctl.write_text("")
+    systemctl.chmod(0o755)
+    statuses = iter(
+        [
+            {"active": False, "packaged_drop_in": True},
+            {"active": True, "packaged_drop_in": True},
+        ]
+    )
+    commands = []
+    sleeps = []
+
+    result = activate_bluez_support(
+        status=lambda: next(statuses),
+        run_command=lambda args, **kwargs: commands.append((args, kwargs)),
+        systemctl_path=systemctl,
+        sleep=sleeps.append,
+    )
+
+    assert result["active"] is True
+    assert commands == [
+        ([str(systemctl), "restart", "bluetooth.service"], {"timeout": 120})
+    ]
+    assert sleeps == [2]
+
+
+def test_activate_bluez_support_requires_systemctl(tmp_path) -> None:
+    try:
+        activate_bluez_support(
+            status=lambda: {"active": False, "packaged_drop_in": True},
+            run_command=lambda *_args, **_kwargs: None,
+            systemctl_path=tmp_path / "missing-systemctl",
+        )
+    except PairingError as error:
+        assert str(error) == "systemctl is unavailable"
+    else:
+        raise AssertionError("activate_bluez_support accepted a missing systemctl")

--- a/tests/test_native_packaging.py
+++ b/tests/test_native_packaging.py
@@ -108,6 +108,39 @@ def test_deb_and_rpm_install_secret_service_client_bindings() -> None:
     assert "Requires:       libsecret" in spec
 
 
+def test_native_backends_install_systemd_privilege_dependencies() -> None:
+    control = (ROOT / "packaging/deb/control").read_text()
+    arch = (ROOT / "packaging/arch/PKGBUILD").read_text()
+    spec = (ROOT / "packaging/rpm/blueferry.spec").read_text()
+
+    assert " polkitd,\n" in control
+    assert " systemd,\n" in control
+    assert "'polkit'" in arch
+    assert "'systemd'" in arch
+    assert "Requires:       polkit" in spec
+    assert "Requires:       systemd" in spec
+    assert "pkexec" not in control
+    assert "pkexec" not in arch
+    assert "pkexec" not in spec
+
+
+def test_native_backends_ship_the_btmgmt_system_unit_template() -> None:
+    unit_name = "blueferry-btmgmt-set-class@.service"
+    unit = (ROOT / "systemd" / unit_name).read_text()
+    deb_rules = (ROOT / "packaging/deb/rules").read_text()
+    deb_install = (ROOT / "packaging/deb/blueferry-backend.install").read_text()
+    arch = (ROOT / "packaging/arch/PKGBUILD").read_text()
+    spec = (ROOT / "packaging/rpm/blueferry.spec").read_text()
+
+    assert "Type=oneshot" in unit
+    assert "ExecStart=/usr/bin/btmgmt --index %i class 4 8" in unit
+    assert "[Install]" not in unit
+    assert f"systemd/{unit_name}" in deb_rules
+    assert f"usr/lib/systemd/system/{unit_name}" in deb_install
+    assert f"systemd/{unit_name}" in arch
+    assert f"%{{_unitdir}}/{unit_name}" in spec
+
+
 def test_deb_and_rpm_backend_ship_private_textual_runtime() -> None:
     control = (ROOT / "packaging/deb/control").read_text().lower()
     deb_install = (ROOT / "packaging/deb/blueferry-backend.install").read_text()


### PR DESCRIPTION
## Summary

- delegate adapter class changes to a packaged systemd service template instead of invoking `btmgmt` through `pkexec`
- restart `bluetooth.service` through `systemctl`, allowing systemd and Polkit to handle authorization
- install the unit and explicit systemd/Polkit runtime dependencies in Arch, Debian, and RPM packages
- report missing authentication agents and missing packaged units clearly
- make an unset device class advisory in `blueferry doctor` and point users at either graphical pairing or `blueferry pair-setup`

## Verification

- `ruff check .`
- `bandit -r src/blueferry -q`
- `mypy src/blueferry`
- hermetic pytest suite: 614 passed
- Qt/QML lint
- `git diff --check`