### PR TITLE
Validate contact records at data boundaries

### DIFF
--- a/src/blueferry/client_wire.py
+++ b/src/blueferry/client_wire.py
@@ -10,6 +10,11 @@ import json
 from collections.abc import Mapping
 from typing import Any, TypeVar, cast
 
+from blueferry.limits import (
+    MAX_CONTACT_ADDRESS_CHARS,
+    MAX_CONTACT_ADDRESSES_PER_CARD,
+    MAX_CONTACT_NAME_CHARS,
+)
 from blueferry.models import BackendStatus, EventRecord, Thread
 
 T = TypeVar("T")
@@ -56,14 +61,29 @@ def decode_contacts(value: object) -> list[tuple[str, str]]:
     ]
 
 
+def _decode_contact_addresses(value: object) -> list[str]:
+    if not isinstance(value, list | tuple):
+        return []
+    return [
+        address
+        for address in value[:MAX_CONTACT_ADDRESSES_PER_CARD]
+        if isinstance(address, str)
+        and len(address) <= MAX_CONTACT_ADDRESS_CHARS
+    ]
+
+
+def _decode_contact_name(value: object) -> str:
+    return value[:MAX_CONTACT_NAME_CHARS] if isinstance(value, str) else ""
+
+
 def decode_contact_records(value: object) -> list[tuple[str, list[str], list[str]]]:
     """Decode whole-phonebook records, keeping one person as one record."""
     items = decode_json(value, list)
     return [
         (
-            str(item.get("name", "")),
-            [str(address) for address in item.get("phones", [])],
-            [str(address) for address in item.get("emails", [])],
+            _decode_contact_name(item.get("name")),
+            _decode_contact_addresses(item.get("phones")),
+            _decode_contact_addresses(item.get("emails")),
         )
         for item in items
         if isinstance(item, Mapping)

--- a/src/blueferry/contact_repository.py
+++ b/src/blueferry/contact_repository.py
@@ -16,6 +16,7 @@ from blueferry import config
 from blueferry.events import is_email_shaped
 from blueferry.limits import (
     MAX_CONTACT_ADDRESS_CHARS,
+    MAX_CONTACT_ADDRESSES_PER_CARD,
     MAX_CONTACT_NAME_CHARS,
     MAX_PHONEBOOK_CONTACTS,
 )
@@ -50,6 +51,13 @@ CREATE TABLE IF NOT EXISTS secure_contacts (
     payload      TEXT NOT NULL
 );
 """
+
+
+def _stored_address_items(value: object) -> list[object] | tuple[object, ...]:
+    """Return one bounded stored collection without iterating scalar values."""
+    if not isinstance(value, list | tuple):
+        return []
+    return value[:MAX_CONTACT_ADDRESSES_PER_CARD]
 
 
 def _open_db() -> sqlite3.Connection:
@@ -172,14 +180,20 @@ class ContactRepository:
                 value = json.loads(plaintext)
                 if not isinstance(value, dict):
                     continue
-                name = str(value.get("name") or "")[:MAX_CONTACT_NAME_CHARS]
+                raw_name = value.get("name")
+                name = (
+                    raw_name[:MAX_CONTACT_NAME_CHARS]
+                    if isinstance(raw_name, str)
+                    else ""
+                )
                 phones = [
-                    str(item) for item in value.get("phones", [])
+                    item for item in _stored_address_items(value.get("phones"))
                     if isinstance(item, str)
                     and len(item) <= MAX_CONTACT_ADDRESS_CHARS
                 ]
                 emails = [
-                    str(item).casefold() for item in value.get("emails", [])
+                    item.casefold()
+                    for item in _stored_address_items(value.get("emails"))
                     if isinstance(item, str)
                     and len(item) <= MAX_CONTACT_ADDRESS_CHARS
                     and is_email_shaped(item)

--- a/tests/test_client_models.py
+++ b/tests/test_client_models.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from blueferry.client import BackendClient, BackendError
+from blueferry.limits import MAX_CONTACT_ADDRESSES_PER_CARD
 from blueferry.models import BackendStatus, EventRecord, Thread
 
 
@@ -24,6 +25,13 @@ class _Messages:
 
     def ListEvents(self, *_args, **_kwargs):
         return json.dumps([{"kind": "ancs_notification", "title": "Test"}])
+
+    def ListContacts(self, *_args, **_kwargs):
+        return json.dumps([{
+            "name": "Alice Example",
+            "phones": ["15551234567"],
+            "emails": ["alice@example.com"],
+        }])
 
     def GetNotificationPolicy(self, **_kwargs):
         return "messages"
@@ -52,6 +60,9 @@ def test_backend_client_returns_shared_models(monkeypatch):
     assert client.threads()[0].recipients == ("test@example.com",)
     assert isinstance(client.events([])[0], EventRecord)
     assert client.events([])[0].title == "Test"
+    assert client.list_contacts() == [
+        ("Alice Example", ["15551234567"], ["alice@example.com"]),
+    ]
     assert client.notification_policy() == "messages"
     assert client.set_notification_policy("none") == "none"
     group = client.set_group_participants(
@@ -69,6 +80,39 @@ def test_backend_client_rejects_wrong_json_shape(monkeypatch):
 
     with pytest.raises(BackendError, match="expected dict"):
         client.status()
+
+
+def test_backend_client_discards_malformed_contact_address_collections(
+    monkeypatch,
+) -> None:
+    client = BackendClient()
+    messages = _Messages()
+    monkeypatch.setattr(messages, "ListContacts", lambda *_args, **_kwargs: json.dumps([
+        {"name": "Alice", "phones": None, "emails": "alice@example.com"},
+        {
+            "name": "Bob",
+            "phones": ["15551234567", None, 42],
+            "emails": ["bob@example.com", {"address": "wrong shape"}],
+        },
+        {
+            "name": None,
+            "phones": [str(index) for index in range(
+                MAX_CONTACT_ADDRESSES_PER_CARD + 1
+            )],
+            "emails": [],
+        },
+    ]))
+    monkeypatch.setattr(client, "_iface", lambda _name: messages)
+
+    assert client.list_contacts() == [
+        ("Alice", [], []),
+        ("Bob", ["15551234567"], ["bob@example.com"]),
+        (
+            "",
+            [str(index) for index in range(MAX_CONTACT_ADDRESSES_PER_CARD)],
+            [],
+        ),
+    ]
 
 
 def test_status_model_normalizes_legacy_map_refusal_detail() -> None:

--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -18,6 +18,7 @@ from blueferry.history import (
     read_events,
     scrub_unprotected_events,
 )
+from blueferry.limits import MAX_CONTACT_ADDRESSES_PER_CARD
 from blueferry.settings_store import SettingsStore
 from blueferry.storage_security import (
     CorruptStorageError,
@@ -389,6 +390,50 @@ def test_plaintext_secure_contact_record_fails_closed(
     assert resolver.resolve("+1 555 123 4567") is None
     assert resolver.find_by_name("alice") == []
     assert storage.status.state == "error"
+
+
+def test_encrypted_contact_record_bounds_and_validates_address_lists(
+    tmp_path, monkeypatch,
+) -> None:
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
+    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
+    storage = _storage(tmp_path)
+    records = [
+        {"name": "Alice", "phones": "15551234567", "emails": None},
+        {
+            "name": "Bob",
+            "phones": ["15557654321", None, 42],
+            "emails": ["BOB@example.com", {"address": "wrong shape"}],
+        },
+        {
+            "name": None,
+            "phones": [str(index) for index in range(
+                MAX_CONTACT_ADDRESSES_PER_CARD + 1
+            )],
+            "emails": [],
+        },
+    ]
+    with closing(contact_repository._open_db()) as database, database:
+        for record in records:
+            database.execute(
+                "INSERT INTO secure_contacts(payload) VALUES (?)",
+                (storage.encrypt(
+                    json.dumps(record), purpose="contact-record-v1"
+                ),),
+            )
+
+    resolver = ContactsResolver(storage=storage)
+
+    assert resolver.records() == [
+        (
+            "",
+            [str(index) for index in range(MAX_CONTACT_ADDRESSES_PER_CARD)],
+            [],
+        ),
+        ("Alice", [], []),
+        ("Bob", ["15557654321"], ["bob@example.com"]),
+    ]
 
 
 def test_unencrypted_policy_reads_plaintext_contact_records(


### PR DESCRIPTION
## Summary

- validate encrypted contact address fields before iterating them
- bound stored and decoded address collections to the existing per-card limits
- discard malformed scalar and non-string values in D-Bus contact records
- cover authenticated malformed storage and public client decoding paths

## Validation

- 624 tests passed in the hermetic D-Bus suite
- Ruff
- mypy
- Bandit
- QML lint
- git diff --check