### PR TITLE
Drop the desktop Qt theme plugin in the test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,15 @@ if not _running_private_suite:
     os.environ["DBUS_SESSION_BUS_ADDRESS"] = _unreachable_bus
     os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = _unreachable_bus
 
+# Qt tests must not adopt the operator's desktop. A platform theme plugin is
+# the dangerous one: QT_QPA_PLATFORMTHEME=gtk3 pulls GTK3 into a process where
+# the GTK4 client tests have already initialized gi, and the two GLib
+# thread-default context stacks deadlock the suite. Force a headless platform
+# and no theme plugin before any test module can import PySide6.
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+os.environ.pop("QT_QPA_PLATFORMTHEME", None)
+os.environ.pop("QT_STYLE_OVERRIDE", None)
+
 
 def _forbid_live_bus(kind: str):
     def forbidden(*_args, **_kwargs):


### PR DESCRIPTION
Rebased onto 0.7.1. The `setdefault` half of this is already fixed there, so
what's left is one line in `conftest.py`.

Forcing `QT_QPA_PLATFORM=offscreen` isn't sufficient on its own. Qt loads the
platform *theme* plugin regardless of the platform, so on a desktop exporting
`QT_QPA_PLATFORMTHEME=gtk3` (Omarchy sets this session-wide) Qt pulls GTK3
into a process where the GTK4 client tests have already initialized gi. The
two GLib thread-default context stacks deadlock. I confirmed this by setting
only the platform and watching it still hang.

With the theme plugin dropped, the whole suite runs in one process:

```
python -m pytest -q
615 passed, 31 warnings in 6.05s
```

That includes `tests/test_qml_presenters.py` alongside the GTK tests, so the
split invocation added to `check()` in 0.7.1 should no longer be needed. That
would also put the QML tests back under `coverage run`, which currently only
wraps the first invocation. I left `check()` alone here since it's your call
whether to trust this on other desktops.
