### PR TITLE
Release BlueFerry 0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.7.7](https://github.com/erikwb/blueferry/releases/tag/v0.7.7) - 2026-08-17
+
+### Fixed
+
+- Keep the Debian backend user service compatible with systemd 255 while
+  retaining stronger sandboxing in other native packages.
+
 ## [0.7.6](https://github.com/erikwb/blueferry/releases/tag/v0.7.6) - 2026-08-17
 
 ### Added

--- a/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
@@ -40,6 +40,12 @@
   </developer>
 
   <releases>
+    <release version="0.7.7" date="2026-08-17">
+      <description>
+        <p>Restores Debian backend startup on systemd 255 while retaining
+        stronger service sandboxing in other native packages.</p>
+      </description>
+    </release>
     <release version="0.7.6" date="2026-08-17">
       <description>
         <p>Adds local conversation deletion, improves pairing diagnostics and

--- a/data/io.weirdware.BlueFerry.Qt.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Qt.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.7.7" date="2026-08-17"><description><p>Restores Debian backend startup on systemd 255 while retaining stronger service sandboxing in other native packages.</p></description></release>
     <release version="0.7.6" date="2026-08-17"><description><p>Adds local conversation deletion, improves pairing diagnostics and Bluetooth recovery, and fixes backend startup on systemd 255.</p></description></release>
     <release version="0.7.5" date="2026-08-16"><description><p>Recovers ANCS when a previously authorized iPhone stops responding after a Bluetooth reconnect.</p></description></release>
     <release version="0.7.4" date="2026-08-16"><description><p>Recovers iPhone notifications after reconnects, makes message editors expand and wrap, and improves conversation-storage recovery.</p></description></release>

--- a/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.7.7" date="2026-08-17"><description><p>Restores Debian backend startup on systemd 255 while retaining stronger service sandboxing in other native packages.</p></description></release>
     <release version="0.7.6" date="2026-08-17"><description><p>Adds local conversation deletion, improves pairing diagnostics and Bluetooth recovery, and fixes backend startup on systemd 255.</p></description></release>
     <release version="0.7.5" date="2026-08-16"><description><p>Recovers ANCS when a previously authorized iPhone stops responding after a Bluetooth reconnect.</p></description></release>
     <release version="0.7.4" date="2026-08-16"><description><p>Recovers iPhone notifications after reconnects, makes message editors expand and wrap, and improves conversation-storage recovery.</p></description></release>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   blueferry-qt
   blueferry-quickshell
 )
-pkgver=0.7.6
+pkgver=0.7.7
 pkgrel=1
 pkgdesc='BlueFerry Bluetooth bridge from iPhone to Linux'
 arch=('any')

--- a/packaging/deb/changelog
+++ b/packaging/deb/changelog
@@ -1,3 +1,10 @@
+blueferry (0.7.7-1) unstable; urgency=medium
+
+  * Keep the backend user service compatible with systemd 255 on Debian while
+    retaining stronger sandboxing in other native packages.
+
+ -- BlueFerry Contributors <blueferry@weirdware.io>  Mon, 17 Aug 2026 00:00:00 -0400
+
 blueferry (0.7.6-1) unstable; urgency=medium
 
   * Add backend-owned deletion of individual local conversations.

--- a/packaging/rpm/blueferry.spec
+++ b/packaging/rpm/blueferry.spec
@@ -1,5 +1,5 @@
 Name:           blueferry-backend
-Version:        0.7.6
+Version:        0.7.7
 Release:        1%{?dist}
 Summary:        iPhone Bluetooth bridge backend, daemon, and CLI
 License:        GPL-2.0-or-later AND MIT AND BSD-2-Clause AND PSF-2.0
@@ -196,6 +196,9 @@ fi
 %{_metainfodir}/io.weirdware.BlueFerry.Qt.metainfo.xml
 
 %changelog
+* Mon Aug 17 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.7-1
+- Keep the Debian backend user service compatible with systemd 255.
+
 * Mon Aug 17 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.6-1
 - Add backend-owned deletion of individual local conversations.
 - Record pairing-mode choices in diagnostic reports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueferry"
-version = "0.7.6"
+version = "0.7.7"
 description = "BlueFerry brings iPhone messages, notifications, and contacts to Linux"
 authors = [
   {name = "Erik Bourget", email = "erik@ebourget.net"},

--- a/src/blueferry/__init__.py
+++ b/src/blueferry/__init__.py
@@ -1,3 +1,3 @@
 """BlueFerry — Bluetooth bridge from a paired iPhone to Linux desktop."""
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"


### PR DESCRIPTION
## Summary

- bump BlueFerry and native package metadata to 0.7.7
- document the Debian systemd 255 backend-service compatibility fix
- add the 0.7.7 release to each client's AppStream metadata

## Validation

- `python -m pytest -q`
- `ruff check .`
- `bandit -r src/blueferry -q`
- `mypy src/blueferry`
- AppStream and desktop-file validation
- `python -m build --no-isolation`