### PR TITLE
Keep Debian user service compatible with systemd 255

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -49,6 +49,12 @@ jobs:
         run: pacman -U --noconfirm packaging/arch/*.pkg.tar.zst
       - name: Smoke test
         run: |
+          install -d -m700 /tmp/blueferry-systemd-analyze
+          XDG_RUNTIME_DIR=/tmp/blueferry-systemd-analyze \
+            systemd-analyze --user verify --recursive-errors=no --man=no \
+            blueferry.service
+          systemd-analyze verify --recursive-errors=no --man=no \
+            blueferry-btmgmt-set-class@hci0.service
           if command -v systemd-analyze >/dev/null; then
             systemd-analyze verify --man=no bluetooth.service
           fi
@@ -81,6 +87,12 @@ jobs:
       - name: Install and smoke-test the exact Arch artifacts
         run: |
           pacman -U --noconfirm packages/*.pkg.tar.zst
+          install -d -m700 /tmp/blueferry-systemd-analyze
+          XDG_RUNTIME_DIR=/tmp/blueferry-systemd-analyze \
+            systemd-analyze --user verify --recursive-errors=no --man=no \
+            blueferry.service
+          systemd-analyze verify --recursive-errors=no --man=no \
+            blueferry-btmgmt-set-class@hci0.service
           if command -v systemd-analyze >/dev/null; then
             systemd-analyze verify --man=no bluetooth.service
           fi
@@ -123,6 +135,16 @@ jobs:
         run: apt-get install -y ./dist/deb/*.deb
       - name: Smoke test
         run: |
+          install -d -m700 /tmp/blueferry-systemd-analyze
+          XDG_RUNTIME_DIR=/tmp/blueferry-systemd-analyze \
+            systemd-analyze --user verify --recursive-errors=no --man=no \
+            blueferry.service
+          systemd-analyze verify --recursive-errors=no --man=no \
+            blueferry-btmgmt-set-class@hci0.service
+          compatibility_override=/usr/lib/systemd/user/blueferry.service.d/20-capability-compat.conf
+          for option in PrivateDevices ProtectClock ProtectKernelLogs ProtectKernelModules; do
+            grep -Fx "$option=false" "$compatibility_override"
+          done
           test ! -e /usr/lib/systemd/system/bluetooth.service.d/blueferry.conf
           ! dpkg-query -L blueferry-backend | grep -F '/bluetooth.service.d/'
           blueferry version
@@ -194,6 +216,16 @@ jobs:
       - name: Install and smoke-test the exact Debian artifacts
         run: |
           apt-get install -y ${{ matrix.packages }}
+          install -d -m700 /tmp/blueferry-systemd-analyze
+          XDG_RUNTIME_DIR=/tmp/blueferry-systemd-analyze \
+            systemd-analyze --user verify --recursive-errors=no --man=no \
+            blueferry.service
+          systemd-analyze verify --recursive-errors=no --man=no \
+            blueferry-btmgmt-set-class@hci0.service
+          compatibility_override=/usr/lib/systemd/user/blueferry.service.d/20-capability-compat.conf
+          for option in PrivateDevices ProtectClock ProtectKernelLogs ProtectKernelModules; do
+            grep -Fx "$option=false" "$compatibility_override"
+          done
           test ! -e /usr/lib/systemd/system/bluetooth.service.d/blueferry.conf
           ! dpkg-query -L blueferry-backend | grep -F '/bluetooth.service.d/'
           dpkg --compare-versions "$(dpkg-query -W -f='${Version}' bluez)" ge 5.72
@@ -228,6 +260,12 @@ jobs:
         run: dnf install -y --allowerasing dist/rpm/*.noarch.rpm
       - name: Smoke test
         run: |
+          install -d -m700 /tmp/blueferry-systemd-analyze
+          XDG_RUNTIME_DIR=/tmp/blueferry-systemd-analyze \
+            systemd-analyze --user verify --recursive-errors=no --man=no \
+            blueferry.service
+          systemd-analyze verify --recursive-errors=no --man=no \
+            blueferry-btmgmt-set-class@hci0.service
           blueferry version
           python3 -c 'import blueferry; print(blueferry.__version__)'
           python3 -c 'import gi; gi.require_version("Secret", "1"); from gi.repository import Secret'
@@ -266,6 +304,12 @@ jobs:
       - name: Install and smoke-test the exact Fedora artifacts
         run: |
           dnf install -y --allowerasing packages/*.noarch.rpm
+          install -d -m700 /tmp/blueferry-systemd-analyze
+          XDG_RUNTIME_DIR=/tmp/blueferry-systemd-analyze \
+            systemd-analyze --user verify --recursive-errors=no --man=no \
+            blueferry.service
+          systemd-analyze verify --recursive-errors=no --man=no \
+            blueferry-btmgmt-set-class@hci0.service
           if command -v systemd-analyze >/dev/null; then
             systemd-analyze verify --man=no bluetooth.service
           fi

--- a/packaging/deb/20-capability-compat.conf
+++ b/packaging/deb/20-capability-compat.conf
@@ -1,0 +1,8 @@
+# systemd 255 user managers cannot apply the implicit capability bounding-set
+# changes made by these sandboxing options. The backend remains an
+# unprivileged service with the other restrictions from blueferry.service.
+[Service]
+PrivateDevices=false
+ProtectClock=false
+ProtectKernelLogs=false
+ProtectKernelModules=false

--- a/packaging/deb/blueferry-backend.install
+++ b/packaging/deb/blueferry-backend.install
@@ -9,6 +9,7 @@ usr/lib/python3*/dist-packages/blueferry/sinks
 usr/lib/python3*/dist-packages/blueferry-*.dist-info
 usr/lib/blueferry/vendor
 usr/lib/systemd/user/blueferry.service
+usr/lib/systemd/user/blueferry.service.d/20-capability-compat.conf
 usr/lib/systemd/user/default.target.wants/blueferry.service
 usr/lib/systemd/system/blueferry-btmgmt-set-class@.service
 usr/lib/blueferry/blueferry-set-cod

--- a/packaging/deb/rules
+++ b/packaging/deb/rules
@@ -27,6 +27,8 @@ override_dh_auto_install:
 	done
 	install -Dm644 systemd/blueferry.service \
 		debian/tmp/usr/lib/systemd/user/blueferry.service
+	install -Dm644 packaging/deb/20-capability-compat.conf \
+		debian/tmp/usr/lib/systemd/user/blueferry.service.d/20-capability-compat.conf
 	install -Dm644 systemd/blueferry-btmgmt-set-class@.service \
 		debian/tmp/usr/lib/systemd/system/blueferry-btmgmt-set-class@.service
 	install -Dm755 systemd/blueferry-set-cod \

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -95,7 +95,7 @@ def test_backend_unit_does_not_source_user_controlled_process_environment() -> N
     assert "RestrictAddressFamilies=AF_UNIX" in unit
 
 
-def test_backend_user_unit_does_not_change_process_capabilities() -> None:
+def test_backend_user_unit_does_not_set_a_capability_bounding_set() -> None:
     unit = (ROOT / "systemd" / "blueferry.service").read_text()
 
     assert "CapabilityBoundingSet=" not in unit

--- a/tests/test_native_packaging.py
+++ b/tests/test_native_packaging.py
@@ -145,6 +145,34 @@ def test_native_backends_install_systemd_privilege_dependencies() -> None:
     assert "pkexec" not in spec
 
 
+def test_deb_disables_user_manager_capability_changes() -> None:
+    unit = (ROOT / "systemd/blueferry.service").read_text()
+    override_name = "20-capability-compat.conf"
+    override = (ROOT / "packaging/deb" / override_name).read_text()
+    deb_rules = (ROOT / "packaging/deb/rules").read_text()
+    deb_install = (ROOT / "packaging/deb/blueferry-backend.install").read_text()
+    arch = (ROOT / "packaging/arch/PKGBUILD").read_text()
+    rpm = (ROOT / "packaging/rpm/blueferry.spec").read_text()
+
+    capability_changing_options = (
+        "PrivateDevices",
+        "ProtectClock",
+        "ProtectKernelLogs",
+        "ProtectKernelModules",
+    )
+    for option in capability_changing_options:
+        assert f"{option}=true" in unit
+        assert f"{option}=false" in override
+
+    assert "CapabilityBoundingSet=" not in unit + override
+    assert f"packaging/deb/{override_name}" in deb_rules
+    installed_override = f"blueferry.service.d/{override_name}"
+    assert installed_override in deb_rules
+    assert installed_override in deb_install
+    assert override_name not in arch
+    assert override_name not in rpm
+
+
 def test_native_backends_ship_the_btmgmt_system_unit_template() -> None:
     unit_name = "blueferry-btmgmt-set-class@.service"
     unit = (ROOT / "systemd" / unit_name).read_text()
@@ -247,6 +275,14 @@ def test_package_workflow_installs_identical_artifacts_on_targets() -> None:
     assert workflow.count(
         "systemd-analyze verify --man=no bluetooth.service"
     ) == 3
+    assert workflow.count(
+        "systemd-analyze --user verify --recursive-errors=no --man=no"
+    ) == 6
+    assert workflow.count(
+        "systemd-analyze verify --recursive-errors=no --man=no"
+    ) == 6
+    assert workflow.count("blueferry-btmgmt-set-class@hci0.service") == 6
+    assert workflow.count("compatibility_override=/usr/lib/systemd/user/") == 2
     assert "GH_REPO: ${{ github.repository }}" in workflow
 
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -292,6 +292,18 @@ async def _wait_for_static_text(
     return widget
 
 
+async def _wait_for_static_text_containing(
+    app: BlueFerryApp, pilot, selector: str, expected: str,
+) -> Static:
+    widget = app.query_one(selector, Static)
+    for _attempt in range(30):
+        if expected in widget.render().plain:
+            return widget
+        await pilot.pause(0.05)
+    assert expected in widget.render().plain
+    return widget
+
+
 async def _wait_for_message_meta(
     app: BlueFerryApp, pilot, expected_prefix: str,
 ) -> Static:
@@ -391,9 +403,12 @@ def test_textual_warns_about_bluez_restart_when_only_ancs_is_missing(
         app = BlueFerryApp(TuiState(MissingAncsBackend()), monitor_factory=lambda: None)
 
         async with app.run_test(size=(70, 36)) as pilot:
-            await _wait_for_threads(app, pilot, 2)
-            notice = app.query_one("#notice-bar", Static)
-            assert "sudo systemctl restart bluetooth.service" in notice.render().plain
+            notice = await _wait_for_static_text_containing(
+                app,
+                pilot,
+                "#notice-bar",
+                "sudo systemctl restart bluetooth.service",
+            )
             assert notice.has_class("warn")
             assert notice.region.height >= 3
 


### PR DESCRIPTION
## Summary

- ship a DEB-only user-service override for sandbox options that trigger capability failures under systemd 255
- retain the complete sandbox on Arch and Fedora packages
- verify both installed systemd units throughout the native-package release matrix
- assert that Debian artifacts contain the compatibility override

## Testing

- `pytest -q` — 711 passed, 3 skipped
- built and inspected the Debian packages locally
- [Native packages workflow](https://github.com/erikwb/blueferry/actions/runs/32079187968)

Fixes #63