### PR TITLE
Fix Arch build when mise or a virtualenv shadows /usr/bin/python

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ sudo pacman -S --needed base-devel python
 Run `./build.sh` without `-i` to build without installing. Finished packages
 are written to `packaging/arch/`.
 
+The build always uses `/usr/bin/python`, because the build and test
+dependencies are Arch packages for the system interpreter. A mise, pyenv,
+conda, or activated virtualenv python earlier in `PATH` is ignored rather
+than producing a package for the wrong `site-packages` directory. mise is
+part of the standard Omarchy install, so this is worth knowing there.
+
 #### Debian based distros
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ are written to `packaging/arch/`.
 The build always uses `/usr/bin/python`, because the build and test
 dependencies are Arch packages for the system interpreter. A mise, pyenv,
 conda, or activated virtualenv python earlier in `PATH` is ignored rather
-than producing a package for the wrong `site-packages` directory. mise is
-part of the standard Omarchy install, so this is worth knowing there.
+than producing a package for the wrong `site-packages` directory.
 
 #### Debian based distros
 

--- a/build.sh
+++ b/build.sh
@@ -32,14 +32,10 @@ elif [[ ${1:-} == "--" ]]; then
     shift
 fi
 
-# makepkg must build against the system interpreter. python-build,
-# python-installer, and every checkdepend are Arch packages installed only for
-# /usr/bin/python, and the PKGBUILD derives the installed site-packages path
-# from whichever python it finds first. A mise, pyenv, conda, or activated
-# virtualenv python earlier in PATH either fails in build() with "No module
-# named build" or, worse, silently produces a package whose modules land in a
-# site-packages directory the system interpreter never reads. mise ships in
-# Omarchy's base install, so this is the common case there.
+# python-build and python-installer are installed only for /usr/bin/python
+# the PKGBUILD derives the installed site-packages from whichever python it finds first,
+# so systems that have python earlier on the path (such as via mise, in the case of Omarchy 4 machines)
+# must explicityly use /usr/bin/python
 if [[ ! -x /usr/bin/python ]]; then
     echo "error: /usr/bin/python not found; install the 'python' package" >&2
     exit 127

--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,24 @@ elif [[ ${1:-} == "--" ]]; then
     shift
 fi
 
+# makepkg must build against the system interpreter. python-build,
+# python-installer, and every checkdepend are Arch packages installed only for
+# /usr/bin/python, and the PKGBUILD derives the installed site-packages path
+# from whichever python it finds first. A mise, pyenv, conda, or activated
+# virtualenv python earlier in PATH either fails in build() with "No module
+# named build" or, worse, silently produces a package whose modules land in a
+# site-packages directory the system interpreter never reads. mise ships in
+# Omarchy's base install, so this is the common case there.
+if [[ ! -x /usr/bin/python ]]; then
+    echo "error: /usr/bin/python not found; install the 'python' package" >&2
+    exit 127
+fi
+shadowing_python=$(command -v python 2>/dev/null || true)
+if [[ -n "$shadowing_python" && ! "$shadowing_python" -ef /usr/bin/python ]]; then
+    echo "note: ignoring $shadowing_python; building with /usr/bin/python"
+fi
+export PATH="/usr/bin:$PATH"
+
 for command in git gzip makepkg python tar; do
     command -v "$command" >/dev/null || {
         echo "error: required command not found: $command" >&2

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -46,6 +46,14 @@ source=("$pkgbase-$pkgver.tar.gz")
 # working-tree snapshot. The digest file is ignored and excluded from source.
 sha256sums=("$(<.source-sha256)")
 
+# Build, test, and install with the system interpreter. python-build,
+# python-installer, and the checkdepends are Arch packages for /usr/bin/python
+# only, and _site below must name the interpreter that will import the
+# installed package. This is a no-op in a clean chroot; it matters when makepkg
+# runs from a shell where mise, pyenv, conda, or an activated virtualenv puts a
+# different python first.
+PATH="/usr/bin:$PATH"
+
 _site="usr/lib/python$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')/site-packages"
 _stage='package-stage'
 

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -52,7 +52,7 @@ been configured, the backend also starts at login. Package upgrades and normal
 Bluetooth reconnects do not require manual systemd commands.
 
 The optional Omarchy bar widget is distributed separately from
-[blueferry-quattro](https://github.com/erikwb/blueferry-quattro).
+[omarchy-blueferry](https://github.com/erikwb/omarchy-blueferry).
 
 ## Removing BlueFerry
 


### PR DESCRIPTION
I hit this issue on my Omarchy 4 machine and had claude help me fix it.

```
python: No module named build
==> ERROR: A failure occurred in build().
```

the script now enforces using /usr/bin/python instead of other copies that may be in the user's PATH.

Claude also noticed a broken link in the README and adjusted it to the right one.