### PR TITLE
Fix btmgmt helper under systemd

### DIFF
--- a/systemd/blueferry-btmgmt-set-class@.service
+++ b/systemd/blueferry-btmgmt-set-class@.service
@@ -3,4 +3,6 @@ Description=BlueFerry set Bluetooth adapter hci%i class with btmgmt
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/btmgmt --index %i class 4 8
+# BlueZ 5.72 requires pollable stdin even for non-interactive commands. Give
+# btmgmt an empty pipe because systemd otherwise connects stdin to /dev/null.
+ExecStart=/bin/sh -c ': | /usr/bin/btmgmt --index "$1" class 4 8' blueferry %i

--- a/tests/test_native_packaging.py
+++ b/tests/test_native_packaging.py
@@ -133,7 +133,10 @@ def test_native_backends_ship_the_btmgmt_system_unit_template() -> None:
     spec = (ROOT / "packaging/rpm/blueferry.spec").read_text()
 
     assert "Type=oneshot" in unit
-    assert "ExecStart=/usr/bin/btmgmt --index %i class 4 8" in unit
+    assert (
+        "ExecStart=/bin/sh -c ': | /usr/bin/btmgmt --index \"$1\" class 4 8' "
+        "blueferry %i"
+    ) in unit
     assert "[Install]" not in unit
     assert f"systemd/{unit_name}" in deb_rules
     assert f"usr/lib/systemd/system/{unit_name}" in deb_install


### PR DESCRIPTION
## Summary

- feed `btmgmt` an empty pipe when the privileged systemd unit runs it
- preserve the exact invocation in the native-packaging regression test

BlueZ 5.72 attaches stdin before dispatching non-interactive commands. Under
systemd, stdin is `/dev/null`, which is not pollable; `btmgmt` ignores the
failed attachment and waits in its event loop until BlueFerry's 120-second
timeout. An empty pipe gives it pollable stdin without changing the requested
management command.

Addresses #46.

## Testing

- `python -m pytest -q` — 612 passed, 3 skipped
- `systemd-analyze verify --man=no systemd/blueferry-btmgmt-set-class@.service`
- Linux Mint 22.3 VM with the 0.7.1 packages: the original unit hung; the
  patched unit returned the expected `Invalid Index` error in 0.012 seconds
  with no leftover `btmgmt` process
