### PR TITLE
Release BlueFerry 0.7.1

### DIFF
--- a/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
@@ -40,6 +40,13 @@
   </developer>
 
   <releases>
+    <release version="0.7.1" date="2026-08-15">
+      <description>
+        <p>Improves cross-distro pairing and privileged setup, makes controller
+        capability checks advisory, and polishes Qt startup, connection health,
+        and group messaging.</p>
+      </description>
+    </release>
     <release version="0.7.0" date="2026-08-14">
       <description>
         <p>Adds native Linux packages, compatibility and explicit pairing

--- a/data/io.weirdware.BlueFerry.Qt.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Qt.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.7.1" date="2026-08-15"><description><p>Improves cross-distro pairing and privileged setup, makes controller capability checks advisory, and polishes Qt startup, connection health, and group messaging.</p></description></release>
     <release version="0.7.0" date="2026-08-14"><description><p>Adds native Linux packages, compatibility and explicit pairing modes, build-aware daemon restarts, and ANCS recovery after BlueZ restarts.</p></description></release>
     <release version="0.6.3" date="2026-08-13"><description><p>Lets you pick a Bluetooth controller when more than one is present and keeps pairing, scanning, and forget on that radio.</p></description></release>
     <release version="0.6.2" date="2026-08-10"><description><p>Improves interactive Bluetooth pairing, diagnostics, and forgotten-device handling.</p></description></release>

--- a/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.7.1" date="2026-08-15"><description><p>Improves cross-distro pairing and privileged setup, makes controller capability checks advisory, and polishes Qt startup, connection health, and group messaging.</p></description></release>
     <release version="0.7.0" date="2026-08-14"><description><p>Adds native Linux packages, compatibility and explicit pairing modes, build-aware daemon restarts, and ANCS recovery after BlueZ restarts.</p></description></release>
     <release version="0.6.3" date="2026-08-13"><description><p>Lets you pick a Bluetooth controller when more than one is present and keeps pairing, scanning, and forget on that radio.</p></description></release>
     <release version="0.6.2" date="2026-08-10"><description><p>Improves interactive Bluetooth pairing, diagnostics, and forgotten-device handling.</p></description></release>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   blueferry-qt
   blueferry-quickshell
 )
-pkgver=0.7.0
+pkgver=0.7.1
 pkgrel=1
 pkgdesc='BlueFerry Bluetooth bridge from iPhone to Linux'
 arch=('any')

--- a/packaging/deb/changelog
+++ b/packaging/deb/changelog
@@ -1,3 +1,13 @@
+blueferry (0.7.1-1) unstable; urgency=medium
+
+  * Make controller capability checks advisory and fix D-Bus advertisement
+    typing.
+  * Use packaged systemd units for privileged Bluetooth setup.
+  * Remove Qt startup warnings and polish connection health and group messaging.
+  * Repair tagged release publication.
+
+ -- BlueFerry Contributors <blueferry@weirdware.io>  Sat, 15 Aug 2026 00:00:00 -0400
+
 blueferry (0.7.0-1) unstable; urgency=medium
 
   * Add native packages for supported Arch, Debian, and Fedora systems.

--- a/packaging/rpm/blueferry.spec
+++ b/packaging/rpm/blueferry.spec
@@ -1,5 +1,5 @@
 Name:           blueferry-backend
-Version:        0.7.0
+Version:        0.7.1
 Release:        1%{?dist}
 Summary:        iPhone Bluetooth bridge backend, daemon, and CLI
 License:        GPL-2.0-only AND MIT AND BSD-2-Clause AND PSF-2.0
@@ -192,6 +192,12 @@ fi
 %{_metainfodir}/io.weirdware.BlueFerry.Qt.metainfo.xml
 
 %changelog
+* Sat Aug 15 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.1-1
+- Make controller capability checks advisory and fix D-Bus advertisement typing.
+- Use packaged systemd units for privileged Bluetooth setup.
+- Remove Qt startup warnings and polish connection health and group messaging.
+- Repair tagged release publication.
+
 * Fri Aug 14 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.0-1
 - Add native packages for supported Arch, Debian, and Fedora systems.
 - Add compatibility and explicit iPhone pairing modes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueferry"
-version = "0.7.0"
+version = "0.7.1"
 description = "BlueFerry brings iPhone messages, notifications, and contacts to Linux"
 authors = [
   {name = "Erik Bourget", email = "erik@ebourget.net"},

--- a/src/blueferry/__init__.py
+++ b/src/blueferry/__init__.py
@@ -1,3 +1,3 @@
 """BlueFerry — Bluetooth bridge from a paired iPhone to Linux desktop."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"


### PR DESCRIPTION
## Summary

- bump Python, Arch, Debian, and RPM versions to 0.7.1
- add 0.7.1 AppStream release entries for all graphical clients
- refresh Debian and RPM changelogs for the post-0.7.0 fixes

## Release highlights

- make controller capability checks advisory and fix D-Bus advertisement typing
- use packaged systemd units for privileged Bluetooth setup
- remove Qt startup warnings and polish connection health and group messaging
- repair tagged release publication

## Verification

- 615 tests passed under the hermetic D-Bus test session
- `ruff check .`
- Bandit
- `mypy src/blueferry`
- native packaging version tests
- AppStream and desktop-file validation
- `git diff --check`