### PR TITLE
Polish Qt client startup and messaging UI

### DIFF
--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -10,8 +10,6 @@ Kirigami.ApplicationWindow {
 
     required property var bridge
     property string selectedThreadKey: ""
-    property var pendingThread: null
-    property string pendingBody: ""
     property bool firstRunRedirected: false
     property var iphoneSettingsPage: null
     property string pendingMessageHandle: ""
@@ -62,10 +60,6 @@ Kirigami.ApplicationWindow {
         return "<span>" + value + "</span>"
     }
 
-    function escapedRichTextWithBreaks(value) {
-        return escapedRichText(String(value).replace(/\n/g, "<br/>"))
-    }
-
     function mapConnectionRefused() {
         const status = bridge.status || ({})
         return status.map_connection_refused === true
@@ -79,7 +73,7 @@ Kirigami.ApplicationWindow {
             pageStack.currentIndex = pageStack.depth - 1
             return
         }
-        iphoneSettingsPage = pageStack.push(iphonePageComponent)
+        iphoneSettingsPage = pageStack.push(iphonePageLoader.item)
     }
 
     function closePhoneSettings() {
@@ -187,26 +181,6 @@ Kirigami.ApplicationWindow {
                 onTriggered: Qt.quit()
             }
         ]
-    }
-
-    Kirigami.PromptDialog {
-        id: groupDialog
-        title: qsTr("Send Group Message?")
-        subtitle: root.pendingThread
-            ? root.escapedRichTextWithBreaks(
-                qsTr("The iPhone will reply to these participants:\n\n")
-                + root.pendingThread.recipients.map(root.htmlEscape).join("\n")
-              )
-            : ""
-        standardButtons: Kirigami.Dialog.Cancel
-        customFooterActions: [Kirigami.Action {
-            text: qsTr("Send to Group")
-            icon.name: "document-send"
-            onTriggered: {
-                root.bridge.sendThread(root.pendingThread.key, root.pendingBody, true)
-                groupDialog.close()
-            }
-        }]
     }
 
     Kirigami.PromptDialog {
@@ -569,24 +543,6 @@ Kirigami.ApplicationWindow {
         property bool narrow: width < 680
         property var thread: root.selectedThread()
 
-        actions: [
-            Kirigami.Action {
-                text: qsTr("Edit Group Participants")
-                icon.name: "system-users"
-                visible: messagesPage.thread !== null
-                    && messagesPage.thread.group_origin === "named"
-                onTriggered: {
-                    groupParticipantsDialog.thread = messagesPage.thread
-                    groupParticipantsDialog.open()
-                }
-            },
-            Kirigami.Action {
-                text: qsTr("Settings")
-                icon.name: "settings-configure"
-                onTriggered: root.togglePhoneSettings()
-            }
-        ]
-
         ColumnLayout {
             anchors.fill: parent
             spacing: 0
@@ -663,6 +619,16 @@ Kirigami.ApplicationWindow {
                                     Controls.ToolTip.text: text
                                     Controls.ToolTip.visible: hovered
                                     onClicked: newMessageDialog.open()
+                                }
+                                Controls.ToolButton {
+                                    visible: messagesPage.narrow
+                                    icon.name: "settings-configure"
+                                    text: qsTr("Settings")
+                                    display: Controls.AbstractButton.IconOnly
+                                    Accessible.name: text
+                                    Controls.ToolTip.text: text
+                                    Controls.ToolTip.visible: hovered
+                                    onClicked: root.togglePhoneSettings()
                                 }
                             }
                         }
@@ -745,6 +711,29 @@ Kirigami.ApplicationWindow {
                                     textFormat: Text.PlainText
                                     font.bold: true
                                     elide: Text.ElideRight
+                                }
+                                Controls.ToolButton {
+                                    visible: messagesPage.thread !== null
+                                        && messagesPage.thread.group_origin === "named"
+                                    icon.name: "system-users"
+                                    text: qsTr("Edit Group Participants")
+                                    display: Controls.AbstractButton.IconOnly
+                                    Accessible.name: text
+                                    Controls.ToolTip.text: text
+                                    Controls.ToolTip.visible: hovered
+                                    onClicked: {
+                                        groupParticipantsDialog.thread = messagesPage.thread
+                                        groupParticipantsDialog.open()
+                                    }
+                                }
+                                Controls.ToolButton {
+                                    icon.name: "settings-configure"
+                                    text: qsTr("Settings")
+                                    display: Controls.AbstractButton.IconOnly
+                                    Accessible.name: text
+                                    Controls.ToolTip.text: text
+                                    Controls.ToolTip.visible: hovered
+                                    onClicked: root.togglePhoneSettings()
                                 }
                             }
                         }
@@ -837,15 +826,12 @@ Kirigami.ApplicationWindow {
                                 enabled: composer.enabled && composer.text.trim() !== ""
                                 Accessible.name: qsTr("Send Message")
                                 onClicked: {
-                                    if (messagesPage.thread.is_group) {
-                                        root.pendingThread = messagesPage.thread
-                                        root.pendingBody = composer.text.trim()
-                                        composer.clear()
-                                        groupDialog.open()
-                                    } else {
-                                        root.bridge.sendThread(messagesPage.thread.key, composer.text, false)
-                                        composer.clear()
-                                    }
+                                    root.bridge.sendThread(
+                                        messagesPage.thread.key,
+                                        composer.text,
+                                        messagesPage.thread.is_group
+                                    )
+                                    composer.clear()
                                 }
                             }
                         }
@@ -877,19 +863,22 @@ Kirigami.ApplicationWindow {
         }
     }
 
+    Loader {
+        id: iphonePageLoader
+        // PageRow creates Component-backed pages under an internal QtObject.
+        // Keep this page visually parented and alive so Qt does not warn while
+        // Kirigami is still incubating its toolbar delegates.
+        asynchronous: false
+        visible: false
+        sourceComponent: iphonePageComponent
+    }
+
     Component {
         id: iphonePageComponent
 
         Kirigami.ScrollablePage {
             id: iphonePage
             title: qsTr("iPhone Settings")
-        actions: [
-            Kirigami.Action {
-                text: qsTr("Close Settings")
-                icon.name: "window-close"
-                onTriggered: root.closePhoneSettings()
-            }
-        ]
         property int selectedDevice: -1
         property var device: selectedDevice >= 0 && selectedDevice < root.bridge.devices.length
             ? root.bridge.devices[selectedDevice]
@@ -919,6 +908,20 @@ Kirigami.ApplicationWindow {
         ColumnLayout {
             width: parent.width
             spacing: Kirigami.Units.largeSpacing
+
+                RowLayout {
+                    Layout.fillWidth: true
+
+                    Item { Layout.fillWidth: true }
+                    Controls.ToolButton {
+                        icon.name: "window-close"
+                        text: qsTr("Close Settings")
+                        Accessible.name: text
+                        Controls.ToolTip.text: text
+                        Controls.ToolTip.visible: hovered
+                        onClicked: root.closePhoneSettings()
+                    }
+                }
 
                 Kirigami.InlineMessage {
                     Layout.fillWidth: true
@@ -1174,7 +1177,7 @@ Kirigami.ApplicationWindow {
                     }
                     Controls.Label {
                         Kirigami.FormData.label: qsTr("Messages:")
-                        Layout.fillWidth: true
+                        Layout.fillWidth: root.mapConnectionRefused()
                         wrapMode: Text.Wrap
                         text: root.mapConnectionRefused()
                             ? qsTr("iPhone is refusing message connections; is it connected to another computer?")
@@ -1189,20 +1192,19 @@ Kirigami.ApplicationWindow {
                         text: root.bridge.status.ancs ? qsTr("Connected") : qsTr("Unavailable")
                     }
                     Controls.Label {
-                        Kirigami.FormData.label: qsTr("ANCS Recovery:")
-                        Layout.fillWidth: true
-                        visible: root.bridge.configured
-                            && root.bridge.onboardingCompatibility.notifications_supported
-                            && root.bridge.status.map
-                            && root.bridge.status.pbap
-                            && !root.bridge.status.ancs
-                        wrapMode: Text.Wrap
-                        text: qsTr("FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Before re-pairing, run sudo systemctl restart bluetooth.service, then forget this computer on the iPhone and pair again. This briefly disconnects all Bluetooth devices.")
-                    }
-                    Controls.Label {
                         Kirigami.FormData.label: qsTr("Contact Destinations:")
                         text: root.bridge.status.contacts || "0"
                     }
+                }
+                Kirigami.InlineMessage {
+                    Layout.fillWidth: true
+                    visible: root.bridge.configured === true
+                        && root.bridge.onboardingCompatibility.notifications_supported === true
+                        && root.bridge.status.map === true
+                        && root.bridge.status.pbap === true
+                        && root.bridge.status.ancs === false
+                    type: Kirigami.MessageType.Information
+                    text: qsTr("FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Before re-pairing, run sudo systemctl restart bluetooth.service, then forget this computer on the iPhone and pair again. This briefly disconnects all Bluetooth devices.")
                 }
 
                 Kirigami.Heading { text: qsTr("Desktop Notifications"); level: 2 }

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -147,7 +147,8 @@ def test_qt_package_ships_the_kirigami_ui_and_dependencies() -> None:
     assert "'qqc2-desktop-style'" in pkgbuild
     assert "Kirigami.ApplicationWindow" in qml
     assert "Kirigami.NavigationTabBar" not in qml
-    assert "pageStack.push(iphonePageComponent)" in qml
+    assert "pageStack.push(iphonePageLoader.item)" in qml
+    assert "sourceComponent: iphonePageComponent" in qml
     assert "root.pageStack.push(aboutPage)" in qml
     assert "pageStack.layers.push" not in qml
     assert "Controls.StackView.Immediate" not in qml
@@ -315,22 +316,39 @@ def test_qt_escaped_roster_names_are_forced_to_rich_text() -> None:
     assert "root.htmlEscape(thread.name)" in qml
 
 
-def test_qt_group_confirmation_preserves_escaped_recipient_lines() -> None:
-    qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
-
-    assert 'replace(/\\n/g, "<br/>")' in qml
-    assert "? root.escapedRichTextWithBreaks(" in qml
-    assert 'recipients.map(root.htmlEscape).join("\\n")' in qml
-
-
 def test_qt_messages_toolbar_toggles_dismissible_settings_pane() -> None:
     qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
 
     assert 'text: qsTr("Settings")' in qml
-    assert "onTriggered: root.togglePhoneSettings()" in qml
+    assert "onClicked: root.togglePhoneSettings()" in qml
     assert 'text: qsTr("Close Settings")' in qml
+    assert "onClicked: root.closePhoneSettings()" in qml
+    assert "pageStack.push(iphonePageLoader.item)" in qml
     assert "pageStack.removePage(page)" in qml
+    assert "messagesPage.thread.group_origin" in qml
+    assert "messagesPage.actions" not in qml
+    assert "iphonePage.actions" not in qml
     assert 'text: qsTr("Refresh")' not in qml
+
+
+def test_qt_connection_health_stays_compact_and_centered() -> None:
+    qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
+    health = qml.split('text: qsTr("Connection Health")', 1)[1]
+    health = health.split('text: qsTr("Desktop Notifications")', 1)[0]
+
+    assert "Layout.fillWidth: root.mapConnectionRefused()" in health
+    assert 'Kirigami.FormData.label: qsTr("ANCS Recovery:")' not in health
+    assert "Kirigami.InlineMessage" in health
+
+
+def test_qt_sends_group_replies_without_a_confirmation_dialog() -> None:
+    qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
+
+    assert "messagesPage.thread.is_group" in qml
+    assert 'title: qsTr("Send Group Message?")' not in qml
+    assert "groupDialog.open()" not in qml
+    assert "pendingThread" not in qml
+    assert "pendingBody" not in qml
 
 
 def test_qt_conversation_panes_start_compact_and_are_resizable() -> None:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -260,12 +260,19 @@ async def _wait_for_threads(app: BlueFerryApp, pilot, count: int) -> None:
 async def _wait_for_conversation_title(
     app: BlueFerryApp, pilot, expected: str,
 ) -> None:
-    title = app.query_one("#conversation-title", Static)
+    await _wait_for_static_text(app, pilot, "#conversation-title", expected)
+
+
+async def _wait_for_static_text(
+    app: BlueFerryApp, pilot, selector: str, expected: str,
+) -> Static:
+    widget = app.query_one(selector, Static)
     for _attempt in range(30):
-        if title.render().plain == expected:
-            return
+        if widget.render().plain == expected:
+            return widget
         await pilot.pause(0.05)
-    assert title.render().plain == expected
+    assert widget.render().plain == expected
+    return widget
 
 
 async def _wait_for_message_meta(
@@ -303,8 +310,14 @@ def test_textual_app_renders_status_threads_and_messages() -> None:
         async with app.run_test(size=(120, 36)) as pilot:
             await _wait_for_threads(app, pilot, 2)
 
-            assert app.query_one("#connection-summary").render().plain == "iPhone connected"
-            assert app.query_one("#conversation-title").render().plain == "Alice"
+            connection = await _wait_for_static_text(
+                app, pilot, "#connection-summary", "iPhone connected"
+            )
+            title = await _wait_for_static_text(
+                app, pilot, "#conversation-title", "Alice"
+            )
+            assert connection.render().plain == "iPhone connected"
+            assert title.render().plain == "Alice"
             assert len(app.query(MessageRow)) == 1
 
             app.action_next_thread()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -174,7 +174,9 @@ def test_message_sender_metadata_is_sanitized() -> None:
             await _wait_for_threads(app, pilot, 2)
             app.action_next_thread()
             await _wait_for_conversation_title(app, pilot, "Friends  ·  Group")
-            meta = app.query_one(MessageRow).query_one(".message-meta", Static)
+            meta = await _wait_for_message_meta(
+                app, pilot, "Beau�[31m� forged  ·  "
+            )
             assert meta.render().plain.startswith("Beau�[31m� forged  ·  ")
 
     _run_headless(scenario())
@@ -266,6 +268,22 @@ async def _wait_for_conversation_title(
     assert title.render().plain == expected
 
 
+async def _wait_for_message_meta(
+    app: BlueFerryApp, pilot, expected_prefix: str,
+) -> Static:
+    for _attempt in range(30):
+        for widget in app.query(".message-meta"):
+            if (
+                isinstance(widget, Static)
+                and widget.render().plain.startswith(expected_prefix)
+            ):
+                return widget
+        await pilot.pause(0.05)
+    meta = app.query_one(MessageRow).query_one(".message-meta", Static)
+    assert meta.render().plain.startswith(expected_prefix)
+    return meta
+
+
 def _run_headless(coroutine: Coroutine[Any, Any, None]) -> None:
     # Python 3.14's asyncio.Runner waits unnecessarily for Textual's already
     # drained async generators. A directly-owned loop is deterministic here;
@@ -293,7 +311,7 @@ def test_textual_app_renders_status_threads_and_messages() -> None:
             await _wait_for_conversation_title(app, pilot, "Friends  ·  Group")
             assert state.selected_key == "group"
             assert app.query_one("#conversation-title").render().plain == "Friends  ·  Group"
-            meta = app.query_one(MessageRow).query_one(".message-meta", Static)
+            meta = await _wait_for_message_meta(app, pilot, "Beau  ·  ")
             assert meta.render().plain.startswith("Beau  ·  ")
 
     _run_headless(scenario())


### PR DESCRIPTION
## Summary

- eliminate Kirigami toolbar incubation and page-lifecycle warnings at startup
- restore compact, centered Connection Health presentation and show ANCS recovery separately
- send group-thread replies directly without an extra confirmation dialog
- synchronize Textual message assertions with child-widget mounting

## Tests

- Arch package-style test split: 612 passed, then 3 passed
- `ruff check .`
- `mypy src/blueferry`
- Qt QML lint
- `git diff --check`