### PR TITLE
Release BlueFerry 0.7.5

### DIFF
--- a/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
@@ -40,6 +40,12 @@
   </developer>
 
   <releases>
+    <release version="0.7.5" date="2026-08-16">
+      <description>
+        <p>Recovers ANCS when a previously authorized iPhone stops responding
+        after a Bluetooth reconnect.</p>
+      </description>
+    </release>
     <release version="0.7.4" date="2026-08-16">
       <description>
         <p>Recovers iPhone notifications after reconnects, makes message editors

--- a/data/io.weirdware.BlueFerry.Qt.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Qt.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.7.5" date="2026-08-16"><description><p>Recovers ANCS when a previously authorized iPhone stops responding after a Bluetooth reconnect.</p></description></release>
     <release version="0.7.4" date="2026-08-16"><description><p>Recovers iPhone notifications after reconnects, makes message editors expand and wrap, and improves conversation-storage recovery.</p></description></release>
     <release version="0.7.2" date="2026-08-16"><description><p>Prevents the privileged Bluetooth setup helper from hanging when pairing under systemd.</p></description></release>
     <release version="0.7.1" date="2026-08-15"><description><p>Improves cross-distro pairing and privileged setup, makes controller capability checks advisory, and polishes Qt startup, connection health, and group messaging.</p></description></release>

--- a/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.7.5" date="2026-08-16"><description><p>Recovers ANCS when a previously authorized iPhone stops responding after a Bluetooth reconnect.</p></description></release>
     <release version="0.7.4" date="2026-08-16"><description><p>Recovers iPhone notifications after reconnects, makes message editors expand and wrap, and improves conversation-storage recovery.</p></description></release>
     <release version="0.7.2" date="2026-08-16"><description><p>Prevents the privileged Bluetooth setup helper from hanging when pairing under systemd.</p></description></release>
     <release version="0.7.1" date="2026-08-15"><description><p>Improves cross-distro pairing and privileged setup, makes controller capability checks advisory, and polishes Qt startup, connection health, and group messaging.</p></description></release>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   blueferry-qt
   blueferry-quickshell
 )
-pkgver=0.7.4
+pkgver=0.7.5
 pkgrel=1
 pkgdesc='BlueFerry Bluetooth bridge from iPhone to Linux'
 arch=('any')

--- a/packaging/deb/changelog
+++ b/packaging/deb/changelog
@@ -1,3 +1,10 @@
+blueferry (0.7.5-1) unstable; urgency=medium
+
+  * Recover ANCS when a previously authorized iPhone stops responding after
+    a Bluetooth reconnect.
+
+ -- BlueFerry Contributors <blueferry@weirdware.io>  Sun, 16 Aug 2026 00:00:00 -0400
+
 blueferry (0.7.4-1) unstable; urgency=medium
 
   * Recover ANCS after Bluetooth LE reconnects without stale session races.

--- a/packaging/rpm/blueferry.spec
+++ b/packaging/rpm/blueferry.spec
@@ -1,5 +1,5 @@
 Name:           blueferry-backend
-Version:        0.7.4
+Version:        0.7.5
 Release:        1%{?dist}
 Summary:        iPhone Bluetooth bridge backend, daemon, and CLI
 License:        GPL-2.0-only AND MIT AND BSD-2-Clause AND PSF-2.0
@@ -196,6 +196,10 @@ fi
 %{_metainfodir}/io.weirdware.BlueFerry.Qt.metainfo.xml
 
 %changelog
+* Sun Aug 16 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.5-1
+- Recover ANCS when a previously authorized iPhone stops responding after a
+  Bluetooth reconnect.
+
 * Sun Aug 16 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.4-1
 - Recover ANCS after Bluetooth LE reconnects without stale session races.
 - Make message composers expand, wrap, and scroll in every client.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueferry"
-version = "0.7.4"
+version = "0.7.5"
 description = "BlueFerry brings iPhone messages, notifications, and contacts to Linux"
 authors = [
   {name = "Erik Bourget", email = "erik@ebourget.net"},

--- a/src/blueferry/__init__.py
+++ b/src/blueferry/__init__.py
@@ -1,3 +1,3 @@
 """BlueFerry — Bluetooth bridge from a paired iPhone to Linux desktop."""
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -138,6 +138,11 @@ class AncsClient:
         self._cp_path: str | None = None
         self._notify_started = False
         self._authorized = False
+        # Keep this across bearer/subscription resets. A silent Control Point
+        # probe can mean "permission not granted yet" during onboarding, but
+        # after this client has already received an authorized response it is
+        # evidence that the rebuilt GATT transport is stale.
+        self._was_authorized = False
         self._bearer_connected: bool | None = None
         self._bearer_ready = False
         self._transport_blocked = False
@@ -769,6 +774,7 @@ class AncsClient:
         if self._authorized:
             return
         self._authorized = True
+        self._was_authorized = True
         self._cancel_authorization_retry()
         log.info("ANCS notification access authorized for %s", self.device_path)
         if self.on_status is not None:
@@ -891,6 +897,13 @@ class AncsClient:
             request.assembler.command if request else "none",
         )
         self._request_timeout_id = None
+        if request is not None and request.authorization_probe and self._was_authorized:
+            log.warning(
+                "previously authorized ANCS transport stopped responding; "
+                "resetting the LE bearer"
+            )
+            self._mark_transport_failed()
+            return False
         self._abandon_request(request)
         self._active_request = None
         self._pump_requests()

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -685,6 +685,93 @@ def test_not_connected_control_point_failure_invalidates_ancs_health(
     assert resets == [True]
 
 
+def test_authorization_timeout_resets_previously_authorized_transport(
+    monkeypatch,
+) -> None:
+    scheduled = []
+    resets = []
+
+    class _ControlPoint:
+        @staticmethod
+        def WriteValue(_value, _options, **_kwargs) -> None:
+            pass
+
+    bus = _CharacteristicBus({"/device/cp": _ControlPoint()})
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda _delay, _callback: 91,
+    )
+    monkeypatch.setattr(client_module.GLib, "source_remove", lambda _timer: None)
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        on_transport_failure=lambda: resets.append(True),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    client._started = True
+    client._notify_started = True
+    client._bearer_connected = True
+    client._bearer_ready = True
+    client._cp_path = "/device/cp"
+
+    client._queue_authorization_probe()
+    _complete_authorization_probe(client)
+    client._authorized = False
+    client._queue_authorization_probe()
+    client._request_timed_out()
+
+    assert client.connected is False
+    assert client.subscribed is False
+    assert client._transport_blocked is True
+    assert scheduled[0][0] == client_module.TRANSPORT_RESET_SECONDS
+
+    scheduled[0][1]()
+    assert resets == [True]
+
+
+def test_initial_authorization_timeout_keeps_retrying_without_transport_reset(
+    monkeypatch,
+) -> None:
+    scheduled = []
+    resets = []
+
+    class _ControlPoint:
+        @staticmethod
+        def WriteValue(_value, _options, **_kwargs) -> None:
+            pass
+
+    bus = _CharacteristicBus({"/device/cp": _ControlPoint()})
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda _delay, _callback: 91,
+    )
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        on_transport_failure=lambda: resets.append(True),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    client._started = True
+    client._notify_started = True
+    client._bearer_connected = True
+    client._bearer_ready = True
+    client._cp_path = "/device/cp"
+
+    client._queue_authorization_probe()
+    client._request_timed_out()
+
+    assert client.subscribed is True
+    assert client._transport_blocked is False
+    assert scheduled[0][0] == client_module.AUTHORIZATION_RETRY_SECONDS
+    assert resets == []
+
+
 def test_owner_change_during_start_notify_preserves_new_subscription(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- recover ANCS when a previously authorized iPhone stops responding after an LE reconnect
- preserve first-time notification authorization retries without resetting the bearer
- bump package and application metadata to 0.7.5

## Verification

- confirmed on hardware by toggling Bluetooth off and on on the paired iPhone
- `mise exec -- pytest -q` (689 passed, 3 skipped)
- `mise exec -- ruff check .`
- `mise exec -- mypy src/blueferry`
- `mise exec -- bandit -r src/blueferry -q`
- AppStream validation for all three metainfo files