### PR TITLE
Restore initial ANCS subscription bootstrap

### DIFF
--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -118,6 +118,7 @@ class AncsClient:
         on_bluez_restart: Callable[[], None] | None = None,
         on_transport_failure: Callable[[], None] | None = None,
         *,
+        previously_authorized: bool = False,
         schedule: Callable[[int, Callable[[], bool]], int] = GLib.timeout_add_seconds,
         cancel: Callable[[int], object] = GLib.source_remove,
     ) -> None:
@@ -142,7 +143,7 @@ class AncsClient:
         # probe can mean "permission not granted yet" during onboarding, but
         # after this client has already received an authorized response it is
         # evidence that the rebuilt GATT transport is stale.
-        self._was_authorized = False
+        self._was_authorized = previously_authorized
         self._bearer_connected: bool | None = None
         self._bearer_ready = False
         self._transport_blocked = False
@@ -588,10 +589,18 @@ class AncsClient:
     def _try_subscribe(self) -> None:
         if self._notify_started:
             return
-        if (
-            self._bearer_connected is not True
-            or not self._bearer_ready
-            or self._transport_blocked
+        if self._transport_blocked:
+            return
+        # During first-time authorization, registering the GATT notification
+        # subscriptions is part of the connection bootstrap on some iPhone
+        # and controller combinations. In particular, BlueZ can expose the
+        # bonded ANCS characteristics while Bearer.LE1 remains disconnected
+        # and its explicit Connect method fails. Once authorization has ever
+        # succeeded, retain the stricter settled-bearer requirement so stale
+        # GATT objects cannot masquerade as a live subscription after a
+        # reconnect.
+        if self._was_authorized and (
+            self._bearer_connected is not True or not self._bearer_ready
         ):
             return
         if not (self._ns_path and self._ds_path and self._cp_path):
@@ -662,12 +671,14 @@ class AncsClient:
                     match.remove()
                 except Exception:
                     log.debug("could not roll back ANCS signal watch", exc_info=True)
-            if _connection_was_lost(e):
+            if _connection_was_lost(e) and self._was_authorized:
                 self._mark_transport_failed()
             else:
                 # Do not StopNotify a characteristic that succeeded before a
                 # later CCC write failed. On retry its Notifying property lets
-                # us resume without racing ATT teardown in bluetoothd.
+                # us resume without racing ATT teardown in bluetoothd. Before
+                # first authorization, a disconnected error is also retried:
+                # the pending subscription is part of the LE bootstrap.
                 self._schedule_subscribe_retry()
             return
         if not current_attempt():
@@ -876,7 +887,7 @@ class AncsClient:
             name = error.get_dbus_name() or type(error).__name__
             detail = error.get_dbus_message() or str(error)
             log.warning("ANCS CP WriteValue failed: %s: %s", name, detail)
-            if _connection_was_lost(error):
+            if _connection_was_lost(error) and self._was_authorized:
                 self._mark_transport_failed()
                 return
             self._abandon_request(request)

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -285,6 +285,9 @@ class Daemon:
                 include_non_message_notifications=lambda: (
                     self.notification_policy.value == ALL_NOTIFICATIONS
                 ),
+                previously_authorized=(
+                    NOTIFICATION_ACCESS in self.setup_verification.verified
+                ),
             )
             try:
                 candidate.observe_bearer_state(self.bearers.le_state)

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -481,6 +481,240 @@ def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
     assert ds.start_calls == 1
 
 
+def test_initial_subscription_bootstraps_a_disconnected_le_bearer(
+    monkeypatch,
+) -> None:
+    calls = []
+
+    class _Characteristic:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def StartNotify(self, **_kwargs) -> None:
+            calls.append(("start", self.name))
+
+        def WriteValue(self, _value, _options, **_kwargs) -> None:
+            calls.append(("write", self.name))
+
+    bus = _CharacteristicBus({
+        "/device/ns": _Characteristic("ns"),
+        "/device/ds": _Characteristic("ds"),
+        "/device/cp": _Characteristic("cp"),
+    })
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda _delay, _callback: 9,
+    )
+    client = AncsClient("/device", lambda _event: None)
+    client._started = True
+    client._bearer_connected = False
+    client._bearer_ready = False
+    client._ns_path = "/device/ns"
+    client._ds_path = "/device/ds"
+    client._cp_path = "/device/cp"
+
+    client._try_subscribe()
+
+    assert calls == [
+        ("start", "ns"),
+        ("start", "ds"),
+        ("write", "cp"),
+    ]
+    assert client.subscribed is True
+    assert client.authorized is False
+    assert client.connected is False
+
+
+def test_disconnected_initial_subscription_keeps_retrying(monkeypatch) -> None:
+    scheduled = []
+    resets = []
+
+    class _Characteristic:
+        def __init__(self, *, fail_once: bool = False) -> None:
+            self.fail_once = fail_once
+            self.start_calls = 0
+
+        def StartNotify(self, **_kwargs) -> None:
+            self.start_calls += 1
+            if self.fail_once:
+                self.fail_once = False
+                raise client_module.dbus.exceptions.DBusException(
+                    "Not connected",
+                    name="org.bluez.Error.NotConnected",
+                )
+
+        @staticmethod
+        def WriteValue(_value, _options, **_kwargs) -> None:
+            return None
+
+    ns = _Characteristic(fail_once=True)
+    ds = _Characteristic()
+    cp = _Characteristic()
+    bus = _CharacteristicBus(
+        {"/device/ns": ns, "/device/ds": ds, "/device/cp": cp}
+    )
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda _delay, _callback: 9,
+    )
+    monkeypatch.setattr(client_module.GLib, "source_remove", lambda _timer: None)
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        on_transport_failure=lambda: resets.append(True),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    client._started = True
+    client._bearer_connected = False
+    client._bearer_ready = False
+    client._ns_path = "/device/ns"
+    client._ds_path = "/device/ds"
+    client._cp_path = "/device/cp"
+
+    client._try_subscribe()
+
+    assert client.subscribed is False
+    assert client._transport_blocked is False
+    assert resets == []
+    assert scheduled[0][0] == client_module.SUBSCRIBE_RETRY_SECONDS
+
+    scheduled[0][1]()
+
+    assert ns.start_calls == 2
+    assert ds.start_calls == 1
+    assert client.subscribed is True
+    assert client._transport_blocked is False
+
+
+def test_disconnected_initial_authorization_write_keeps_retrying(
+    monkeypatch,
+) -> None:
+    scheduled = []
+    resets = []
+
+    class _Characteristic:
+        @staticmethod
+        def StartNotify(**_kwargs) -> None:
+            return None
+
+    class _ControlPoint:
+        def __init__(self) -> None:
+            self.write_calls = 0
+
+        def WriteValue(self, _value, _options, **_kwargs) -> None:
+            self.write_calls += 1
+            if self.write_calls == 1:
+                raise client_module.dbus.exceptions.DBusException(
+                    "Not connected",
+                    name="org.bluez.Error.NotConnected",
+                )
+
+    cp = _ControlPoint()
+    bus = _CharacteristicBus({
+        "/device/ns": _Characteristic(),
+        "/device/ds": _Characteristic(),
+        "/device/cp": cp,
+    })
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda _delay, _callback: 9,
+    )
+    monkeypatch.setattr(client_module.GLib, "source_remove", lambda _timer: None)
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        on_transport_failure=lambda: resets.append(True),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    client._started = True
+    client._bearer_connected = False
+    client._bearer_ready = False
+    client._ns_path = "/device/ns"
+    client._ds_path = "/device/ds"
+    client._cp_path = "/device/cp"
+
+    client._try_subscribe()
+
+    assert client.subscribed is True
+    assert client.authorized is False
+    assert client._transport_blocked is False
+    assert resets == []
+    assert scheduled[0][0] == client_module.AUTHORIZATION_RETRY_SECONDS
+
+    scheduled[0][1]()
+
+    assert cp.write_calls == 2
+    _complete_authorization_probe(client)
+    assert client.authorized is True
+    assert client.connected is False
+
+
+def test_previously_authorized_subscription_waits_for_a_settled_bearer(
+    monkeypatch,
+) -> None:
+    calls = []
+    scheduled = []
+
+    class _Characteristic:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def StartNotify(self, **_kwargs) -> None:
+            calls.append(("start", self.name))
+
+        def WriteValue(self, _value, _options, **_kwargs) -> None:
+            calls.append(("write", self.name))
+
+    bus = _CharacteristicBus({
+        "/device/ns": _Characteristic("ns"),
+        "/device/ds": _Characteristic("ds"),
+        "/device/cp": _Characteristic("cp"),
+    })
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(
+        client_module.GLib,
+        "timeout_add_seconds",
+        lambda _delay, _callback: 9,
+    )
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        previously_authorized=True,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    client._started = True
+    client._bearer_connected = False
+    client._bearer_ready = False
+    client._ns_path = "/device/ns"
+    client._ds_path = "/device/ds"
+    client._cp_path = "/device/cp"
+
+    client._try_subscribe()
+
+    assert calls == []
+    assert scheduled == []
+
+    client.observe_bearer_state(True)
+
+    assert scheduled[0][0] == client_module.BEARER_SETTLE_SECONDS
+    scheduled[0][1]()
+    assert calls == [
+        ("start", "ns"),
+        ("start", "ds"),
+        ("write", "cp"),
+    ]
+
+
 def test_partial_start_notify_failure_reuses_live_subscription(monkeypatch) -> None:
     scheduled = []
 
@@ -600,6 +834,7 @@ def test_le_reconnect_replaces_stale_subscription_and_reauthorizes(
     client._cp_path = "/device/cp"
     client._notify_started = True
     client._authorized = True
+    client._was_authorized = True
     old_matches = [_Match(), _Match()]
     client._characteristic_signal_matches = old_matches
 
@@ -663,6 +898,7 @@ def test_not_connected_control_point_failure_invalidates_ancs_health(
     client._cp_path = "/device/cp"
     client._notify_started = True
     client._authorized = True
+    client._was_authorized = True
     matches = [_Match(), _Match()]
     client._characteristic_signal_matches = matches
 

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -47,6 +47,7 @@ def _daemon(calls):
     value.events = _Events(calls)
     value.profiles = _Profiles(calls)
     value.notification_policy = type("Policy", (), {"value": "messages"})()
+    value.setup_verification = type("Verification", (), {"verified": ()})()
     value.ancs = None
     value._watch_sleep_resume = lambda: calls.append("sleep-watch")
     return value
@@ -91,8 +92,9 @@ def test_full_daemon_starts_ancs_client(monkeypatch):
     monkeypatch.setattr(daemon.config, "ANCS_ENABLED", True)
 
     class Ancs:
-        def __init__(self, *_args, **_kwargs):
+        def __init__(self, *_args, **kwargs):
             calls.append("ancs-client")
+            calls.append(("previously-authorized", kwargs["previously_authorized"]))
 
         def observe_bearer_state(self, connected):
             calls.append(("ancs-bearer", connected))
@@ -108,6 +110,41 @@ def test_full_daemon_starts_ancs_client(monkeypatch):
     value._initialize_bluetooth()
 
     assert "ancs-client" in calls
+    assert ("previously-authorized", False) in calls
     assert ("ancs-bearer", False) in calls
     assert "ancs-start" in calls
     assert value.ancs is not None
+
+
+def test_full_daemon_preserves_known_ancs_reconnect_protection(monkeypatch):
+    calls = []
+    value = _daemon(calls)
+    value.setup_verification = type(
+        "Verification",
+        (),
+        {"verified": (daemon.NOTIFICATION_ACCESS,)},
+    )()
+    _ready_bluetooth(monkeypatch, calls)
+    monkeypatch.setattr(daemon.config, "ANCS_ENABLED", True)
+
+    class Ancs:
+        def __init__(self, *_args, **kwargs):
+            calls.append(("previously-authorized", kwargs["previously_authorized"]))
+
+        @staticmethod
+        def observe_bearer_state(_connected):
+            return None
+
+        @staticmethod
+        def start():
+            return None
+
+        @staticmethod
+        def stop():
+            return None
+
+    monkeypatch.setattr(daemon, "AncsClient", Ancs)
+
+    value._initialize_bluetooth()
+
+    assert ("previously-authorized", True) in calls


### PR DESCRIPTION
## Summary

- allow first-time ANCS subscription setup to bootstrap while BlueZ still reports the LE bearer disconnected
- retry initial `StartNotify` and Control Point not-connected failures instead of latching them as stale reconnect failures
- seed prior ANCS authorization from persisted setup verification so already-authorized reconnects retain the stricter bearer-settle and transport-reset protections

## Why

The diagnostic attached to #58 shows that explicit pairing succeeded, both BR/EDR and LE were bonded, and all three ANCS characteristics were discovered. `Bearer.LE1.Connect` then failed with `org.bluez.Error.Failed`, leaving the bearer disconnected.

Since 0.7.4, the ANCS client has required a positively connected and settled bearer before calling `StartNotify`. That protects reconnects from stale BlueZ GATT state, but on this Realtek controller the initial subscription is itself part of establishing the usable LE connection. The result was a bootstrap deadlock and no iOS notification-access prompt.

This change distinguishes first authorization from recovery after a previously working authorization. Initial setup gets the permissive bootstrap behavior; established pairings keep the reconnect safeguards.

Addresses #58.

## Validation

- `pytest -q` — 696 passed, 3 skipped
- `ruff check .`
- `mypy src/blueferry`
