### PR TITLE
Relicense BlueFerry as GPL-2.0-or-later

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,8 @@ Copyright (C) 2026 Gabe Shatunovsky <gabriel@shatunovsky.com>
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
-Foundation, version 2 only.
+Foundation, either version 2 of the License, or (at your option) any later
+version.
 
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991

--- a/README.md
+++ b/README.md
@@ -307,4 +307,4 @@ Shatunovsky. The ANCS constants and wire-format code are adapted from
 [ANCS4Linux](https://github.com/bmh129/ancs4linux), by Paweł Zmarzły and
 Bradley Harmon, under GPL-2.0-or-later.
 
-BlueFerry is licensed under [GPL-2.0-only](LICENSE).
+BlueFerry is licensed under [GPL-2.0-or-later](LICENSE).

--- a/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>io.weirdware.BlueFerry.Gtk</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0-only</project_license>
+  <project_license>GPL-2.0-or-later</project_license>
 
   <name>BlueFerry</name>
   <summary>Your iPhone's messages and notifications on the Linux desktop</summary>

--- a/data/io.weirdware.BlueFerry.Qt.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Qt.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>io.weirdware.BlueFerry.Qt</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0-only</project_license>
+  <project_license>GPL-2.0-or-later</project_license>
   <name>BlueFerry</name>
   <summary>Use your iPhone's messages and notifications on KDE</summary>
   <description><p>A native Kirigami client for the local BlueFerry Bluetooth backend, with safe conversation replies and one adaptive iPhone page for setup, connection health, notification preferences, and maintenance.</p></description>

--- a/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>io.weirdware.BlueFerry.Quickshell</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0-only</project_license>
+  <project_license>GPL-2.0-or-later</project_license>
   <name>BlueFerry Quickshell</name>
   <summary>Use your iPhone from Quickshell</summary>
   <description><p>A lightweight, Quattro-theme-aware Quickshell conversation client for the local BlueFerry backend.</p></description>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgrel=1
 pkgdesc='BlueFerry Bluetooth bridge from iPhone to Linux'
 arch=('any')
 url='https://github.com/erikwb/blueferry'
-license=('GPL-2.0-only')
+license=('GPL-2.0-or-later')
 makedepends=(
   'dbus'
   'python-build'

--- a/packaging/deb/copyright
+++ b/packaging/deb/copyright
@@ -4,7 +4,7 @@ Source: https://github.com/erikwb/blueferry
 
 Files: *
 Copyright: 2026 BlueFerry contributors
-License: GPL-2.0-only
+License: GPL-2.0-or-later
 
 Files: packaging/vendor/textual/wheels/*
 Copyright: Textual and dependency contributors
@@ -12,6 +12,6 @@ License: MIT and BSD-2-Clause and PSF-2.0
 Comment: Each wheel retains its authoritative upstream license file and
  package metadata under its *.dist-info directory.
 
-License: GPL-2.0-only
+License: GPL-2.0-or-later
  On Debian systems, the complete text of the GNU General Public License,
  version 2, is available in /usr/share/common-licenses/GPL-2.

--- a/packaging/rpm/blueferry.spec
+++ b/packaging/rpm/blueferry.spec
@@ -2,7 +2,7 @@ Name:           blueferry-backend
 Version:        0.7.5
 Release:        1%{?dist}
 Summary:        iPhone Bluetooth bridge backend, daemon, and CLI
-License:        GPL-2.0-only AND MIT AND BSD-2-Clause AND PSF-2.0
+License:        GPL-2.0-or-later AND MIT AND BSD-2-Clause AND PSF-2.0
 URL:            https://github.com/erikwb/blueferry
 Source0:        blueferry-%{version}.tar.gz
 BuildArch:      noarch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   {name = "Erik Bourget", email = "erik@ebourget.net"},
   {name = "Gabe Shatunovsky", email = "gabriel@shatunovsky.com"},
 ]
-license = "GPL-2.0-only"
+license = "GPL-2.0-or-later"
 requires-python = ">=3.10"
 readme = "README.md"
 classifiers = [

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -963,7 +963,7 @@ Kirigami.ApplicationWindow {
                 authors: [],
                 credits: [],
                 translators: [],
-                licenses: [{name: "GPL-2.0-only", text: "", spdx: "GPL-2.0-only"}],
+                licenses: [{name: "GPL-2.0-or-later", text: "", spdx: "GPL-2.0-or-later"}],
                 copyrightStatement: qsTr("Copyright © 2026 Erik Bourget <erik@ebourget.net>\nCopyright © 2026 Gabe Shatunovsky <gabriel@shatunovsky.com>"),
                 desktopFileName: "io.weirdware.BlueFerry.Qt"
             })


### PR DESCRIPTION
## Summary

- update the project license grant from GPL v2 only to GPL v2 or any later version
- synchronize Python, distro packaging, AppStream, README, and Qt About metadata

## Validation

- AppStream validation passed for all three metainfo files
- pyproject.toml and AppStream XML parse successfully
- git diff --check passed