### PR TITLE
Record pairing options in diagnostic reports

### DIFF
--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -703,6 +703,10 @@ def complete_pairing(
     if confirmation is None and not _allow_headless:
         raise PairingError("Pairing requires an interactive confirmation callback")
     attempt = quirks_report.start_attempt(interactive=confirmation is not None)
+    attempt["pairing_options"] = {
+        "compatibility_mode": bool(compatibility_mode),
+        "explicit_pairing": bool(explicit_pairing),
+    }
     try:
         outcome = _execute_pairing(
             mac,

--- a/src/blueferry/pairing_policy.py
+++ b/src/blueferry/pairing_policy.py
@@ -80,6 +80,6 @@ def resolve_pairing_policy(
         ancs_capable=ancs_capable,
         ancs_enabled=not compatibility_mode,
         solicitation_enabled=solicitation_enabled,
-        user_forced=force_compatibility,
+        user_forced=force_compatibility or force_explicit_pairing,
         reason=reason,
     )

--- a/src/blueferry/pairing_types.py
+++ b/src/blueferry/pairing_types.py
@@ -24,6 +24,7 @@ class PairingAttempt(TypedDict, total=False):
     controller: dict[str, Any]
     phone: dict[str, Any]
     daemon: dict[str, Any]
+    pairing_options: dict[str, bool]
     pairing_policy: dict[str, Any]
     pairing_transaction: str
     preferred_bearer: str

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import stat
 
 import pytest
@@ -1839,9 +1840,16 @@ def test_interactive_pairing_can_use_explicit_pair_without_connecting(monkeypatc
     ]
     report = pair_setup.quirks_report.issue_report()
     assert report is not None
-    payload = report.read_text()
-    assert '"pairing_transaction": "explicit-device-pair"' in payload
-    assert '"event": "pair_fallback"' not in payload
+    payload = json.loads(report.read_text())
+    assert payload["pairing_transaction"] == "explicit-device-pair"
+    assert payload["pairing_options"] == {
+        "compatibility_mode": False,
+        "explicit_pairing": True,
+    }
+    assert payload["pairing_policy"]["user_forced"] is True
+    assert "pair_fallback" not in {
+        item["event"] for item in payload["timeline"]
+    }
 
 
 def test_peer_initiated_pairing_is_allowed_to_finish(monkeypatch):

--- a/tests/test_pairing_policy.py
+++ b/tests/test_pairing_policy.py
@@ -75,3 +75,4 @@ def test_user_can_force_explicit_pairing_independently_of_compatibility() -> Non
     assert policy.mode is PairingMode.FULL
     assert policy.pairing_strategy == "explicit-device-pair"
     assert policy.ancs_enabled is True
+    assert policy.user_forced is True

--- a/tests/test_quirks_report.py
+++ b/tests/test_quirks_report.py
@@ -460,6 +460,10 @@ def test_complete_pairing_writes_a_scrubbed_success_report(
         "solicitation_enabled": True,
         "user_forced": False,
     }
+    assert parsed["pairing_options"] == {
+        "compatibility_mode": False,
+        "explicit_pairing": False,
+    }
     assert "adapter" not in parsed
     assert "compatibility" not in parsed
     assert Path(result.quirks_report).is_relative_to(report_dir)
@@ -595,6 +599,10 @@ def test_failed_pairing_still_writes_a_report(report_dir, monkeypatch) -> None:
     assert parsed["outcome"]["map"] is None
     assert parsed["outcome"]["ancs"] is None
     assert "error" in parsed["outcome"]
+    assert parsed["pairing_options"] == {
+        "compatibility_mode": False,
+        "explicit_pairing": False,
+    }
     events = [item["event"] for item in parsed["timeline"]]
     assert events[0] == "start"
     assert events[-1] == "failed"


### PR DESCRIPTION
Summary:
- record compatibility-mode and explicit-pairing selections in every pairing report
- capture options before Bluetooth setup so failed attempts include them
- treat either manual pairing override as user-forced policy

Testing:
- 696 passed, 3 skipped
- Ruff
- mypy
- qmllint