### PR TITLE
Release BlueFerry 0.7.4

### DIFF
--- a/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
@@ -40,6 +40,18 @@
   </developer>
 
   <releases>
+    <release version="0.7.4" date="2026-08-16">
+      <description>
+        <p>Recovers iPhone notifications after reconnects, makes message editors
+        expand and wrap, and improves conversation-storage recovery.</p>
+      </description>
+    </release>
+    <release version="0.7.2" date="2026-08-16">
+      <description>
+        <p>Prevents the privileged Bluetooth setup helper from hanging when
+        pairing under systemd.</p>
+      </description>
+    </release>
     <release version="0.7.1" date="2026-08-15">
       <description>
         <p>Improves cross-distro pairing and privileged setup, makes controller

--- a/data/io.weirdware.BlueFerry.Qt.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Qt.metainfo.xml
@@ -14,6 +14,8 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.7.4" date="2026-08-16"><description><p>Recovers iPhone notifications after reconnects, makes message editors expand and wrap, and improves conversation-storage recovery.</p></description></release>
+    <release version="0.7.2" date="2026-08-16"><description><p>Prevents the privileged Bluetooth setup helper from hanging when pairing under systemd.</p></description></release>
     <release version="0.7.1" date="2026-08-15"><description><p>Improves cross-distro pairing and privileged setup, makes controller capability checks advisory, and polishes Qt startup, connection health, and group messaging.</p></description></release>
     <release version="0.7.0" date="2026-08-14"><description><p>Adds native Linux packages, compatibility and explicit pairing modes, build-aware daemon restarts, and ANCS recovery after BlueZ restarts.</p></description></release>
     <release version="0.6.3" date="2026-08-13"><description><p>Lets you pick a Bluetooth controller when more than one is present and keeps pairing, scanning, and forget on that radio.</p></description></release>

--- a/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
@@ -14,6 +14,8 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.7.4" date="2026-08-16"><description><p>Recovers iPhone notifications after reconnects, makes message editors expand and wrap, and improves conversation-storage recovery.</p></description></release>
+    <release version="0.7.2" date="2026-08-16"><description><p>Prevents the privileged Bluetooth setup helper from hanging when pairing under systemd.</p></description></release>
     <release version="0.7.1" date="2026-08-15"><description><p>Improves cross-distro pairing and privileged setup, makes controller capability checks advisory, and polishes Qt startup, connection health, and group messaging.</p></description></release>
     <release version="0.7.0" date="2026-08-14"><description><p>Adds native Linux packages, compatibility and explicit pairing modes, build-aware daemon restarts, and ANCS recovery after BlueZ restarts.</p></description></release>
     <release version="0.6.3" date="2026-08-13"><description><p>Lets you pick a Bluetooth controller when more than one is present and keeps pairing, scanning, and forget on that radio.</p></description></release>

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -1123,7 +1123,7 @@ ShellRoot {
                   id: composerRow
                   anchors.fill: parent
                   anchors.margins: theme.scaled(6)
-                  FerryTextField {
+                  FerryMessageComposer {
                     id: composer
                     Layout.fillWidth: true
                     placeholderText: "Write a message…"
@@ -1135,6 +1135,7 @@ ShellRoot {
                   }
                   FerryButton {
                     id: sendMessageButton
+                    Layout.alignment: Qt.AlignBottom
                     text: root.sendBusy ? "SENDING" : "SEND"
                     highlighted: true
                     enabled: composer.enabled && composer.text.trim() !== "" &&
@@ -1726,12 +1727,14 @@ ShellRoot {
             text: "Message"
             color: theme.muted
           }
-          FerryTextField {
+          FerryMessageComposer {
             id: newMessageBody
             Layout.fillWidth: true
             placeholderText: "Write a message"
             Accessible.name: "Message text"
-            onAccepted: newMessageSendButton.clicked()
+            onAccepted: {
+              if (newMessageSendButton.enabled) newMessageSendButton.clicked()
+            }
           }
           RowLayout {
             Layout.alignment: Qt.AlignRight
@@ -2000,6 +2003,63 @@ ShellRoot {
       border.color: control.activeFocus ? theme.accent
         : control.flat ? "transparent" : theme.divider
       radius: theme.controlRadius
+    }
+  }
+
+  component FerryMessageComposer: ScrollView {
+    id: control
+    property alias text: editor.text
+    property alias placeholderText: editor.placeholderText
+    property bool flat: false
+    signal accepted()
+
+    Layout.minimumWidth: 0
+    Layout.minimumHeight: theme.scaled(36)
+    Layout.preferredHeight: Math.min(
+      Math.max(editor.contentHeight + editor.topPadding + editor.bottomPadding + 2,
+               Layout.minimumHeight),
+      Layout.maximumHeight
+    )
+    Layout.maximumHeight: theme.scaled(144)
+    clip: true
+    ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+    ScrollBar.vertical.policy: ScrollBar.AsNeeded
+
+    function clear() { editor.clear() }
+    function forceActiveFocus() { editor.forceActiveFocus() }
+    function submit(event) {
+      if ((event.modifiers & Qt.ShiftModifier) !== 0) {
+        event.accepted = false
+        return
+      }
+      accepted()
+      event.accepted = true
+    }
+
+    background: Rectangle {
+      color: control.flat ? "transparent" : theme.control
+      border.color: editor.activeFocus ? theme.accent
+        : control.flat ? "transparent" : theme.divider
+      radius: theme.controlRadius
+    }
+
+    TextArea {
+      id: editor
+      width: control.availableWidth
+      leftPadding: theme.scaled(10)
+      rightPadding: theme.scaled(10)
+      color: theme.windowText
+      placeholderTextColor: theme.muted
+      selectionColor: theme.accent
+      selectedTextColor: theme.highlightedText
+      font.family: theme.fontFamily
+      font.pixelSize: theme.baseFontSize
+      selectByMouse: true
+      wrapMode: TextEdit.Wrap
+      background: null
+      Accessible.name: control.Accessible.name
+      Keys.onReturnPressed: event => control.submit(event)
+      Keys.onEnterPressed: event => control.submit(event)
     }
   }
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   blueferry-qt
   blueferry-quickshell
 )
-pkgver=0.7.1
+pkgver=0.7.4
 pkgrel=1
 pkgdesc='BlueFerry Bluetooth bridge from iPhone to Linux'
 arch=('any')

--- a/packaging/deb/changelog
+++ b/packaging/deb/changelog
@@ -1,3 +1,18 @@
+blueferry (0.7.4-1) unstable; urgency=medium
+
+  * Recover ANCS after Bluetooth LE reconnects without stale session races.
+  * Make message composers expand, wrap, and scroll in every client.
+  * Repair Qt utility pages and expose unavailable conversation storage.
+  * Verify Sync Contacts after successful empty phonebook pulls.
+
+ -- BlueFerry Contributors <blueferry@weirdware.io>  Sun, 16 Aug 2026 00:00:00 -0400
+
+blueferry (0.7.2-1) unstable; urgency=medium
+
+  * Prevent the privileged btmgmt helper from hanging under systemd.
+
+ -- BlueFerry Contributors <blueferry@weirdware.io>  Sun, 16 Aug 2026 00:00:00 -0400
+
 blueferry (0.7.1-1) unstable; urgency=medium
 
   * Make controller capability checks advisory and fix D-Bus advertisement

--- a/packaging/rpm/blueferry.spec
+++ b/packaging/rpm/blueferry.spec
@@ -1,5 +1,5 @@
 Name:           blueferry-backend
-Version:        0.7.1
+Version:        0.7.4
 Release:        1%{?dist}
 Summary:        iPhone Bluetooth bridge backend, daemon, and CLI
 License:        GPL-2.0-only AND MIT AND BSD-2-Clause AND PSF-2.0
@@ -196,6 +196,15 @@ fi
 %{_metainfodir}/io.weirdware.BlueFerry.Qt.metainfo.xml
 
 %changelog
+* Sun Aug 16 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.4-1
+- Recover ANCS after Bluetooth LE reconnects without stale session races.
+- Make message composers expand, wrap, and scroll in every client.
+- Repair Qt utility pages and expose unavailable conversation storage.
+- Verify Sync Contacts after successful empty phonebook pulls.
+
+* Sun Aug 16 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.2-1
+- Prevent the privileged btmgmt helper from hanging under systemd.
+
 * Sat Aug 15 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.1-1
 - Make controller capability checks advisory and fix D-Bus advertisement typing.
 - Use packaged systemd units for privileged Bluetooth setup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueferry"
-version = "0.7.1"
+version = "0.7.4"
 description = "BlueFerry brings iPhone messages, notifications, and contacts to Linux"
 authors = [
   {name = "Erik Bourget", email = "erik@ebourget.net"},

--- a/src/blueferry/__init__.py
+++ b/src/blueferry/__init__.py
@@ -1,3 +1,3 @@
 """BlueFerry — Bluetooth bridge from a paired iPhone to Linux desktop."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.4"

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -377,8 +377,9 @@ class Daemon:
     def _contacts_pulled(self, pulled: int) -> int:
         """GLib-side cache refresh after a successful PBAP pull."""
         count = self.contacts.refresh()
-        if count > 0:
-            self._mark_setup_task(CONTACTS)
+        # Completing PullAll proves that the iPhone granted Sync Contacts,
+        # even when its phonebook is empty.
+        self._mark_setup_task(CONTACTS)
         if self._dbus_service is not None:
             self._dbus_service.operations.invalidate_conversations()
             self._dbus_service.emit_history_changed()

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -65,6 +65,32 @@ Kirigami.ApplicationWindow {
         return status.map_connection_refused === true
     }
 
+    function retainedStorageUnavailable() {
+        const status = bridge.status || ({})
+        return status.daemon === true
+            && status.storage_policy !== undefined
+            && status.storage_policy !== "none"
+            && status.storage_state !== "ready"
+    }
+
+    function storageDetail() {
+        const status = bridge.status || ({})
+        if (status.storage_detail)
+            return status.storage_detail
+        return qsTr("Local conversation history is unavailable.")
+    }
+
+    function storageStatusText() {
+        const status = bridge.status || ({})
+        if (status.storage_policy === "none")
+            return qsTr("Disabled")
+        if (status.storage_state === "ready")
+            return qsTr("Available")
+        if (status.storage_state === "locked")
+            return qsTr("Locked")
+        return qsTr("Unavailable")
+    }
+
     function openPhoneSettings() {
         // Utility pages belong in Kirigami's PageRow. Its modal layers are an
         // anchored StackView internally: animated pushes warn about those
@@ -171,7 +197,7 @@ Kirigami.ApplicationWindow {
                 icon.name: "help-about"
                 onTriggered: {
                     root.closePhoneSettings()
-                    root.pageStack.push(aboutPage)
+                    root.pageStack.layers.push(aboutPage)
                 }
             },
             Kirigami.Action {
@@ -575,6 +601,27 @@ Kirigami.ApplicationWindow {
                     ]
                 }
 
+                Kirigami.InlineMessage {
+                    Layout.fillWidth: true
+                    visible: root.retainedStorageUnavailable()
+                    text: root.htmlEscape(root.storageDetail())
+                    type: Kirigami.MessageType.Warning
+                    position: Kirigami.InlineMessage.Position.Header
+                    actions: [
+                        Kirigami.Action {
+                            visible: root.bridge.status.storage_policy === "encrypted"
+                            text: qsTr("Unlock Local Data")
+                            icon.name: "document-decrypt"
+                            enabled: !root.bridge.busy
+                            onTriggered: root.bridge.unlockStorage()
+                        },
+                        Kirigami.Action {
+                            text: qsTr("Open Settings")
+                            onTriggered: root.openPhoneSettings()
+                        }
+                    ]
+                }
+
                 Controls.SplitView {
                     id: messagesSplit
                     Layout.fillWidth: true
@@ -678,8 +725,16 @@ Kirigami.ApplicationWindow {
                                 width: parent.width - Kirigami.Units.largeSpacing * 2
                                 visible: threadList.count === 0
                                 icon.name: "mail-message-new"
-                                text: qsTr("No Conversations Yet")
-                                explanation: qsTr("New iPhone messages will appear here.")
+                                text: root.bridge.status.storage_policy === "none"
+                                    ? qsTr("Conversation History Disabled")
+                                    : root.retainedStorageUnavailable()
+                                        ? qsTr("Conversation History Unavailable")
+                                        : qsTr("No Conversations Yet")
+                                explanation: root.bridge.status.storage_policy === "none"
+                                    ? qsTr("Local messages are not being retained. Choose a storage option in Settings to keep conversation history.")
+                                    : root.retainedStorageUnavailable()
+                                        ? root.storageDetail()
+                                        : qsTr("New iPhone messages will appear here.")
                             }
                         }
                     }
@@ -958,6 +1013,8 @@ Kirigami.ApplicationWindow {
                         ? "select-device" : iphonePage.effectiveStage
                     compatibility: root.bridge.onboardingCompatibility
                     status: root.bridge.status
+                    storagePolicy: root.bridge.status.storage_policy || ""
+                    storageState: root.bridge.status.storage_state || ""
                 }
 
                 Kirigami.FormLayout {
@@ -1253,6 +1310,33 @@ Kirigami.ApplicationWindow {
                             storageChangeDialog.requestedPolicy = currentValue
                             storageChangeDialog.open()
                         }
+                    }
+
+                    Controls.Label {
+                        Kirigami.FormData.label: qsTr("Status:")
+                        Layout.fillWidth: true
+                        text: root.storageStatusText()
+                        textFormat: Text.PlainText
+                    }
+
+                    Controls.Label {
+                        Kirigami.FormData.label: qsTr("Details:")
+                        Layout.fillWidth: true
+                        visible: root.bridge.status.storage_detail !== undefined
+                            && root.bridge.status.storage_detail !== ""
+                        text: root.bridge.status.storage_detail || ""
+                        textFormat: Text.PlainText
+                        wrapMode: Text.Wrap
+                    }
+
+                    Controls.Button {
+                        Kirigami.FormData.label: qsTr("Keyring:")
+                        visible: root.bridge.status.storage_policy === "encrypted"
+                            && root.bridge.status.storage_state !== "ready"
+                        text: qsTr("Unlock Local Data")
+                        icon.name: "document-decrypt"
+                        enabled: root.bridge.status.daemon === true && !root.bridge.busy
+                        onClicked: root.bridge.unlockStorage()
                     }
                 }
 

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -15,6 +15,56 @@ Kirigami.ApplicationWindow {
     property string pendingMessageHandle: ""
     property var warnedRosterChanges: ({})
 
+    component ExpandingMessageComposer: Controls.ScrollView {
+        id: messageComposer
+
+        property alias text: editor.text
+        property alias placeholderText: editor.placeholderText
+        signal accepted()
+
+        Layout.fillWidth: true
+        Layout.minimumWidth: 0
+        Layout.minimumHeight: Kirigami.Units.gridUnit * 2.5
+        Layout.preferredHeight: Math.min(
+            Math.max(
+                editor.contentHeight + editor.topPadding + editor.bottomPadding + 2,
+                Layout.minimumHeight
+            ),
+            Layout.maximumHeight
+        )
+        Layout.maximumHeight: Kirigami.Units.gridUnit * 8
+        clip: true
+        Controls.ScrollBar.horizontal.policy: Controls.ScrollBar.AlwaysOff
+        Controls.ScrollBar.vertical.policy: Controls.ScrollBar.AsNeeded
+
+        function clear() {
+            editor.clear()
+        }
+
+        function forceActiveFocus() {
+            editor.forceActiveFocus()
+        }
+
+        function submit(event) {
+            if ((event.modifiers & Qt.ShiftModifier) !== 0) {
+                event.accepted = false
+                return
+            }
+            accepted()
+            event.accepted = true
+        }
+
+        Controls.TextArea {
+            id: editor
+            width: messageComposer.availableWidth
+            wrapMode: TextEdit.Wrap
+            selectByMouse: true
+            Accessible.name: messageComposer.Accessible.name
+            Keys.onReturnPressed: event => messageComposer.submit(event)
+            Keys.onEnterPressed: event => messageComposer.submit(event)
+        }
+    }
+
     visible: true
     width: 980
     height: 680
@@ -480,6 +530,7 @@ Kirigami.ApplicationWindow {
         preferredWidth: Kirigami.Units.gridUnit * 24
         standardButtons: Kirigami.Dialog.Cancel
         customFooterActions: [Kirigami.Action {
+            id: newMessageSendAction
             text: qsTr("Send")
             icon.name: "document-send"
             enabled: newRecipient.text.trim() !== ""
@@ -550,13 +601,14 @@ Kirigami.ApplicationWindow {
                 text: qsTr("Message")
                 font.bold: true
             }
-            Controls.TextArea {
+            ExpandingMessageComposer {
                 id: newMessageBody
-                Layout.fillWidth: true
-                Layout.preferredHeight: Kirigami.Units.gridUnit * 5
                 placeholderText: qsTr("Write a Message")
-                wrapMode: TextEdit.Wrap
                 Accessible.name: qsTr("Message Text")
+                onAccepted: {
+                    if (newMessageSendAction.enabled)
+                        newMessageSendAction.trigger()
+                }
             }
         }
     }
@@ -865,9 +917,8 @@ Kirigami.ApplicationWindow {
                             Layout.fillWidth: true
                             Layout.margins: Kirigami.Units.smallSpacing
 
-                            Controls.TextField {
+                            ExpandingMessageComposer {
                                 id: composer
-                                Layout.fillWidth: true
                                 placeholderText: qsTr("Write a Message")
                                 enabled: messagesPage.thread !== null
                                     && messagesPage.thread.reply_ready && !root.bridge.busy
@@ -876,6 +927,7 @@ Kirigami.ApplicationWindow {
                             }
                             Controls.Button {
                                 id: sendButton
+                                Layout.alignment: Qt.AlignBottom
                                 text: qsTr("Send")
                                 icon.name: "document-send"
                                 enabled: composer.enabled && composer.text.trim() !== ""

--- a/src/blueferry/qt/qml/OnboardingSummary.qml
+++ b/src/blueferry/qt/qml/OnboardingSummary.qml
@@ -7,9 +7,12 @@ Kirigami.InlineMessage {
     required property string stage
     required property var compatibility
     required property var status
+    property string storagePolicy: ""
+    property string storageState: ""
 
     visible: true
-    text: htmlEscape(titleForStage()) + "\n" + htmlEscape(detailForStage())
+    text: htmlEscape(titleForStage()) + "\n"
+        + htmlEscape(detailForStage(storagePolicy, storageState))
     type: stage === "ready" || stage === "ready-without-ancs"
         ? Kirigami.MessageType.Positive
         : Kirigami.MessageType.Information
@@ -21,22 +24,28 @@ Kirigami.InlineMessage {
             .replace(/>/g, "&gt;")
     }
 
-    function pendingTasks() {
+    function pendingTasks(storagePolicy, storageState) {
         const verified = status.verified_iphone_setup || []
         const tasks = []
         if (verified.indexOf("message-notifications") < 0)
             tasks.push(qsTr("Enable Show Message Notifications"))
-        if (verified.indexOf("contacts") < 0)
-            tasks.push(qsTr("Enable Sync Contacts"))
+        if (verified.indexOf("contacts") < 0) {
+            if (storagePolicy === "encrypted" && storageState !== "ready")
+                tasks.push(qsTr("Unlock Local Data, then sync contacts again"))
+            else if (storagePolicy === "none")
+                tasks.push(qsTr("Choose a Local Data storage option to sync contacts"))
+            else
+                tasks.push(qsTr("Enable Sync Contacts"))
+        }
         if (compatibility.notifications_supported
                 && verified.indexOf("notification-access") < 0)
             tasks.push(qsTr("Allow Notification Access when prompted"))
         return tasks
     }
 
-    function pendingTasksText() {
+    function pendingTasksText(storagePolicy, storageState) {
         let detail = qsTr("Open Settings → Bluetooth on the iPhone, tap ⓘ next to this computer, then finish the settings below. After approving “Allow System Notifications,” you may need to return to the Bluetooth device list and reopen this computer before the other settings appear:\n• ")
-            + pendingTasks().join("\n• ")
+            + pendingTasks(storagePolicy, storageState).join("\n• ")
         const verified = status.verified_iphone_setup || []
         if (compatibility.notifications_supported
                 && verified.indexOf("notification-access") < 0)
@@ -57,13 +66,13 @@ Kirigami.InlineMessage {
         return titles[stage] || qsTr("Set Up BlueFerry")
     }
 
-    function detailForStage() {
+    function detailForStage(storagePolicy, storageState) {
         const details = {
             "checking": qsTr("Inspecting the selected Bluetooth controller without changing it."),
             "activate-bluetooth": qsTr("The packaged BlueZ bearer support needs one authorized Bluetooth restart."),
             "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. When the pairing request appears on the iPhone, approve it and confirm that the codes match. Pairing may appear idle for up to 15 seconds. After it completes, return to the Bluetooth device list and open this computer's ⓘ page a few times; turn on any new toggles that appear. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."),
             "starting": qsTr("The configured backend is starting. This normally takes a few seconds."),
-            "iphone-settings": pendingTasksText(),
+            "iphone-settings": pendingTasksText(storagePolicy, storageState),
             "ready": qsTr("Bluetooth services and iPhone permissions have been verified."),
             "ready-without-ancs": qsTr("Messages and contacts have been verified. System notifications are unavailable, so group texts may appear as individual conversations.")
         }

--- a/src/blueferry/tui.tcss
+++ b/src/blueferry/tui.tcss
@@ -343,7 +343,9 @@ ConversationItem.-highlight .avatar {
 }
 
 #composer-wrap {
-    height: 8;
+    height: auto;
+    min-height: 8;
+    max-height: 12;
     padding: 1 2 0 2;
     background: #10192b;
     border-top: solid #233551;
@@ -354,7 +356,9 @@ ConversationItem.-highlight .avatar {
 }
 
 #composer {
-    height: 4;
+    height: auto;
+    min-height: 4;
+    max-height: 8;
     background: #151f35;
     border: tall #2a3d5c;
     color: #f8fafc;
@@ -482,7 +486,9 @@ ModalScreen {
 }
 
 #new-body {
-    height: 8;
+    height: auto;
+    min-height: 4;
+    max-height: 8;
     background: #151f35;
 }
 

--- a/src/blueferry/ui/conversations.py
+++ b/src/blueferry/ui/conversations.py
@@ -6,7 +6,7 @@ Live signals tell this page when to refresh that backend-owned model.
 
 from __future__ import annotations
 
-from gi.repository import Adw, GLib, Gtk, Pango
+from gi.repository import Adw, Gdk, GLib, Gtk, Pango
 
 from blueferry.conversation_state import (
     ConversationSnapshot,
@@ -23,6 +23,69 @@ from blueferry.ui.status_presenter import (
 from blueferry.ui.util import format_ts
 
 _ELLIPSIZE_END = Pango.EllipsizeMode.END
+
+
+class MessageComposer(Gtk.ScrolledWindow):
+    """A wrapping message editor that grows before it starts scrolling."""
+
+    def __init__(self, placeholder: str, on_submit) -> None:
+        super().__init__(
+            hscrollbar_policy=Gtk.PolicyType.NEVER,
+            vscrollbar_policy=Gtk.PolicyType.AUTOMATIC,
+            min_content_height=44,
+            max_content_height=150,
+            propagate_natural_height=True,
+            hexpand=True,
+        )
+        self._view = Gtk.TextView(
+            accepts_tab=False,
+            wrap_mode=Gtk.WrapMode.WORD_CHAR,
+            top_margin=8,
+            bottom_margin=8,
+            left_margin=10,
+            right_margin=10,
+        )
+        self._placeholder = Gtk.Label(
+            label=placeholder,
+            css_classes=["dim-label"],
+            halign=Gtk.Align.START,
+            valign=Gtk.Align.START,
+            margin_top=8,
+            margin_start=10,
+        )
+        self._placeholder.set_can_target(False)
+        overlay = Gtk.Overlay(child=self._view)
+        overlay.add_overlay(self._placeholder)
+        self.set_child(overlay)
+        self._on_submit = on_submit
+        self._view.get_buffer().connect("changed", self._content_changed)
+        keys = Gtk.EventControllerKey()
+        keys.connect("key-pressed", self._key_pressed)
+        self._view.add_controller(keys)
+
+    def _content_changed(self, buffer) -> None:
+        self._placeholder.set_visible(buffer.get_char_count() == 0)
+        self.queue_resize()
+
+    def _key_pressed(self, _controller, keyval, _keycode, state) -> bool:
+        enter = keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter)
+        if enter and not state & Gdk.ModifierType.SHIFT_MASK:
+            self._on_submit(self)
+            return True
+        return False
+
+    def connect_changed(self, callback) -> int:
+        return self._view.get_buffer().connect("changed", callback)
+
+    def get_text(self) -> str:
+        buffer = self._view.get_buffer()
+        return buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), False)
+
+    def set_text(self, value: str) -> None:
+        self._view.get_buffer().set_text(value)
+
+    def grab_focus(self) -> bool:
+        return self._view.grab_focus()
 
 
 def _participant_lines(value: str) -> list[str]:
@@ -131,6 +194,7 @@ class ConversationsPage(Gtk.Box):
             hexpand=True,
         )
         self._msg_scroll = Gtk.ScrolledWindow(
+            hscrollbar_policy=Gtk.PolicyType.NEVER,
             hexpand=True,
             vexpand=True,
             child=self._msg_list,
@@ -199,13 +263,14 @@ class ConversationsPage(Gtk.Box):
             margin_start=6,
             margin_end=6,
         )
-        self._entry = Gtk.Entry(
-            placeholder_text=_("Write a Message"), hexpand=True, sensitive=False
+        self._entry = MessageComposer(
+            _("Write a Message"), self._on_send
         )
-        self._entry.connect("activate", self._on_send)
+        self._entry.set_sensitive(False)
         self._send_btn = Gtk.Button(
             icon_name="document-send-symbolic",
             sensitive=False,
+            valign=Gtk.Align.END,
             css_classes=["suggested-action"],
             tooltip_text=_("Send Message"),
         )
@@ -264,9 +329,12 @@ class ConversationsPage(Gtk.Box):
         )
 
         content.append(Gtk.Label(label=_("Message"), xalign=0, css_classes=["heading"]))
-        self._new_body = Gtk.Entry(placeholder_text=_("Write a Message"))
-        self._new_body.connect("changed", lambda _entry: self._update_new_send_button())
-        self._new_body.connect("activate", self._send_new_message)
+        self._new_body = MessageComposer(
+            _("Write a Message"), self._send_new_message
+        )
+        self._new_body.connect_changed(
+            lambda _buffer: self._update_new_send_button()
+        )
         content.append(self._new_body)
 
         cancel = Gtk.Button(label=_("Cancel"))
@@ -288,7 +356,7 @@ class ConversationsPage(Gtk.Box):
         self._new_message_dialog = Adw.Dialog(
             title=_("New Message"),
             content_width=440,
-            content_height=390,
+            follows_content_size=True,
             child=toolbar,
         )
 
@@ -693,6 +761,9 @@ class ConversationsPage(Gtk.Box):
                 Gtk.Label(
                     label=_("You") if message.outgoing else message.sender,
                     xalign=0,
+                    wrap=True,
+                    wrap_mode=Pango.WrapMode.WORD_CHAR,
+                    max_width_chars=46,
                     css_classes=["dim-label", "caption", "heading"],
                 )
             )
@@ -700,6 +771,7 @@ class ConversationsPage(Gtk.Box):
             label=message.body,
             xalign=0,
             wrap=True,
+            wrap_mode=Pango.WrapMode.WORD_CHAR,
             selectable=True,
             max_width_chars=46,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,10 @@ if not _running_private_suite:
 # thread-default context stacks deadlock the suite. Force a headless platform
 # and no theme plugin before any test module can import PySide6.
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
+# Package builds can reuse Qt's per-user compiled QML cache even though they
+# are testing a newly extracted source tree at the same path. Always compile
+# the QML under test from its current source.
+os.environ["QML_DISABLE_DISK_CACHE"] = "1"
 os.environ.pop("QT_QPA_PLATFORMTHEME", None)
 os.environ.pop("QT_STYLE_OVERRIDE", None)
 

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -130,6 +130,58 @@ def test_map_refusal_reveals_prominent_message_banner() -> None:
     assert banner.revealed is True
 
 
+def test_gtk_message_composer_sends_on_enter_and_keeps_shift_enter() -> None:
+    submitted = []
+    composer = SimpleNamespace(
+        _on_submit=lambda widget: submitted.append(widget),
+    )
+
+    handled = conversations.MessageComposer._key_pressed(
+        composer,
+        None,
+        conversations.Gdk.KEY_Return,
+        0,
+        conversations.Gdk.ModifierType(0),
+    )
+    shift_handled = conversations.MessageComposer._key_pressed(
+        composer,
+        None,
+        conversations.Gdk.KEY_Return,
+        0,
+        conversations.Gdk.ModifierType.SHIFT_MASK,
+    )
+
+    assert handled is True
+    assert shift_handled is False
+    assert submitted == [composer]
+
+
+def test_gtk_message_composer_placeholder_tracks_empty_buffer() -> None:
+    class Placeholder:
+        visible = None
+
+        def set_visible(self, value) -> None:
+            self.visible = value
+
+    placeholder = Placeholder()
+    resize_requests = []
+    composer = SimpleNamespace(
+        _placeholder=placeholder,
+        queue_resize=lambda: resize_requests.append(True),
+    )
+
+    conversations.MessageComposer._content_changed(
+        composer, SimpleNamespace(get_char_count=lambda: 0)
+    )
+    assert placeholder.visible is True
+
+    conversations.MessageComposer._content_changed(
+        composer, SimpleNamespace(get_char_count=lambda: 12)
+    )
+    assert placeholder.visible is False
+    assert resize_requests == [True, True]
+
+
 def test_participant_editor_keeps_unique_nonempty_lines() -> None:
     assert conversations._participant_lines(
         " +15551111111 \n\nbeau@example.com\n+15551111111\n"

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -116,6 +116,18 @@ def test_no_storage_policy_reasserts_empty_local_data(monkeypatch):
     assert cleared == ["events", "contacts"]
 
 
+def test_successful_empty_phonebook_verifies_contact_permission():
+    instance = _bare_daemon()
+    instance.contacts = SimpleNamespace(refresh=lambda: 0)
+    verified = []
+    instance._mark_setup_task = verified.append
+
+    count = instance._contacts_pulled(0)
+
+    assert count == 0
+    assert verified == [daemon_mod.CONTACTS]
+
+
 def test_status_exposes_split_ancs_and_last_le_error(monkeypatch):
     instance = _bare_daemon()
     instance.contacts = SimpleNamespace(count=lambda: 0)

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -431,6 +431,44 @@ def test_all_gui_clients_offer_contacts_aware_new_messages() -> None:
     assert 'backendBridge.request("contacts"' in quickshell
 
 
+def test_all_clients_expand_and_scroll_long_message_drafts() -> None:
+    gtk = (ROOT / "src/blueferry/ui/conversations.py").read_text()
+    qt = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
+    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+    tui_styles = (ROOT / "src/blueferry/tui.tcss").read_text()
+
+    assert gtk.count("= MessageComposer(") == 2
+    assert "Gtk.Overlay(child=self._view)" in gtk
+    assert "placeholder_text=placeholder" not in gtk
+    assert "propagate_natural_height=True" in gtk
+    assert "vscrollbar_policy=Gtk.PolicyType.AUTOMATIC" in gtk
+    assert "follows_content_size=True" in gtk
+    assert "Gdk.ModifierType.SHIFT_MASK" in gtk
+    assert gtk.count("wrap_mode=Pango.WrapMode.WORD_CHAR") == 2
+    message_viewport = gtk.split("self._msg_scroll = Gtk.ScrolledWindow(", 1)[1]
+    assert "hscrollbar_policy=Gtk.PolicyType.NEVER" in message_viewport.split(
+        ")", 1
+    )[0]
+
+    assert qt.count("ExpandingMessageComposer {") == 2
+    assert "Layout.minimumWidth: 0" in qt
+    assert "Controls.ScrollBar.vertical.policy: Controls.ScrollBar.AsNeeded" in qt
+    assert "Layout.maximumHeight: Kirigami.Units.gridUnit * 8" in qt
+    assert "Qt.ShiftModifier" in qt
+
+    assert quickshell.count("FerryMessageComposer {") == 2
+    assert "Layout.minimumWidth: 0" in quickshell
+    assert "ScrollBar.vertical.policy: ScrollBar.AsNeeded" in quickshell
+    assert "Layout.maximumHeight: theme.scaled(144)" in quickshell
+    assert "Qt.ShiftModifier" in quickshell
+
+    composer_styles = tui_styles.split("#composer {", maxsplit=1)[1].split(
+        "}", maxsplit=1
+    )[0]
+    assert "height: auto" in composer_styles
+    assert "max-height: 8" in composer_styles
+
+
 def test_quickshell_keeps_private_dbus_values_out_of_process_arguments() -> None:
     quickshell = _qml_bundle(ROOT / "data/quickshell")
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -187,8 +187,8 @@ def test_qt_package_ships_the_kirigami_ui_and_dependencies() -> None:
     assert "Kirigami.NavigationTabBar" not in qml
     assert "pageStack.push(iphonePageLoader.item)" in qml
     assert "sourceComponent: iphonePageComponent" in qml
-    assert "root.pageStack.push(aboutPage)" in qml
-    assert "pageStack.layers.push" not in qml
+    assert "root.pageStack.layers.push(aboutPage)" in qml
+    assert qml.count("pageStack.layers.push") == 1
     assert "Controls.StackView.Immediate" not in qml
     assert "Kirigami.AboutPage" in qml
     assert "customFooterActions" in qml
@@ -533,7 +533,7 @@ def test_all_gui_clients_offer_unencrypted_local_storage() -> None:
     assert '"Unencrypted local data"' in quickshell
 
 
-def test_gui_clients_open_encrypted_storage_without_setup_buttons() -> None:
+def test_gui_clients_handle_encrypted_storage_unlocks() -> None:
     gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
     qt_controller = (ROOT / "src/blueferry/qt/controller.py").read_text()
     qt_qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
@@ -541,7 +541,9 @@ def test_gui_clients_open_encrypted_storage_without_setup_buttons() -> None:
 
     assert "_unlock_storage_button" not in gtk
     assert "_maybe_unlock_storage" in qt_controller
-    assert "onClicked: root.bridge.unlockStorage()" not in qt_qml
+    assert "onClicked: root.bridge.unlockStorage()" in qt_qml
+    assert 'qsTr("Conversation History Unavailable")' in qt_qml
+    assert 'qsTr("Unlock Local Data")' in qt_qml
     assert "root.maybeUnlockStorage()" in quickshell
     assert "onClicked: storageUnlockProcess.running" not in quickshell
 

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -89,3 +89,23 @@ def test_qt_onboarding_summary_renders_stage_from_properties(qml_engine) -> None
     assert summary is not None
     assert "BlueFerry Is Connected" in summary.property("text")
     summary.deleteLater()
+
+
+def test_qt_onboarding_summary_explains_locked_contact_sync(qml_engine) -> None:
+    component = _component(
+        qml_engine, "src/blueferry/qt/qml/OnboardingSummary.qml"
+    )
+    summary = component.createWithInitialProperties({
+        "stage": "iphone-settings",
+        "compatibility": {"notifications_supported": False},
+        "status": {"verified_iphone_setup": ["message-notifications"]},
+    })
+
+    assert summary is not None
+    assert summary.setProperty("storagePolicy", "encrypted")
+    assert summary.setProperty("storageState", "locked")
+    assert summary.property("storagePolicy") == "encrypted"
+    assert summary.property("storageState") == "locked"
+    assert "Unlock Local Data, then sync contacts again" in summary.property("text")
+    assert "Enable Sync Contacts" not in summary.property("text")
+    summary.deleteLater()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -515,6 +515,12 @@ def test_textual_composer_sends_without_blocking_ui() -> None:
             await _wait_for_threads(app, pilot, 2)
             composer = app.query_one("#composer", TextArea)
             composer.focus()
+            compact_height = composer.size.height
+            composer.text = "\n".join(f"Line {index}" for index in range(20))
+            await pilot.pause()
+            assert compact_height < composer.size.height <= 8
+            assert composer.max_scroll_y > 0
+
             composer.text = "Line one"
             await pilot.press("shift+enter")
             assert "\n" in composer.text


### PR DESCRIPTION
## Summary

- make message composers grow, wrap, and scroll across GTK, Qt, Quickshell, and TUI clients
- keep GTK message bubbles within the conversation viewport
- repair the Kirigami About page and expose locked or unavailable conversation storage with an unlock retry
- verify Sync Contacts after successful empty phonebook pulls
- bump project and native package metadata to 0.7.4 and restore the 0.7.2 release-history entries

The KDE 8/9/10 shortcut diagnostics reported in #47 come from the upstream desktop style standard Cut/Copy/Paste bindings and are non-fatal.

## Validation

- 687 passed, 3 skipped
- Ruff
- Bandit
- mypy
- Qt and Quickshell QML lint
- AppStream validation

Addresses #47.