### PR TITLE
Run native package CI weekly

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,19 +1,11 @@
 name: Native packages
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/packages.yml"
-      - "data/**"
-      - "packaging/**"
-      - "src/**"
-      - "systemd/**"
-      - "tests/**"
-      - "build.sh"
-      - "pyproject.toml"
   push:
-    branches: [main]
     tags: ["v*"]
+  schedule:
+    # Exercise current distribution repositories without doing so on every commit.
+    - cron: "17 6 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/tests/test_native_packaging.py
+++ b/tests/test_native_packaging.py
@@ -227,3 +227,14 @@ def test_package_workflow_installs_identical_artifacts_on_targets() -> None:
         "systemd-analyze verify --man=no bluetooth.service"
     ) == 3
     assert "GH_REPO: ${{ github.repository }}" in workflow
+
+
+def test_package_workflow_does_not_run_for_each_commit() -> None:
+    workflow = (ROOT / ".github/workflows/packages.yml").read_text()
+    triggers = workflow.split("permissions:", maxsplit=1)[0]
+
+    assert "pull_request:" not in triggers
+    assert "branches:" not in triggers
+    assert 'tags: ["v*"]' in triggers
+    assert "schedule:" in triggers
+    assert "workflow_dispatch:" in triggers


### PR DESCRIPTION
## Summary

- stop running the native package build and install matrix on every push and pull-request commit
- retain tagged-release and manual runs
- run the matrix weekly to catch distribution repository drift with much less rate-limit pressure
- add a regression test for the workflow triggers

## Tests

- `/usr/bin/pytest -q tests/test_native_packaging.py` (12 passed)
- `ruff check tests/test_native_packaging.py`