### PR TITLE
Fix user service startup on systemd 255

### DIFF
--- a/systemd/blueferry.service
+++ b/systemd/blueferry.service
@@ -21,7 +21,6 @@ RestartSec=5
 TimeoutStopSec=180
 UMask=0077
 NoNewPrivileges=true
-CapabilityBoundingSet=
 PrivateDevices=true
 PrivateTmp=true
 ProtectClock=true

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -91,9 +91,14 @@ def test_backend_unit_does_not_source_user_controlled_process_environment() -> N
 
     assert "EnvironmentFile=" not in unit
     assert "NoNewPrivileges=true" in unit
-    assert "CapabilityBoundingSet=" in unit
     assert "ProtectSystem=strict" in unit
     assert "RestrictAddressFamilies=AF_UNIX" in unit
+
+
+def test_backend_user_unit_does_not_change_process_capabilities() -> None:
+    unit = (ROOT / "systemd" / "blueferry.service").read_text()
+
+    assert "CapabilityBoundingSet=" not in unit
 
 
 def test_backend_package_includes_maintained_protocol_findings() -> None:


### PR DESCRIPTION
## Summary

- stop applying an empty capability bounding set in the unprivileged backend user unit
- retain `NoNewPrivileges` and the existing filesystem, namespace, device, and address-family restrictions
- prevent capability directives from returning to the user unit

## Validation

- 711 passed in the hermetic D-Bus suite
- 58 focused namespace and native-packaging tests passed
- Ruff
- Bandit
- mypy
- `systemd-analyze --user verify systemd/blueferry.service`

Closes #63.