### PR TITLE
Keep the mypy pass hermetic against host site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,14 @@ ignore_missing_imports = true
 warn_unused_ignores = true
 check_untyped_defs = true
 
+# typer pulls in rich, whose optional Jupyter support imports IPython, which
+# imports numpy. mypy parses installed stubs with the *target* grammar, and
+# numpy's stubs use PEP 695 `type` statements, so a 3.10 target rejects them.
+# None of these are ours to check — don't follow them.
+[[tool.mypy.overrides]]
+module = ["IPython.*", "numpy.*"]
+follow_imports = "skip"
+
 [[tool.mypy.overrides]]
 module = [
   "blueferry.backend_operations",


### PR DESCRIPTION
Fixes #77.

`mypy` follows imports into whatever is installed alongside it and parses those stubs with the **target** grammar rather than the running interpreter's. `python_version = "3.10"` matches `requires-python`, so numpy 2.5's stubs — which use PEP 695 `type` statements — are a syntax error, and `check()` dies after `build()` has already produced the wheel:

```
numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
```

Nothing here imports numpy. The path is `typer` → `rich`, whose optional Jupyter support does `from IPython.core.formatters import BaseFormatter` inside a function body, and `IPython/core/formatters.py` imports numpy. mypy builds its import graph statically, so the function-local import is followed all the same.

This skips both modules instead of raising `python_version`, which would quietly retire the 3.10 compatibility guard `requires-python` asks for. `--no-site-packages` would also fix it, but at the cost of real typing for typer and textual.

The override is inert where `ipython` and `numpy` are absent, so this is a no-op in a clean chroot and in CI, which installs only the declared dependencies — the same shape as #73.

### Verification

- `mypy src/blueferry` → `Success: no issues found in 73 source files`, on a machine with ipython 9.16.1 and numpy 2.5.2 installed (fails without this change)
- `./build.sh` → all four split packages build, full `check()` passes: ruff, bandit, mypy, pytest + coverage, desktop-file-validate, appstreamcli, qmllint

### Caveat

If `warn_unused_configs` is ever enabled, this section will warn in environments where neither package is installed.
