### PR TITLE
Recover ANCS after LE reconnects

### DIFF
--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -93,6 +93,12 @@ def _char_path_to_device_path(char_path: str) -> str:
     return "/".join(char_path.rsplit("/", 2)[:-2])
 
 
+def _connection_was_lost(error: dbus.exceptions.DBusException) -> bool:
+    name = (error.get_dbus_name() or "").casefold()
+    detail = (error.get_dbus_message() or str(error)).casefold()
+    return name.endswith(".notconnected") or "not connected" in detail
+
+
 class AncsClient:
     """Tracks ANCS characteristics under one target device and subscribes
     when all three are present.
@@ -126,6 +132,8 @@ class AncsClient:
         self._cp_path: str | None = None
         self._notify_started = False
         self._authorized = False
+        self._bearer_connected: bool | None = None
+        self._reset_notify_on_reconnect = False
 
         # In-flight per-notification attribute requests + app-name cache
         self._app_name_cache: OrderedDict[str, str] = OrderedDict()
@@ -247,6 +255,7 @@ class AncsClient:
             self._remove_manager_watches()
             self._cancel_subscribe_retry()
             self._clear_characteristic_subscription(stop_notify=False)
+            self._reset_notify_on_reconnect = False
             self._ns_path = self._ds_path = self._cp_path = None
 
     def _remove_manager_watches(self) -> None:
@@ -278,6 +287,7 @@ class AncsClient:
             self._remove_manager_watches()
             self._cancel_subscribe_retry()
             self._clear_characteristic_subscription(stop_notify=False)
+            self._reset_notify_on_reconnect = False
             self._ns_path = self._ds_path = self._cp_path = None
             if was_connected and self.on_status is not None:
                 self.on_status()
@@ -341,7 +351,52 @@ class AncsClient:
         # StartNotify only proves that BlueZ subscribed to the GATT
         # characteristics. iOS notification access is usable only after an
         # authorized Control Point round trip succeeds.
-        return self.subscribed and self.authorized
+        return (
+            self._bearer_connected is not False
+            and self.subscribed
+            and self.authorized
+        )
+
+    def observe_bearer_state(self, connected: bool | None) -> None:
+        """Invalidate stale GATT state and rebuild it after an LE reconnect.
+
+        BlueZ retains ANCS characteristic objects, and sometimes their
+        ``Notifying`` property, across a physical LE disconnect. ObjectManager
+        removal alone therefore cannot define the subscription lifecycle.
+        """
+        if connected is None:
+            return
+        previous = self._bearer_connected
+        self._bearer_connected = connected
+        if not connected:
+            had_state = bool(
+                self._notify_started
+                or self._authorized
+                or self._characteristic_signal_matches
+                or self._active_request is not None
+                or self._request_queue
+            )
+            if not had_state:
+                return
+            log.info("iPhone LE bearer disconnected; resetting ANCS subscription")
+            self._reset_notify_on_reconnect = self._notify_started
+            self._cancel_subscribe_retry()
+            # StopNotify can block or fail while the ATT link is down. Remove
+            # our local receivers now and replace BlueZ's registration once
+            # the bearer is observably connected again.
+            self._clear_characteristic_subscription(stop_notify=False)
+            if self.on_status is not None:
+                self.on_status()
+            return
+
+        if previous is False and self._reset_notify_on_reconnect:
+            log.info("iPhone LE bearer reconnected; rebuilding ANCS subscription")
+            self._stop_bluez_notifications()
+            self._reset_notify_on_reconnect = False
+        # This is intentionally safe on every bearer poll. It also recovers a
+        # Control Point failure when the disconnect was too brief for the
+        # bearer supervisor itself to observe a state transition.
+        self._try_subscribe()
 
     def stop(self) -> None:
         log.info("ANCS client stopping")
@@ -396,6 +451,7 @@ class AncsClient:
                 self._cancel_subscribe_retry()
                 self._cancel_authorization_retry()
                 self._clear_characteristic_subscription()
+                self._reset_notify_on_reconnect = False
                 log.warning("ANCS char gone: %s", path_s)
                 if was_connected and self.on_status is not None:
                     self.on_status()
@@ -411,21 +467,28 @@ class AncsClient:
                 log.debug("could not remove ANCS characteristic watch", exc_info=True)
         self._characteristic_signal_matches = []
         if self._notify_started and stop_notify:
-            for path in (self._ns_path, self._ds_path):
-                if path:
-                    try:
-                        dbus.Interface(
-                            get_system_bus().get_object("org.bluez", path),
-                            "org.bluez.GattCharacteristic1",
-                        ).StopNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
-                    except dbus.exceptions.DBusException:
-                        pass
+            self._stop_bluez_notifications()
         self._notify_started = False
         self._authorized = False
         self._reset_requests()
 
+    def _stop_bluez_notifications(self) -> None:
+        """Best-effort removal of BlueZ's possibly stale notify ownership."""
+        for path in (self._ns_path, self._ds_path):
+            if not path:
+                continue
+            try:
+                dbus.Interface(
+                    get_system_bus().get_object("org.bluez", path),
+                    "org.bluez.GattCharacteristic1",
+                ).StopNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
+            except dbus.exceptions.DBusException:
+                log.debug("could not stop stale ANCS notification", exc_info=True)
+
     def _try_subscribe(self) -> None:
         if self._notify_started:
+            return
+        if self._bearer_connected is False:
             return
         if not (self._ns_path and self._ds_path and self._cp_path):
             return
@@ -689,6 +752,9 @@ class AncsClient:
             name = error.get_dbus_name() or type(error).__name__
             detail = error.get_dbus_message() or str(error)
             log.warning("ANCS CP WriteValue failed: %s: %s", name, detail)
+            if _connection_was_lost(error):
+                self.observe_bearer_state(False)
+                return
             self._abandon_request(request)
             self._active_request = None
             self._pump_requests()

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -68,6 +68,8 @@ DBUS_CALL_TIMEOUT_SECONDS = 10
 SUBSCRIBE_RETRY_SECONDS = 2
 AUTHORIZATION_RETRY_SECONDS = 5
 MANAGER_RETRY_SECONDS = 2
+BEARER_SETTLE_SECONDS = 2
+TRANSPORT_RESET_SECONDS = 15
 
 _BLUEZ_BUS_NAME = "org.bluez"
 _DBUS_BUS_NAME = "org.freedesktop.DBus"
@@ -113,6 +115,8 @@ class AncsClient:
         on_event: Callable[[AncsEvent], None],
         on_status: Callable[[], None] | None = None,
         include_non_message_notifications: Callable[[], bool] | None = None,
+        on_bluez_restart: Callable[[], None] | None = None,
+        on_transport_failure: Callable[[], None] | None = None,
         *,
         schedule: Callable[[int, Callable[[], bool]], int] = GLib.timeout_add_seconds,
         cancel: Callable[[int], object] = GLib.source_remove,
@@ -120,6 +124,8 @@ class AncsClient:
         self.device_path = device_path
         self.on_event = on_event
         self.on_status = on_status
+        self._on_bluez_restart = on_bluez_restart
+        self._on_transport_failure = on_transport_failure
         self._include_non_message_notifications = (
             include_non_message_notifications or (lambda: False)
         )
@@ -133,7 +139,9 @@ class AncsClient:
         self._notify_started = False
         self._authorized = False
         self._bearer_connected: bool | None = None
-        self._reset_notify_on_reconnect = False
+        self._bearer_ready = False
+        self._transport_blocked = False
+        self._owned_notify_paths: set[str] = set()
 
         # In-flight per-notification attribute requests + app-name cache
         self._app_name_cache: OrderedDict[str, str] = OrderedDict()
@@ -158,6 +166,8 @@ class AncsClient:
         self._manager_retry_id: int | None = None
         self._subscribe_retry_id: int | None = None
         self._authorization_retry_id: int | None = None
+        self._bearer_settle_id: int | None = None
+        self._transport_reset_id: int | None = None
         self._started = False
 
     # ---- lifecycle ------------------------------------------------------
@@ -187,6 +197,8 @@ class AncsClient:
             except Exception:
                 log.debug("could not remove partial BlueZ owner watch", exc_info=True)
             raise
+        if self._bearer_connected is True:
+            self._schedule_bearer_settle()
 
     def _bind_manager_and_rescan(self) -> None:
         """Reconnect ObjectManager signals and sweep the current object tree."""
@@ -255,7 +267,6 @@ class AncsClient:
             self._remove_manager_watches()
             self._cancel_subscribe_retry()
             self._clear_characteristic_subscription(stop_notify=False)
-            self._reset_notify_on_reconnect = False
             self._ns_path = self._ds_path = self._cp_path = None
 
     def _remove_manager_watches(self) -> None:
@@ -284,16 +295,23 @@ class AncsClient:
             was_connected = self.connected
             log.info("BlueZ owner disappeared; resetting ANCS discovery")
             self._cancel_manager_retry()
+            self._cancel_bearer_settle()
+            self._cancel_transport_reset()
             self._remove_manager_watches()
             self._cancel_subscribe_retry()
             self._clear_characteristic_subscription(stop_notify=False)
-            self._reset_notify_on_reconnect = False
+            self._bearer_connected = None
+            self._bearer_ready = False
+            self._transport_blocked = False
+            self._owned_notify_paths.clear()
             self._ns_path = self._ds_path = self._cp_path = None
             if was_connected and self.on_status is not None:
                 self.on_status()
         if not new_owner:
             return
         log.info("BlueZ owner available; rebuilding ANCS discovery")
+        if self._on_bluez_restart is not None:
+            self._on_bluez_restart()
         if self._manager_bind_in_progress:
             log.debug("deferring ANCS discovery rebuild until the current sweep finishes")
             return
@@ -352,7 +370,9 @@ class AncsClient:
         # characteristics. iOS notification access is usable only after an
         # authorized Control Point round trip succeeds.
         return (
-            self._bearer_connected is not False
+            self._bearer_connected is True
+            and self._bearer_ready
+            and not self._transport_blocked
             and self.subscribed
             and self.authorized
         )
@@ -365,10 +385,16 @@ class AncsClient:
         removal alone therefore cannot define the subscription lifecycle.
         """
         if connected is None:
+            self._bearer_connected = None
+            self._bearer_ready = False
+            self._cancel_bearer_settle()
             return
         previous = self._bearer_connected
         self._bearer_connected = connected
         if not connected:
+            self._bearer_ready = False
+            self._cancel_bearer_settle()
+            self._cancel_transport_reset()
             had_state = bool(
                 self._notify_started
                 or self._authorized
@@ -379,7 +405,6 @@ class AncsClient:
             if not had_state:
                 return
             log.info("iPhone LE bearer disconnected; resetting ANCS subscription")
-            self._reset_notify_on_reconnect = self._notify_started
             self._cancel_subscribe_retry()
             # StopNotify can block or fail while the ATT link is down. Remove
             # our local receivers now and replace BlueZ's registration once
@@ -389,14 +414,80 @@ class AncsClient:
                 self.on_status()
             return
 
-        if previous is False and self._reset_notify_on_reconnect:
+        if previous is True:
+            return
+        if previous is False:
             log.info("iPhone LE bearer reconnected; rebuilding ANCS subscription")
-            self._stop_bluez_notifications()
-            self._reset_notify_on_reconnect = False
-        # This is intentionally safe on every bearer poll. It also recovers a
-        # Control Point failure when the disconnect was too brief for the
-        # bearer supervisor itself to observe a state transition.
+            self._transport_blocked = False
+            self._cancel_transport_reset()
+        if self._started:
+            self._schedule_bearer_settle()
+
+    def _schedule_bearer_settle(self) -> None:
+        if self._bearer_settle_id is not None or self._bearer_connected is not True:
+            return
+        self._bearer_settle_id = self._schedule(
+            BEARER_SETTLE_SECONDS,
+            self._finish_bearer_settle,
+        )
+
+    def _finish_bearer_settle(self) -> bool:
+        self._bearer_settle_id = None
+        if not self._started or self._bearer_connected is not True:
+            return False
+        self._bearer_ready = True
         self._try_subscribe()
+        return False
+
+    def _cancel_bearer_settle(self) -> None:
+        if self._bearer_settle_id is None:
+            return
+        try:
+            self._cancel(self._bearer_settle_id)
+        except Exception:
+            log.debug("could not remove ANCS bearer settle timer", exc_info=True)
+        self._bearer_settle_id = None
+
+    def _mark_transport_failed(self) -> None:
+        """Latch a stale GATT transport until LE genuinely cycles."""
+        was_connected = self.connected
+        self._transport_blocked = True
+        self._bearer_ready = False
+        self._cancel_bearer_settle()
+        self._cancel_subscribe_retry()
+        self._clear_characteristic_subscription(stop_notify=False)
+        if (
+            self._started
+            and self._bearer_connected is True
+            and self._on_transport_failure is not None
+            and self._transport_reset_id is None
+        ):
+            self._transport_reset_id = self._schedule(
+                TRANSPORT_RESET_SECONDS,
+                self._request_transport_reset,
+            )
+        if was_connected and self.on_status is not None:
+            self.on_status()
+
+    def _request_transport_reset(self) -> bool:
+        self._transport_reset_id = None
+        if (
+            self._started
+            and self._transport_blocked
+            and self._bearer_connected is True
+            and self._on_transport_failure is not None
+        ):
+            self._on_transport_failure()
+        return False
+
+    def _cancel_transport_reset(self) -> None:
+        if self._transport_reset_id is None:
+            return
+        try:
+            self._cancel(self._transport_reset_id)
+        except Exception:
+            log.debug("could not remove ANCS transport reset timer", exc_info=True)
+        self._transport_reset_id = None
 
     def stop(self) -> None:
         log.info("ANCS client stopping")
@@ -407,7 +498,11 @@ class AncsClient:
         self._cancel_manager_retry()
         self._cancel_subscribe_retry()
         self._cancel_authorization_retry()
-        self._clear_characteristic_subscription()
+        self._cancel_bearer_settle()
+        self._cancel_transport_reset()
+        self._clear_characteristic_subscription(
+            stop_notify=self._bearer_connected is True and self._bearer_ready,
+        )
         self._remove_manager_watches()
         if self._owner_signal_match is not None:
             try:
@@ -450,8 +545,8 @@ class AncsClient:
                 setattr(self, attr, None)
                 self._cancel_subscribe_retry()
                 self._cancel_authorization_retry()
-                self._clear_characteristic_subscription()
-                self._reset_notify_on_reconnect = False
+                self._clear_characteristic_subscription(stop_notify=False)
+                self._owned_notify_paths.discard(path_s)
                 log.warning("ANCS char gone: %s", path_s)
                 if was_connected and self.on_status is not None:
                     self.on_status()
@@ -473,22 +568,26 @@ class AncsClient:
         self._reset_requests()
 
     def _stop_bluez_notifications(self) -> None:
-        """Best-effort removal of BlueZ's possibly stale notify ownership."""
-        for path in (self._ns_path, self._ds_path):
-            if not path:
-                continue
+        """Best-effort removal of notification ownership created by us."""
+        for path in tuple(self._owned_notify_paths):
             try:
                 dbus.Interface(
                     get_system_bus().get_object("org.bluez", path),
                     "org.bluez.GattCharacteristic1",
                 ).StopNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
             except dbus.exceptions.DBusException:
-                log.debug("could not stop stale ANCS notification", exc_info=True)
+                log.debug("could not stop ANCS notification", exc_info=True)
+            finally:
+                self._owned_notify_paths.discard(path)
 
     def _try_subscribe(self) -> None:
         if self._notify_started:
             return
-        if self._bearer_connected is False:
+        if (
+            self._bearer_connected is not True
+            or not self._bearer_ready
+            or self._transport_blocked
+        ):
             return
         if not (self._ns_path and self._ds_path and self._cp_path):
             return
@@ -509,7 +608,6 @@ class AncsClient:
         # Install receivers before StartNotify so the first value cannot arrive
         # in the gap between notification activation and signal registration.
         matches = []
-        started = []
         try:
             bus = get_system_bus()
             matches.append(bus.add_signal_receiver(
@@ -537,30 +635,35 @@ class AncsClient:
                 bus.get_object("org.bluez", ds_path),
                 "org.bluez.GattCharacteristic1",
             )
-            ns.StartNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
-            started.append(ns)
+            if not self._characteristic_is_notifying(bus, ns_path):
+                ns.StartNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
+                if current_attempt():
+                    self._owned_notify_paths.add(ns_path)
             if not current_attempt():
                 remove_attempt_matches(matches)
                 return
-            ds.StartNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
-            started.append(ds)
+            if not self._characteristic_is_notifying(bus, ds_path):
+                ds.StartNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
+                if current_attempt():
+                    self._owned_notify_paths.add(ds_path)
         except dbus.exceptions.DBusException as e:
             if not current_attempt():
                 remove_attempt_matches(matches)
                 log.debug("discarded stale ANCS subscribe attempt after BlueZ changed owner")
                 return
             log.warning("ANCS StartNotify failed: %s", e.get_dbus_name())
-            for characteristic in started:
-                try:
-                    characteristic.StopNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
-                except dbus.exceptions.DBusException:
-                    log.debug("could not roll back ANCS notification", exc_info=True)
             for match in matches:
                 try:
                     match.remove()
                 except Exception:
                     log.debug("could not roll back ANCS signal watch", exc_info=True)
-            self._schedule_subscribe_retry()
+            if _connection_was_lost(e):
+                self._mark_transport_failed()
+            else:
+                # Do not StopNotify a characteristic that succeeded before a
+                # later CCC write failed. On retry its Notifying property lets
+                # us resume without racing ATT teardown in bluetoothd.
+                self._schedule_subscribe_retry()
             return
         if not current_attempt():
             remove_attempt_matches(matches)
@@ -572,6 +675,21 @@ class AncsClient:
             "ANCS characteristic subscriptions active; requesting notification access"
         )
         self._queue_authorization_probe()
+
+    @staticmethod
+    def _characteristic_is_notifying(bus, path: str) -> bool:
+        try:
+            properties = dbus.Interface(
+                bus.get_object("org.bluez", path),
+                "org.freedesktop.DBus.Properties",
+            )
+            return bool(properties.Get(
+                "org.bluez.GattCharacteristic1",
+                "Notifying",
+                timeout=DBUS_CALL_TIMEOUT_SECONDS,
+            ))
+        except (AttributeError, dbus.exceptions.DBusException):
+            return False
 
     def _schedule_subscribe_retry(self) -> None:
         if (
@@ -753,7 +871,7 @@ class AncsClient:
             detail = error.get_dbus_message() or str(error)
             log.warning("ANCS CP WriteValue failed: %s: %s", name, detail)
             if _connection_was_lost(error):
-                self.observe_bearer_state(False)
+                self._mark_transport_failed()
                 return
             self._abandon_request(request)
             self._active_request = None

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -76,6 +76,7 @@ def preferred_bearer_unavailable(error: Exception) -> bool:
 ReadConnected = Callable[[str], bool | None]
 Connect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
 Prefer = Callable[[str], None]
+ObserveLeState = Callable[[bool | None], None]
 Schedule = Callable[[int, Callable[[], bool]], int]
 Cancel = Callable[[int], object]
 Clock = Callable[[], float]
@@ -95,6 +96,7 @@ class BearerSupervisor:
         *,
         le_enabled: bool = True,
         on_status: Callable[[], None] | None = None,
+        on_le_state: ObserveLeState | None = None,
         read_connected: ReadConnected | None = None,
         connect: Connect | None = None,
         prefer: Prefer | None = None,
@@ -104,6 +106,7 @@ class BearerSupervisor:
     ) -> None:
         self.device_path = device_path
         self._on_status = on_status
+        self._on_le_state = on_le_state
         self._read_connected = read_connected or self._read_bluez_connected
         self._connect = connect or self._connect_bluez
         self._prefer = prefer or (
@@ -129,6 +132,11 @@ class BearerSupervisor:
     @property
     def le_connected(self) -> bool:
         return self._states["le"] is True
+
+    @property
+    def le_state(self) -> bool | None:
+        """Return the latest observed LE bearer state."""
+        return self._states["le"]
 
     def start(self) -> None:
         if self._running:
@@ -259,6 +267,11 @@ class BearerSupervisor:
             self._last_errors.pop(kind, None)
             self._failures[kind] = 0
             self._next_attempt[kind] = 0.0
+        # ANCS can independently discover a failed GATT transaction between
+        # polls. Repeat the latest observation so it can recover even when the
+        # supervisor itself did not observe the brief disconnect transition.
+        if kind == "le" and self._on_le_state is not None:
+            self._on_le_state(value)
         if previous != value and self._on_status is not None:
             self._on_status()
 

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -75,6 +75,7 @@ def preferred_bearer_unavailable(error: Exception) -> bool:
 
 ReadConnected = Callable[[str], bool | None]
 Connect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
+Disconnect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
 Prefer = Callable[[str], None]
 ObserveLeState = Callable[[bool | None], None]
 Schedule = Callable[[int, Callable[[], bool]], int]
@@ -99,6 +100,7 @@ class BearerSupervisor:
         on_le_state: ObserveLeState | None = None,
         read_connected: ReadConnected | None = None,
         connect: Connect | None = None,
+        disconnect: Disconnect | None = None,
         prefer: Prefer | None = None,
         schedule: Schedule = GLib.timeout_add_seconds,
         cancel: Cancel = GLib.source_remove,
@@ -109,6 +111,7 @@ class BearerSupervisor:
         self._on_le_state = on_le_state
         self._read_connected = read_connected or self._read_bluez_connected
         self._connect = connect or self._connect_bluez
+        self._disconnect = disconnect or self._disconnect_bluez
         self._prefer = prefer or (
             self._prefer_bluez if connect is None else lambda _kind: None
         )
@@ -119,7 +122,12 @@ class BearerSupervisor:
         self._timer_id: int | None = None
         self._le_settle_id: int | None = None
         self._running = False
+        self._generation = 0
         self._connecting: set[str] = set()
+        self._disconnecting: set[str] = set()
+        self._le_reset_pending = False
+        self._le_reset_failures = 0
+        self._next_le_reset_attempt = 0.0
         self._last_errors: dict[str, tuple[str, str]] = {}
         self._states: dict[str, bool | None] = {"bredr": None, "le": None}
         self._failures: dict[str, int] = {"bredr": 0, "le": 0}
@@ -164,9 +172,45 @@ class BearerSupervisor:
         if self._running:
             self._tick()
 
+    def reset_after_bluez_restart(self) -> None:
+        """Forget callbacks and observations owned by the previous daemon."""
+        previous = dict(self._states)
+        self._generation += 1
+        self._connecting.clear()
+        self._disconnecting.clear()
+        self._le_reset_pending = False
+        self._le_reset_failures = 0
+        self._next_le_reset_attempt = 0.0
+        self._cancel_le_settle()
+        self._states = {"bredr": None, "le": None}
+        self._failures = {"bredr": 0, "le": 0}
+        self._next_attempt = {"bredr": 0.0, "le": 0.0}
+        self._last_errors.clear()
+        if self._on_le_state is not None:
+            self._on_le_state(None)
+        if any(value is not None for value in previous.values()) and self._on_status:
+            self._on_status()
+        if self._running:
+            self._tick()
+
+    def recover_le_transport(self) -> None:
+        """Request one serialized LE reset after GATT and bearer state diverge."""
+        if not self._running or not self._le_enabled:
+            return
+        if not self._le_reset_pending:
+            log.warning(
+                "ANCS transport disagrees with BlueZ; resetting the LE bearer"
+            )
+        self._le_reset_pending = True
+        self._cancel_le_settle()
+        self._request_le_disconnect()
+
     def stop(self) -> None:
         self._running = False
+        self._generation += 1
         self._connecting.clear()
+        self._disconnecting.clear()
+        self._le_reset_pending = False
         self._cancel_le_settle()
         if self._timer_id is not None:
             try:
@@ -197,6 +241,17 @@ class BearerSupervisor:
         le = self._read("le")
         self._update_state("bredr", bredr)
         self._update_state("le", le)
+
+        if self._le_reset_pending:
+            if le is False:
+                self._le_reset_pending = False
+                self._le_reset_failures = 0
+                self._next_le_reset_attempt = 0.0
+            elif le is True:
+                self._request_le_disconnect()
+                return True
+            else:
+                return True
 
         # Establish the normal Bluetooth ACL/profile connection before LE.
         # This is the order used by the proven manual setup flow and avoids
@@ -267,10 +322,10 @@ class BearerSupervisor:
             self._last_errors.pop(kind, None)
             self._failures[kind] = 0
             self._next_attempt[kind] = 0.0
-        # ANCS can independently discover a failed GATT transaction between
-        # polls. Repeat the latest observation so it can recover even when the
-        # supervisor itself did not observe the brief disconnect transition.
-        if kind == "le" and self._on_le_state is not None:
+        # Repeating stale Connected=true after a failed GATT operation can
+        # race BlueZ's pending CCC registration with ATT teardown. Consumers
+        # therefore receive only genuine bearer lifecycle transitions.
+        if previous != value and kind == "le" and self._on_le_state is not None:
             self._on_le_state(value)
         if previous != value and self._on_status is not None:
             self._on_status()
@@ -281,6 +336,7 @@ class BearerSupervisor:
         if self._clock() < self._next_attempt[kind]:
             return
         self._connecting.add(kind)
+        generation = self._generation
         log.info("connecting iPhone %s bearer", kind.upper())
         try:
             # Pairing pins the device to BR/EDR so iOS sees MAP/PBAP first.
@@ -289,20 +345,36 @@ class BearerSupervisor:
             self._prefer(kind)
             self._connect(
                 kind,
-                lambda: self._connect_succeeded(kind),
-                lambda error: self._connect_failed(kind, error),
+                lambda: self._connect_succeeded(kind, generation),
+                lambda error: self._connect_failed(kind, error, generation),
             )
         except Exception as error:
-            self._connect_failed(kind, error)
+            self._connect_failed(kind, error, generation)
 
-    def _connect_succeeded(self, kind: str) -> None:
+    def _connect_succeeded(self, kind: str, generation: int) -> None:
+        if generation != self._generation:
+            return
         self._connecting.discard(kind)
         self._last_errors.pop(kind, None)
-        self._failures[kind] = 0
-        self._next_attempt[kind] = 0.0
-        log.info("iPhone %s bearer connection requested successfully", kind.upper())
+        # A successful method reply only means BlueZ accepted the request; it
+        # does not mean the bearer connected. Keep widening the quiet window
+        # until an observed Connected=true resets it.
+        self._failures[kind] += 1
+        delay = min(
+            POLL_SECONDS * (2 ** self._failures[kind]),
+            BACKOFF_CAP_SECONDS,
+        )
+        self._next_attempt[kind] = self._clock() + delay
+        log.info(
+            "iPhone %s bearer connection requested successfully; "
+            "waiting up to %ds for state change",
+            kind.upper(),
+            delay,
+        )
 
-    def _connect_failed(self, kind: str, error: Exception) -> None:
+    def _connect_failed(self, kind: str, error: Exception, generation: int) -> None:
+        if generation != self._generation:
+            return
         self._connecting.discard(kind)
         name, message = _connect_error_parts(error)
         if name in {
@@ -310,6 +382,7 @@ class BearerSupervisor:
             "org.bluez.Error.InProgress",
         }:
             log.debug("%s bearer connection already active", kind.upper())
+            self._connect_succeeded(kind, generation)
             return
         self._failures[kind] += 1
         delay = min(
@@ -326,6 +399,65 @@ class BearerSupervisor:
                 delay,
             )
             self._last_errors[kind] = (name, message)
+
+    def _request_le_disconnect(self) -> None:
+        if "le" in self._disconnecting:
+            return
+        if self._clock() < self._next_le_reset_attempt:
+            return
+        self._disconnecting.add("le")
+        generation = self._generation
+        try:
+            self._disconnect(
+                "le",
+                lambda: self._disconnect_succeeded(generation),
+                lambda error: self._disconnect_failed(error, generation),
+            )
+        except Exception as error:
+            self._disconnect_failed(error, generation)
+
+    def _disconnect_succeeded(self, generation: int) -> None:
+        if generation != self._generation:
+            return
+        self._disconnecting.discard("le")
+        self._le_reset_failures += 1
+        delay = min(
+            POLL_SECONDS * (2 ** self._le_reset_failures),
+            BACKOFF_CAP_SECONDS,
+        )
+        self._next_le_reset_attempt = self._clock() + delay
+        log.info(
+            "iPhone LE bearer reset requested successfully; "
+            "waiting up to %ds for state change",
+            delay,
+        )
+
+    def _disconnect_failed(self, error: Exception, generation: int) -> None:
+        if generation != self._generation:
+            return
+        self._disconnecting.discard("le")
+        name, message = _connect_error_parts(error)
+        if name in {
+            "org.bluez.Error.NotConnected",
+            "org.bluez.Error.AlreadyDisconnected",
+        } or "not connected" in message.casefold():
+            self._le_reset_pending = False
+            self._update_state("le", False)
+            if self.bredr_connected:
+                self._schedule_le_connect()
+            return
+        self._le_reset_failures += 1
+        delay = min(
+            POLL_SECONDS * (2 ** self._le_reset_failures),
+            BACKOFF_CAP_SECONDS,
+        )
+        self._next_le_reset_attempt = self._clock() + delay
+        detail = f"{name}: {message}" if message else name
+        log.warning(
+            "could not reset iPhone LE bearer: %s (next attempt in %ds)",
+            detail,
+            delay,
+        )
 
     def _read_bluez_connected(self, kind: str) -> bool | None:
         obj = get_system_bus().get_object("org.bluez", self.device_path)
@@ -351,6 +483,22 @@ class BearerSupervisor:
             interface,
         )
         bearer.Connect(
+            reply_handler=on_success,
+            error_handler=on_error,
+            timeout=45.0,
+        )
+
+    def _disconnect_bluez(
+        self,
+        kind: str,
+        on_success: Callable[[], None],
+        on_error: Callable[[Exception], None],
+    ) -> None:
+        bearer = dbus.Interface(
+            get_system_bus().get_object("org.bluez", self.device_path),
+            _INTERFACES[kind],
+        )
+        bearer.Disconnect(
             reply_handler=on_success,
             error_handler=on_error,
             timeout=45.0,

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -97,6 +97,7 @@ class Daemon:
             device_path,
             le_enabled=False,
             on_status=self._emit_status,
+            on_le_state=self._observe_le_state,
         )
         self._contacts_refresh_id: int | None = None
         self._bus_name = None
@@ -136,6 +137,10 @@ class Daemon:
         emit = getattr(self._dbus_service, "emit_status", None)
         if emit is not None:
             emit()
+
+    def _observe_le_state(self, connected: bool | None) -> None:
+        if self.ancs is not None:
+            self.ancs.observe_bearer_state(connected)
 
     def _mark_setup_task(self, task: str) -> bool:
         try:
@@ -280,6 +285,7 @@ class Daemon:
                 ),
             )
             try:
+                candidate.observe_bearer_state(self.bearers.le_state)
                 candidate.start()
             except Exception:
                 candidate.stop()

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -280,6 +280,8 @@ class Daemon:
                 device_path,
                 on_event=self.events.ancs,
                 on_status=self._emit_status,
+                on_bluez_restart=self.bearers.reset_after_bluez_restart,
+                on_transport_failure=self.bearers.recover_le_transport,
                 include_non_message_notifications=lambda: (
                     self.notification_policy.value == ALL_NOTIFICATIONS
                 ),

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -468,6 +468,120 @@ def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
     assert ds.start_calls == 1
 
 
+def test_le_reconnect_replaces_stale_subscription_and_reauthorizes(
+    monkeypatch,
+) -> None:
+    calls = []
+    statuses = []
+
+    class _Characteristic:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def StartNotify(self, **_kwargs) -> None:
+            calls.append(("start", self.name))
+
+        def StopNotify(self, **_kwargs) -> None:
+            calls.append(("stop", self.name))
+
+        def WriteValue(self, _value, _options, **_kwargs) -> None:
+            calls.append(("write", self.name))
+
+    ns = _Characteristic("ns")
+    ds = _Characteristic("ds")
+    cp = _Characteristic("cp")
+    bus = _CharacteristicBus(
+        {"/device/ns": ns, "/device/ds": ds, "/device/cp": cp}
+    )
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda _delay, _callback: 9,
+    )
+    monkeypatch.setattr(client_module.GLib, "source_remove", lambda _timer: None)
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        on_status=lambda: statuses.append(True),
+    )
+    client._started = True
+    client._bearer_connected = True
+    client._ns_path = "/device/ns"
+    client._ds_path = "/device/ds"
+    client._cp_path = "/device/cp"
+    client._notify_started = True
+    client._authorized = True
+    old_matches = [_Match(), _Match()]
+    client._characteristic_signal_matches = old_matches
+
+    client.observe_bearer_state(False)
+
+    assert client.connected is False
+    assert client.subscribed is False
+    assert client.authorized is False
+    assert all(match.removed for match in old_matches)
+    assert calls == []
+    assert statuses == [True]
+
+    client.observe_bearer_state(True)
+
+    assert calls == [
+        ("stop", "ns"),
+        ("stop", "ds"),
+        ("start", "ns"),
+        ("start", "ds"),
+        ("write", "cp"),
+    ]
+    assert client.subscribed is True
+    assert client.authorized is False
+    _complete_authorization_probe(client)
+    assert client.connected is True
+    assert statuses == [True, True]
+
+
+def test_not_connected_control_point_failure_invalidates_ancs_health(
+    monkeypatch,
+) -> None:
+    statuses = []
+
+    class _ControlPoint:
+        @staticmethod
+        def WriteValue(_value, _options, **_kwargs) -> None:
+            raise client_module.dbus.exceptions.DBusException(
+                "Not connected",
+                name="org.bluez.Error.Failed",
+            )
+
+    bus = _CharacteristicBus({"/device/cp": _ControlPoint()})
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        on_status=lambda: statuses.append(True),
+    )
+    client._started = True
+    client._bearer_connected = True
+    client._ns_path = "/device/ns"
+    client._ds_path = "/device/ds"
+    client._cp_path = "/device/cp"
+    client._notify_started = True
+    client._authorized = True
+    matches = [_Match(), _Match()]
+    client._characteristic_signal_matches = matches
+
+    client._request_attrs(Notification.parse(_notification(42)))
+
+    assert client.connected is False
+    assert client.subscribed is False
+    assert client.authorized is False
+    assert client._bearer_connected is False
+    assert all(match.removed for match in matches)
+    assert statuses == [True]
+
+
 def test_owner_change_during_start_notify_preserves_new_subscription(
     monkeypatch,
 ) -> None:

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -263,10 +263,18 @@ def test_bluez_restart_rebinds_manager_and_rescans_cached_ancs_objects(
     monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
     monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
     statuses = []
-    client = AncsClient("/device", lambda _event: None, on_status=lambda: statuses.append(True))
+    restarts = []
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        on_status=lambda: statuses.append(True),
+        on_bluez_restart=lambda: restarts.append(True),
+    )
     monkeypatch.setattr(client, "_try_subscribe", lambda: None)
 
     client.start()
+    client._bearer_connected = True
+    client._bearer_ready = True
     client._notify_started = True
     client._authorized = True
     characteristic_matches = [_Match(), _Match()]
@@ -291,6 +299,7 @@ def test_bluez_restart_rebinds_manager_and_rescans_cached_ancs_objects(
     assert client._ns_path == "/device/service0023/char0027"
     assert client._ds_path == "/device/service0023/char002a"
     assert client._cp_path == "/device/service0023/char0024"
+    assert restarts == [True]
 
 
 def test_bluez_restart_retries_when_object_manager_is_not_ready(monkeypatch) -> None:
@@ -395,7 +404,9 @@ def test_characteristic_removal_discards_all_characteristic_receivers(
     assert client._notify_started is False
     assert client._characteristic_signal_matches == []
     assert all(match.removed for match in matches)
-    assert stopped == [True]
+    # The characteristic is already disappearing; issuing StopNotify here can
+    # race BlueZ's pending CCC completion with ATT teardown.
+    assert stopped == []
 
 
 def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
@@ -442,6 +453,8 @@ def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
     )
     client._started = True
+    client._bearer_connected = True
+    client._bearer_ready = True
     client._ns_path = "/device/ns"
     client._ds_path = "/device/ds"
     client._cp_path = "/device/cp"
@@ -468,11 +481,83 @@ def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
     assert ds.start_calls == 1
 
 
+def test_partial_start_notify_failure_reuses_live_subscription(monkeypatch) -> None:
+    scheduled = []
+
+    class _Characteristic:
+        def __init__(self, *, fail_once: bool = False) -> None:
+            self.fail_once = fail_once
+            self.notifying = False
+            self.start_calls = 0
+            self.stop_calls = 0
+
+        def Get(self, _interface, name, **_kwargs):
+            assert name == "Notifying"
+            return self.notifying
+
+        def StartNotify(self, **_kwargs) -> None:
+            self.start_calls += 1
+            if self.fail_once:
+                self.fail_once = False
+                raise client_module.dbus.exceptions.DBusException(
+                    "not ready",
+                    name="org.bluez.Error.Failed",
+                )
+            self.notifying = True
+
+        def StopNotify(self, **_kwargs) -> None:
+            self.stop_calls += 1
+
+        @staticmethod
+        def WriteValue(_value, _options, **_kwargs) -> None:
+            return None
+
+    ns = _Characteristic()
+    ds = _Characteristic(fail_once=True)
+    cp = _Characteristic()
+    bus = _CharacteristicBus(
+        {"/device/ns": ns, "/device/ds": ds, "/device/cp": cp}
+    )
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda _delay, _callback: 9,
+    )
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    client._started = True
+    client._bearer_connected = True
+    client._bearer_ready = True
+    client._ns_path = "/device/ns"
+    client._ds_path = "/device/ds"
+    client._cp_path = "/device/cp"
+
+    client._try_subscribe()
+
+    assert ns.start_calls == 1
+    assert ns.stop_calls == 0
+    assert ds.start_calls == 1
+    assert client.subscribed is False
+
+    scheduled[0][1]()
+
+    assert ns.start_calls == 1
+    assert ns.stop_calls == 0
+    assert ds.start_calls == 2
+    assert client.subscribed is True
+
+
 def test_le_reconnect_replaces_stale_subscription_and_reauthorizes(
     monkeypatch,
 ) -> None:
     calls = []
     statuses = []
+    scheduled = []
 
     class _Characteristic:
         def __init__(self, name: str) -> None:
@@ -505,9 +590,11 @@ def test_le_reconnect_replaces_stale_subscription_and_reauthorizes(
         "/device",
         lambda _event: None,
         on_status=lambda: statuses.append(True),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
     )
     client._started = True
     client._bearer_connected = True
+    client._bearer_ready = True
     client._ns_path = "/device/ns"
     client._ds_path = "/device/ds"
     client._cp_path = "/device/cp"
@@ -527,9 +614,11 @@ def test_le_reconnect_replaces_stale_subscription_and_reauthorizes(
 
     client.observe_bearer_state(True)
 
+    assert calls == []
+    assert scheduled[0][0] == client_module.BEARER_SETTLE_SECONDS
+    scheduled[0][1]()
+
     assert calls == [
-        ("stop", "ns"),
-        ("stop", "ds"),
         ("start", "ns"),
         ("start", "ds"),
         ("write", "cp"),
@@ -545,6 +634,8 @@ def test_not_connected_control_point_failure_invalidates_ancs_health(
     monkeypatch,
 ) -> None:
     statuses = []
+    scheduled = []
+    resets = []
 
     class _ControlPoint:
         @staticmethod
@@ -561,9 +652,12 @@ def test_not_connected_control_point_failure_invalidates_ancs_health(
         "/device",
         lambda _event: None,
         on_status=lambda: statuses.append(True),
+        on_transport_failure=lambda: resets.append(True),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
     )
     client._started = True
     client._bearer_connected = True
+    client._bearer_ready = True
     client._ns_path = "/device/ns"
     client._ds_path = "/device/ds"
     client._cp_path = "/device/cp"
@@ -577,9 +671,18 @@ def test_not_connected_control_point_failure_invalidates_ancs_health(
     assert client.connected is False
     assert client.subscribed is False
     assert client.authorized is False
-    assert client._bearer_connected is False
+    assert client._bearer_connected is True
+    assert client._transport_blocked is True
     assert all(match.removed for match in matches)
     assert statuses == [True]
+    assert scheduled[0][0] == client_module.TRANSPORT_RESET_SECONDS
+
+    client.observe_bearer_state(True)
+    assert client.subscribed is False
+    assert len(scheduled) == 1
+
+    scheduled[0][1]()
+    assert resets == [True]
 
 
 def test_owner_change_during_start_notify_preserves_new_subscription(
@@ -618,6 +721,8 @@ def test_owner_change_during_start_notify_preserves_new_subscription(
     monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
     client = AncsClient("/device", lambda _event: None)
     client._started = True
+    client._bearer_connected = True
+    client._bearer_ready = True
     client._ns_path = "/device/ns"
     client._ds_path = "/device/ds"
     client._cp_path = "/device/cp"
@@ -656,6 +761,8 @@ def test_owner_change_during_control_point_write_preserves_new_request(
     client = AncsClient("/device", lambda _event: None)
     client._started = True
     client._notify_started = True
+    client._bearer_connected = True
+    client._bearer_ready = True
     client._cp_path = "/device/cp"
 
     client._queue_authorization_probe()
@@ -699,6 +806,8 @@ def test_control_point_failure_keeps_ancs_unready_and_retries(
     )
     client._started = True
     client._notify_started = True
+    client._bearer_connected = True
+    client._bearer_ready = True
     client._cp_path = "/device/cp"
 
     client._queue_authorization_probe()

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -299,6 +299,33 @@ def test_backoff_resets_once_the_bearer_connects() -> None:
     assert attempts == ["bredr", "bredr"]
 
 
+def test_le_observer_receives_every_polled_state() -> None:
+    state = {"bredr": True, "le": True}
+    observed = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda *_args: None,
+        on_le_state=observed.append,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+
+    supervisor.start()
+    assert supervisor.le_state is True
+    assert observed == [True]
+
+    # Repeat observations let a consumer recover when it detected a brief
+    # disconnect that fell entirely between supervisor polls.
+    scheduled[0][1]()
+    assert observed == [True, True]
+
+    state["le"] = False
+    scheduled[0][1]()
+    assert supervisor.le_state is False
+    assert observed[-1] is False
+
+
 def test_stop_cancels_health_check() -> None:
     cancelled = []
     supervisor = BearerSupervisor(

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -267,6 +267,32 @@ def test_failed_connection_is_retried_after_backoff() -> None:
     assert attempts == ["bredr", "bredr", "bredr"]
 
 
+def test_accepted_connection_request_waits_for_observed_state_change() -> None:
+    attempts = []
+    scheduled = []
+    now = 0.0
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=lambda _kind: False,
+        connect=lambda kind, on_success, _on_error: (
+            attempts.append(kind),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    assert attempts == ["bredr"]
+
+    scheduled[0][1]()
+    assert attempts == ["bredr"]
+
+    now = 11.0
+    scheduled[0][1]()
+    assert attempts == ["bredr", "bredr"]
+
+
 def test_backoff_resets_once_the_bearer_connects() -> None:
     state = {"bredr": False, "le": False}
     attempts = []
@@ -299,7 +325,7 @@ def test_backoff_resets_once_the_bearer_connects() -> None:
     assert attempts == ["bredr", "bredr"]
 
 
-def test_le_observer_receives_every_polled_state() -> None:
+def test_le_observer_receives_only_lifecycle_transitions() -> None:
     state = {"bredr": True, "le": True}
     observed = []
     scheduled = []
@@ -315,15 +341,82 @@ def test_le_observer_receives_every_polled_state() -> None:
     assert supervisor.le_state is True
     assert observed == [True]
 
-    # Repeat observations let a consumer recover when it detected a brief
-    # disconnect that fell entirely between supervisor polls.
+    # A stale true must not make ANCS resubscribe after a failed GATT request.
     scheduled[0][1]()
-    assert observed == [True, True]
+    assert observed == [True]
 
     state["le"] = False
     scheduled[0][1]()
     assert supervisor.le_state is False
     assert observed[-1] is False
+
+
+def test_gatt_transport_failure_cycles_le_once_before_reconnecting() -> None:
+    state = {"bredr": True, "le": True}
+    disconnects = []
+    connections = []
+    observed = []
+    scheduled = []
+    now = 0.0
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, _on_error: (
+            connections.append(kind),
+            on_success(),
+        ),
+        disconnect=lambda kind, on_success, _on_error: (
+            disconnects.append(kind),
+            on_success(),
+        ),
+        on_le_state=observed.append,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
+    )
+    supervisor.start()
+
+    supervisor.recover_le_transport()
+    supervisor.recover_le_transport()
+    assert disconnects == ["le"]
+
+    scheduled[0][1]()
+    assert disconnects == ["le"]
+
+    state["le"] = False
+    scheduled[0][1]()
+    assert observed == [True, False]
+    assert scheduled[-1][0] == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+
+    scheduled[-1][1]()
+    assert connections == ["le"]
+
+
+def test_bluez_restart_discards_callbacks_from_the_previous_owner() -> None:
+    callbacks = []
+    statuses = []
+    observed = []
+
+    def connect(_kind, on_success, on_error):
+        callbacks.append((on_success, on_error))
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=lambda _kind: False,
+        connect=connect,
+        on_status=lambda: statuses.append(True),
+        on_le_state=observed.append,
+        schedule=lambda _delay, _callback: 7,
+    )
+    supervisor.start()
+    assert len(callbacks) == 1
+
+    supervisor.reset_after_bluez_restart()
+    callbacks[0][1](RuntimeError("stale failure"))
+
+    assert supervisor.snapshot()["last_le_error"] == ""
+    assert observed[-1] is False
+    assert statuses
 
 
 def test_stop_cancels_health_check() -> None:

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -12,6 +12,12 @@ class _Bearer:
     def start(self):
         self.calls.append("bearers-start")
 
+    def reset_after_bluez_restart(self):
+        self.calls.append("bearers-reset")
+
+    def recover_le_transport(self):
+        self.calls.append("bearers-recover-le")
+
 
 class _Events:
     def __init__(self, calls):

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -4,6 +4,8 @@ from blueferry import daemon
 
 
 class _Bearer:
+    le_state = False
+
     def __init__(self, calls):
         self.calls = calls
 
@@ -86,6 +88,9 @@ def test_full_daemon_starts_ancs_client(monkeypatch):
         def __init__(self, *_args, **_kwargs):
             calls.append("ancs-client")
 
+        def observe_bearer_state(self, connected):
+            calls.append(("ancs-bearer", connected))
+
         def start(self):
             calls.append("ancs-start")
 
@@ -97,5 +102,6 @@ def test_full_daemon_starts_ancs_client(monkeypatch):
     value._initialize_bluetooth()
 
     assert "ancs-client" in calls
+    assert ("ancs-bearer", False) in calls
     assert "ancs-start" in calls
     assert value.ancs is not None


### PR DESCRIPTION
## Summary

- rebuild ANCS subscriptions after the iPhone LE bearer reconnects
- add settle and transport-reset handling so stale BlueZ callbacks cannot corrupt a new connection
- coordinate bearer supervision and daemon lifecycle recovery across BlueZ restarts

## Tests

- `/usr/bin/pytest -q tests/test_ancs_client.py tests/test_bearer_supervisor.py tests/test_daemon_pairing_policy.py` (37 passed)