### PR TITLE
Avoid RemoveSession after OBEX transport loss

### DIFF
--- a/src/blueferry/obex/sessions.py
+++ b/src/blueferry/obex/sessions.py
@@ -204,9 +204,20 @@ class SessionManager:
         self.pbap = _create_session("PBAP")
         log.info("PBAP session: %s", self.pbap.path)
 
-    def close_all(self) -> None:
+    def close_all(self, *, remove_remote: bool = True) -> None:
+        """Forget both sessions, optionally asking obexd to remove them first.
+
+        Recovery from an observed transport loss must not call RemoveSession:
+        BlueZ 5.87 can crash when that request drives an already-disconnected
+        GObex channel into read_packet(). Normal shutdown and partial-open
+        cleanup still remove live remote sessions; the next open attempt can
+        clean up any surviving stale object after the reconnect delay.
+        """
         self._closing = True
         try:
+            if not remove_remote:
+                log.debug("discarding local OBEX session state after transport loss")
+                return
             client = _client()
             for sess in (self.map, self.pbap):
                 if sess is None:

--- a/src/blueferry/profile_supervisor.py
+++ b/src/blueferry/profile_supervisor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from functools import partial
 from typing import Any, Protocol
 
 from gi.repository import GLib
@@ -29,7 +30,7 @@ class ProfileSessions(Protocol):
     def start_monitoring(self) -> None: ...
     def stop_monitoring(self) -> None: ...
     def open_all(self) -> None: ...
-    def close_all(self) -> None: ...
+    def close_all(self, *, remove_remote: bool = True) -> None: ...
 
 
 class ProfileWorker(Protocol):
@@ -112,7 +113,7 @@ class ProfileSupervisor:
             on_error=lambda error: self._open_failed(generation, error),
         )
 
-    def reconnect(self, reason: str) -> None:
+    def reconnect(self, reason: str, *, remove_remote_sessions: bool = True) -> None:
         """Discard current consumers and sessions, then reconnect shortly."""
         if self._stopping:
             return
@@ -129,14 +130,20 @@ class ProfileSupervisor:
             self._on_lost(reason)
         self._opening = False
         self._closing = True
+        close = self.sessions.close_all
+        if not remove_remote_sessions:
+            close = partial(self.sessions.close_all, remove_remote=False)
         self.worker.submit(
-            self.sessions.close_all,
+            close,
             on_success=lambda _result: self._closed(generation),
             on_error=lambda error: self._close_failed(generation, error),
         )
 
     def session_lost(self, reason: str) -> None:
-        self.reconnect(reason)
+        # The transport is already failing. Keep cleanup serialized behind any
+        # in-flight open, but do not send RemoveSession into the dead channel:
+        # BlueZ 5.87 can NULL-dereference read_err in gobex/read_packet there.
+        self.reconnect(reason, remove_remote_sessions=False)
 
     def stop(self) -> None:
         """Cancel future transitions; worker shutdown performs final cleanup."""

--- a/tests/test_profile_supervisor.py
+++ b/tests/test_profile_supervisor.py
@@ -17,6 +17,7 @@ class FakeSessions:
         self.monitoring = False
         self.opens = 0
         self.closes = 0
+        self.remote_closes = []
 
     def set_on_lost(self, callback) -> None:
         self.lost = callback
@@ -32,8 +33,9 @@ class FakeSessions:
         self.map = ObexSession("MAP", "/map")
         self.pbap = ObexSession("PBAP", "/pbap")
 
-    def close_all(self) -> None:
+    def close_all(self, *, remove_remote: bool = True) -> None:
         self.closes += 1
+        self.remote_closes.append(remove_remote)
         self.map = None
         self.pbap = None
 
@@ -150,7 +152,7 @@ def test_map_connection_refusal_is_exposed_and_polls_quickly_until_ready() -> No
     assert scheduled[-1][0] == INITIAL_MAP_CONNECT_POLL_SECONDS
 
 
-def test_loss_closes_once_then_reconnects() -> None:
+def test_loss_discards_once_then_reconnects() -> None:
     supervisor, sessions, worker, scheduled, ready, lost, _statuses = (
         make_supervisor()
     )
@@ -165,6 +167,7 @@ def test_loss_closes_once_then_reconnects() -> None:
     assert len(worker.jobs) == 1
     worker.succeed()
     assert sessions.closes == 1
+    assert sessions.remote_closes == [False]
     assert scheduled[-1][0] == MAP_RECONNECT_POLL_SECONDS
     scheduled[-1][1]()
     worker.fail(RuntimeError("still offline"))
@@ -173,6 +176,20 @@ def test_loss_closes_once_then_reconnects() -> None:
     scheduled[-1][1]()
     worker.succeed()
     assert ready == [True, True]
+
+
+def test_explicit_reconnect_still_removes_live_remote_sessions() -> None:
+    supervisor, sessions, worker, scheduled, _ready, _lost, _statuses = (
+        make_supervisor()
+    )
+    supervisor.start()
+    worker.succeed()
+
+    supervisor.reconnect("system resumed")
+    worker.succeed()
+
+    assert sessions.remote_closes == [True]
+    assert scheduled[-1][0] == MAP_RECONNECT_POLL_SECONDS
 
 
 def test_stop_cancels_a_pending_retry_and_ignores_late_callbacks() -> None:

--- a/tests/test_session_reconnect.py
+++ b/tests/test_session_reconnect.py
@@ -92,3 +92,20 @@ def test_close_clears_state_even_when_obexd_is_unreachable(monkeypatch) -> None:
     assert manager.map is None
     assert manager.pbap is None
     assert manager._closing is False
+
+
+def test_close_can_discard_lost_sessions_without_calling_obexd(monkeypatch) -> None:
+    manager = SessionManager()
+    manager.map = ObexSession("MAP", "/session/map")
+    manager.pbap = ObexSession("PBAP", "/session/pbap")
+    monkeypatch.setattr(
+        sessions_mod,
+        "_client",
+        lambda: (_ for _ in ()).throw(AssertionError("must not call obexd")),
+    )
+
+    manager.close_all(remove_remote=False)
+
+    assert manager.map is None
+    assert manager.pbap is None
+    assert manager._closing is False


### PR DESCRIPTION
## Summary

- discard local MAP/PBAP session handles after an observed OBEX transport loss
- avoid calling `Client1.RemoveSession()` on a channel that is already disconnecting
- keep normal remote cleanup for shutdown, explicit reconnects, and partial-open failures
- cover both loss recovery and normal cleanup with regression tests

## Why

BlueZ 5.87 can crash in `gobex/read_packet()` when a non-error `GIOStatus` leaves `read_err` NULL. Our field sequence lost PBAP first, then BlueFerry called `RemoveSession()` on MAP during cleanup, driving obexd into that crash path.

Upstream bug: bluez/bluez#2407
https://github.com/bluez/bluez/issues/2407

The workaround keeps cleanup serialized through the OBEX worker but only discards local handles after an observed loss. Any surviving stale remote object is deferred to the delayed reopen path. A live retry of the same recovery scenario completed without crashing obexd.

## Testing

- `pytest -q tests/test_session_reconnect.py tests/test_profile_supervisor.py` — 14 passed
- full `pytest -q` — 691 passed, 3 skipped
- `ruff check` on changed files
- `mypy` on changed source files