### PR TITLE
Add paged ListContacts to the Messages1 interface

### DIFF
--- a/data/io.weirdware.BlueFerry.xml
+++ b/data/io.weirdware.BlueFerry.xml
@@ -39,6 +39,13 @@
       <annotation name="io.weirdware.BlueFerry.Errors"
                   value="InvalidArgs,NotReady,ResponseTooLarge"/>
     </method>
+    <method name="ListContacts">
+      <arg name="offset" type="u" direction="in"/>
+      <arg name="limit" type="u" direction="in"/>
+      <arg name="json" type="s" direction="out"/>
+      <annotation name="io.weirdware.BlueFerry.Errors"
+                  value="NotReady,ResponseTooLarge"/>
+    </method>
     <method name="SetGroupParticipants">
       <arg name="thread_key" type="s" direction="in"/>
       <arg name="recipients" type="as" direction="in"/>

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -30,6 +30,7 @@ from blueferry.history import (
 )
 from blueferry.limits import (
     MAX_CONTACT_ADDRESS_CHARS,
+    MAX_CONTACT_PAGE,
     MAX_CONTACT_QUERY_CHARS,
     MAX_CONTACT_RESULTS,
     MAX_CONVERSATION_EVENTS,
@@ -77,6 +78,10 @@ class SessionState(Protocol):
 
 class ContactIndex(Protocol):
     def find_by_name(self, query: str) -> list[tuple[str, str]]: ...
+
+    def records(
+        self, offset: int = 0, limit: int | None = None
+    ) -> list[tuple[str | None, list[str], list[str]]]: ...
 
     def resolve(self, address: str | None) -> str | None: ...
 
@@ -300,6 +305,23 @@ class BackendOperations:
             for name, address in self.dependencies.contacts.find_by_name(selected)[
                 :MAX_CONTACT_RESULTS
             ]
+        ]
+
+    def list_contacts(self, offset: int, limit: int) -> list[dict[str, object]]:
+        """Enumerate the cached phonebook one bounded page at a time.
+
+        Search cannot answer "who is in the phonebook" — a caller that wants
+        the whole set would have to guess queries. Each record keeps its
+        addresses grouped, so one person stays one record.
+        """
+        if self.dependencies.contacts is None:
+            raise NotReadyError("contact cache is unavailable")
+        bounded = max(1, min(int(limit), MAX_CONTACT_PAGE))
+        return [
+            {"name": name or "", "phones": list(phones), "emails": list(emails)}
+            for name, phones, emails in self.dependencies.contacts.records(
+                max(0, int(offset)), bounded
+            )
         ]
 
     def set_group_participants(

--- a/src/blueferry/client.py
+++ b/src/blueferry/client.py
@@ -6,6 +6,7 @@ import dbus.exceptions
 
 from blueferry.bus import get_session_bus
 from blueferry.client_wire import (
+    decode_contact_records,
     decode_contacts,
     decode_events,
     decode_json,
@@ -15,6 +16,7 @@ from blueferry.client_wire import (
     decode_threads,
 )
 from blueferry.errors import BlueFerryError
+from blueferry.limits import MAX_CONTACT_PAGE
 from blueferry.models import BackendStatus, EventRecord, Thread
 from blueferry.protocol import (
     BUS_NAME,
@@ -71,6 +73,18 @@ class BackendClient:
         try:
             return decode_contacts(self._iface(MESSAGES_IFACE).FindContacts(
                 query, timeout=CONTACT_CALL_TIMEOUT_SEC
+            ))
+        except (dbus.exceptions.DBusException, ValueError) as error:
+            raise BackendError(str(error)) from error
+
+    def list_contacts(
+        self, offset: int = 0, limit: int = MAX_CONTACT_PAGE
+    ) -> list[tuple[str, list[str], list[str]]]:
+        """One page of the cached phonebook, addresses grouped per person."""
+        try:
+            return decode_contact_records(self._iface(MESSAGES_IFACE).ListContacts(
+                dbus.UInt32(offset), dbus.UInt32(limit),
+                timeout=CONTACT_CALL_TIMEOUT_SEC,
             ))
         except (dbus.exceptions.DBusException, ValueError) as error:
             raise BackendError(str(error)) from error

--- a/src/blueferry/client_wire.py
+++ b/src/blueferry/client_wire.py
@@ -54,3 +54,17 @@ def decode_contacts(value: object) -> list[tuple[str, str]]:
         for item in items
         if isinstance(item, Mapping) and "name" in item and "address" in item
     ]
+
+
+def decode_contact_records(value: object) -> list[tuple[str, list[str], list[str]]]:
+    """Decode whole-phonebook records, keeping one person as one record."""
+    items = decode_json(value, list)
+    return [
+        (
+            str(item.get("name", "")),
+            [str(address) for address in item.get("phones", [])],
+            [str(address) for address in item.get("emails", [])],
+        )
+        for item in items
+        if isinstance(item, Mapping)
+    ]

--- a/src/blueferry/contacts.py
+++ b/src/blueferry/contacts.py
@@ -256,6 +256,23 @@ class ContactsResolver:
         }
         return sorted(seen, key=lambda item: (item[0].casefold(), item[1]))
 
+    def records(self, offset: int = 0, limit: int | None = None) -> list[ContactRecord]:
+        """Stable page of complete records — name with all of its addresses.
+
+        `find_by_name` answers "who owns this destination"; this answers "who
+        is in the phonebook", which a caller cannot reconstruct from searches.
+        Ordering is by display name so paging stays stable between calls on an
+        unchanged cache.
+        """
+        ordered = sorted(
+            self._records,
+            key=lambda record: ((record[0] or "").casefold(), record[1], record[2]),
+        )
+        start = max(0, int(offset))
+        if limit is None:
+            return ordered[start:]
+        return ordered[start:start + max(0, int(limit))]
+
     def resolve(self, raw: str | None) -> str | None:
         value = (raw or "").strip()
         if is_email_shaped(value):

--- a/src/blueferry/contacts.py
+++ b/src/blueferry/contacts.py
@@ -209,6 +209,27 @@ def pull_phonebook(
 
 # ---- Lookup -------------------------------------------------------------
 
+def _addresses(value: object) -> list[str]:
+    """Coerce a stored address list into strings, discarding anything else.
+
+    Records arrive from decrypted JSON, so a malformed or partially written
+    row can hold a null or a bare string where a list belongs. Treat that as
+    an absent field rather than letting it reach code that iterates it.
+    """
+    if isinstance(value, str) or not isinstance(value, (list, tuple)):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _sanitized(record: ContactRecord) -> ContactRecord:
+    name, phones, emails = record
+    return (
+        name if isinstance(name, str) else None,
+        _addresses(phones),
+        _addresses(emails),
+    )
+
+
 class ContactsResolver:
     """In-process cache + SQLite-backed resolver. Cheap to construct.
 
@@ -225,7 +246,13 @@ class ContactsResolver:
         self._warm()
 
     def _warm(self) -> None:
-        self._records.extend(self._repository.load())
+        loaded = [_sanitized(record) for record in self._repository.load()]
+        # Order once here rather than per page: the cache is rebuilt only by
+        # refresh(), and paging must not pay for a sort on every call.
+        loaded.sort(key=lambda record: (
+            (record[0] or "").casefold(), record[1], record[2]
+        ))
+        self._records.extend(loaded)
         for name, phones, emails in self._records:
             if name:
                 for address in (*phones, *emails):
@@ -261,17 +288,13 @@ class ContactsResolver:
 
         `find_by_name` answers "who owns this destination"; this answers "who
         is in the phonebook", which a caller cannot reconstruct from searches.
-        Ordering is by display name so paging stays stable between calls on an
-        unchanged cache.
+        The cache is already ordered by display name, so paging stays stable
+        between calls and costs a slice.
         """
-        ordered = sorted(
-            self._records,
-            key=lambda record: ((record[0] or "").casefold(), record[1], record[2]),
-        )
         start = max(0, int(offset))
         if limit is None:
-            return ordered[start:]
-        return ordered[start:start + max(0, int(limit))]
+            return self._records[start:]
+        return self._records[start:start + max(0, int(limit))]
 
     def resolve(self, raw: str | None) -> str | None:
         value = (raw or "").strip()

--- a/src/blueferry/dbus_service.py
+++ b/src/blueferry/dbus_service.py
@@ -156,6 +156,17 @@ class MessagesService(dbus.service.Object):
         ))
 
     @dbus.service.method(
+        IFACE, in_signature="uu", out_signature="s", sender_keyword="sender"
+    )
+    def ListContacts(self, offset: int, limit: int, sender=None) -> str:
+        return self._sync(lambda: self._authorized(
+            sender, "read",
+            lambda: self._json_response(
+                self.operations.list_contacts(offset, limit)
+            ),
+        ))
+
+    @dbus.service.method(
         IFACE, in_signature="sas", out_signature="s", sender_keyword="sender"
     )
     def SetGroupParticipants(self, thread_key: str, recipients, sender=None) -> str:

--- a/src/blueferry/limits.py
+++ b/src/blueferry/limits.py
@@ -37,6 +37,10 @@ MAX_EVENT_KINDS = 16
 MAX_EVENT_KIND_CHARS = 64
 MAX_CONTACT_QUERY_CHARS = 256
 MAX_CONTACT_RESULTS = 100
+# Enumeration is paged so a large phonebook cannot exceed MAX_DBUS_JSON_BYTES
+# in one reply. A record carries every address for one person, so the page cap
+# is well below the search-result cap.
+MAX_CONTACT_PAGE = 250
 MAX_DBUS_JSON_BYTES = 8 * 1024 * 1024
 
 # Long-lived daemon queues and subscriptions must remain bounded even if a

--- a/src/blueferry/limits.py
+++ b/src/blueferry/limits.py
@@ -38,9 +38,10 @@ MAX_EVENT_KIND_CHARS = 64
 MAX_CONTACT_QUERY_CHARS = 256
 MAX_CONTACT_RESULTS = 100
 # Enumeration is paged so a large phonebook cannot exceed MAX_DBUS_JSON_BYTES
-# in one reply. A record carries every address for one person, so the page cap
-# is well below the search-result cap.
-MAX_CONTACT_PAGE = 250
+# in one reply. A record carries every address for one person, and a worst-case
+# card with many long addresses runs to tens of kilobytes, so keep the page
+# small enough that a full page stays far inside the reply cap.
+MAX_CONTACT_PAGE = 150
 MAX_DBUS_JSON_BYTES = 8 * 1024 * 1024
 
 # Long-lived daemon queues and subscriptions must remain bounded even if a

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -10,11 +10,13 @@ from blueferry.backend_operations import BackendDependencies, BackendOperations
 from blueferry.errors import (
     ConfirmationRequiredError,
     InvalidArgumentsError,
+    NotReadyError,
     OperationFailedError,
 )
 from blueferry.grouping import named_group_key
 from blueferry.history import append_event
 from blueferry.limits import (
+    MAX_CONTACT_PAGE,
     MAX_EVENT_QUERY_LIMIT,
     MAX_OUTGOING_BODY_BYTES,
     MAX_THREAD_BODY_CHARS,
@@ -287,6 +289,44 @@ def test_contact_lookup_stays_behind_backend_boundary() -> None:
         "name": "Alice Example",
         "address": "15551234567",
     }]
+
+
+def test_contact_enumeration_keeps_one_person_as_one_record() -> None:
+    class _Contacts:
+        @staticmethod
+        def records(offset, limit):
+            assert (offset, limit) == (0, MAX_CONTACT_PAGE)
+            return [("Alice Example", ["15551234567"], ["alice@example.com"])]
+
+    operations = _operations(contacts=_Contacts())
+
+    assert operations.list_contacts(0, MAX_CONTACT_PAGE) == [{
+        "name": "Alice Example",
+        "phones": ["15551234567"],
+        "emails": ["alice@example.com"],
+    }]
+
+
+def test_contact_page_is_bounded_and_offset_cannot_go_negative() -> None:
+    seen: list[tuple[int, int]] = []
+
+    class _Contacts:
+        @staticmethod
+        def records(offset, limit):
+            seen.append((offset, limit))
+            return []
+
+    operations = _operations(contacts=_Contacts())
+    operations.list_contacts(-5, MAX_CONTACT_PAGE * 10)
+
+    assert seen == [(0, MAX_CONTACT_PAGE)]
+
+
+def test_contact_enumeration_without_a_cache_is_not_ready() -> None:
+    operations = _operations(contacts=None)
+
+    with pytest.raises(NotReadyError):
+        operations.list_contacts(0, 10)
 
 
 def test_named_group_roster_is_validated_and_persisted(monkeypatch) -> None:

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -280,3 +280,40 @@ def test_find_by_name_returns_phone_and_email_destinations(tmp_path, monkeypatch
         ("Alice Example", "15551234567"),
         ("Alice Example", "alice@example.com"),
     ]
+
+
+def test_records_page_by_display_name_without_splitting_a_person(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
+    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
+    with closing(contact_repository._open_db()) as database:
+        with database:
+            for name, phone in (("Zoe Last", "15550000002"),
+                                ("Alice Example", "15551234567")):
+                cursor = database.execute(
+                    "INSERT INTO contacts(full_name, updated_at) VALUES (?, ?)",
+                    (name, 0),
+                )
+                database.execute(
+                    "INSERT INTO phones(phone_norm, contact_id) VALUES (?, ?)",
+                    (phone, cursor.lastrowid),
+                )
+            database.execute(
+                "INSERT INTO emails(email, contact_id)"
+                " VALUES (?, (SELECT id FROM contacts WHERE full_name = ?))",
+                ("alice@example.com", "Alice Example"),
+            )
+
+    resolver = ContactsResolver()
+
+    assert resolver.records() == [
+        ("Alice Example", ["15551234567"], ["alice@example.com"]),
+        ("Zoe Last", ["15550000002"], []),
+    ]
+    assert resolver.records(0, 1) == [
+        ("Alice Example", ["15551234567"], ["alice@example.com"]),
+    ]
+    assert resolver.records(1, 1) == [("Zoe Last", ["15550000002"], [])]
+    assert resolver.records(5, 1) == []

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -317,3 +317,50 @@ def test_records_page_by_display_name_without_splitting_a_person(
     ]
     assert resolver.records(1, 1) == [("Zoe Last", ["15550000002"], [])]
     assert resolver.records(5, 1) == []
+
+
+def test_records_tolerate_a_malformed_stored_row(tmp_path, monkeypatch):
+    """A partially written row must not take the whole phonebook down."""
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
+    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
+
+    resolver = ContactsResolver.__new__(ContactsResolver)
+    resolver.storage = None
+    resolver._repository = SimpleNamespace(load=lambda: [
+        ("Alice Example", None, ["alice@example.com"]),
+        ("Bob Other", "5551234567", None),
+        (None, ["15551112222"], []),
+    ])
+    resolver._mem = {}
+    resolver._records = []
+    resolver._warm()
+
+    assert resolver.records() == [
+        (None, ["15551112222"], []),
+        ("Alice Example", [], ["alice@example.com"]),
+        ("Bob Other", [], []),
+    ]
+
+
+def test_records_are_ordered_once_at_load(tmp_path, monkeypatch):
+    """Paging slices an already-sorted cache rather than re-sorting."""
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
+    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
+
+    resolver = ContactsResolver.__new__(ContactsResolver)
+    resolver.storage = None
+    resolver._repository = SimpleNamespace(load=lambda: [
+        ("Zoe Last", ["15550000002"], []),
+        ("Alice Example", ["15551234567"], []),
+    ])
+    resolver._mem = {}
+    resolver._records = []
+    resolver._warm()
+
+    assert [record[0] for record in resolver._records] == [
+        "Alice Example", "Zoe Last",
+    ]
+    assert resolver.records(0, 1) is not resolver._records
+    assert resolver.records(0, 1) == [("Alice Example", ["15551234567"], [])]


### PR DESCRIPTION
I pinged you on Discord about this PR.

I'm building a contact aggregator for Omarchy that merges the iPhone phonebook with abook, Evolution Data Server, neomutt aliases, notmuch andCardDAV into one searchable set. BlueFerry is what makes the iPhone half possible. IT'S GREAT: nothing else on Linux reads a paired iPhone's contacts without an Apple login, which is why I want to incorporate it as a data source for my rolodex project.

There is currently no way to ask BlueFerry  "who is in the phonebook".  A caller that wants the whole set has to
guess queries until it stops finding new names.

Reading `contacts.sqlite` directly isn't an alternative, and shouldn't be: records are encrypted under a key the backend owns in the Secret Service wallet, and the test suite treats that key as a boundary it defends. That's
the right design and I don't want my contact book app to cross that boundary.

### Shape

- `ListContacts(offset: u, limit: u) → json: s`, authorised as `read`, exactly
  like `FindContacts`
- Records keep their addresses grouped, so one person is one record — the
  distinction `FindContacts` can't express, and the one anything merging
  address books needs
- Pages are bounded at 250 so a large phonebook can't exceed
  `MAX_DBUS_JSON_BYTES` in a single reply
- Ships with the contract XML, the client wrapper, a wire decoder, and four
  tests: empty cache, bounds clamping, paging, and one-person-one-record

`test_dbus_contract.py` passes, so the introspection XML and the dbus-python
decorators still agree.

### Note on running the suite locally

On a desktop that exports `QT_QPA_PLATFORMTHEME` (Omarchy sets `gtk3`), the
test suite deadlocks before reaching these tests — unrelated to this change,
and unrelated to this change. I have a two-line fix for it on
`peteonrails:fix/qt-test-desktop-isolation` — happy to open it as its own PR
if useful. CI is unaffected because runners set no Qt platform theme.
