### PR TITLE
Quickshell: replace the emoji gear with theme-colored text buttons

### DIFF
--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -883,10 +883,13 @@ ShellRoot {
               RowLayout {
                 Layout.fillWidth: true
                 FerryButton {
-                  text: "⚙"
-                  implicitWidth: implicitHeight
-                  labelSize: theme.displaySize
+                  text: "SETTINGS"
+                  labelSize: theme.captionSize
+                  labelBold: true
+                  labelLetterSpacing: 1
                   bare: true
+                  subtle: true
+                  leftPadding: theme.scaled(4)
                   Accessible.name: "iPhone settings"
                   ToolTip.visible: hovered
                   ToolTip.text: "iPhone settings"
@@ -1528,10 +1531,13 @@ ShellRoot {
             RowLayout {
               Layout.fillWidth: true
               FerryButton {
-                text: "⚙"
-                implicitWidth: implicitHeight
-                labelSize: theme.displaySize
+                text: "‹ MESSAGES"
+                labelSize: theme.captionSize
+                labelBold: true
+                labelLetterSpacing: 1
                 bare: true
+                subtle: true
+                leftPadding: theme.scaled(4)
                 Accessible.name: "Back to messages"
                 ToolTip.visible: hovered
                 ToolTip.text: "Back to messages"
@@ -2040,6 +2046,9 @@ ShellRoot {
     id: control
     property real labelSize: theme.baseFontSize
     property bool bare: false
+    property bool subtle: false
+    property bool labelBold: false
+    property real labelLetterSpacing: 0
     implicitHeight: theme.scaled(34)
     leftPadding: theme.scaled(12)
     rightPadding: theme.scaled(12)
@@ -2051,10 +2060,12 @@ ShellRoot {
       textFormat: Text.PlainText
       color: !control.enabled ? theme.muted
         : control.bare && control.hovered ? theme.accent
-        : control.highlighted ? theme.primaryText : theme.windowText
+        : control.highlighted ? theme.primaryText
+        : control.subtle ? theme.muted : theme.windowText
       font.family: theme.fontFamily
       font.pixelSize: control.labelSize
-      font.bold: control.highlighted
+      font.bold: control.labelBold || control.highlighted
+      font.letterSpacing: control.labelLetterSpacing
       horizontalAlignment: Text.AlignHCenter
       verticalAlignment: Text.AlignVCenter
       elide: Text.ElideRight


### PR DESCRIPTION
Fixes #79.

## The bug

The sidebar settings button rendered as a blue color-emoji, ignoring the theme — the only non-theme-colored element in the window.

`FerryButton` *does* set a theme color on its content `Text` (`shell.qml:2052`), but it never applies: `iA Writer Mono S` has no glyph for `⚙` U+2699, and because that codepoint carries `Emoji=Yes`, Qt's fallback resolves to `NotoColorEmoji.ttf` — a color-bitmap font that discards `color:` outright.

Verified in isolation, in a standalone Qt 6 window with no BlueFerry code involved: the same glyph with an explicit `color: "#E8B87D"` still renders blue.

Worth noting the `✦` at `shell.qml:1055` is *also* absent from the base font yet renders correctly in `theme.muted` — the difference is only that U+2726 isn't emoji-flagged, so it falls back to a monochrome font. The bug is specific to emoji-flagged codepoints, not to font fallback generally.

## The fix

Swapping in a different symbol only moves the problem — the base font contains none of the plausible alternatives (`✳`, `※`, `≡`, `⌘` all missing), so it would stay dependent on which fallback Qt picks per machine. Using only glyphs `iA Writer Mono S` actually contains makes it deterministic, and fits the existing typographic idiom (`CONVERSATIONS`, `NO CONVERSATIONS`, `PICK A THREAD`):

| | before | after |
|---|---|---|
| sidebar (`:886`) | `⚙` | `SETTINGS` |
| settings pane (`:1531`) | `⚙` | `‹ MESSAGES` |

Both at `theme.captionSize`, bold, `letterSpacing: 1`, `theme.muted`, hovering to `theme.accent`. The sidebar button gets `leftPadding: theme.scaled(4)` so it aligns on the same left edge as the `CONVERSATIONS` header directly above it.

The settings-pane change also corrects an **affordance bug**: that button was a gear whose `Accessible.name` and `ToolTip.text` both already said "Back to messages".

Every glyph now used is verified present in `iAWriterMonoS-Regular.ttf`'s cmap, so no font fallback can hijack the color on any machine.

## Component change

`FerryButton` gains three properties — `subtle`, `labelBold`, `labelLetterSpacing` — so the call sites stay declarative instead of hardcoding a `contentItem`. **All three default to the previous behavior**, so the two other `bare: true` buttons render byte-identically.

## Size

19 insertions, 8 deletions in one file. Net +11 lines.

## Testing

- **Confirmed live in a running client** — installed over `/usr/share/blueferry/quickshell/shell.qml` on Arch Linux / Hyprland / Quickshell 0.3.1 / Qt 6.11.2. `SETTINGS` renders in `theme.muted` amber, left edge aligned with the `CONVERSATIONS` header above it. (Screenshot below; contact name redacted.)
- `qmllint` (Qt 6.11.2) — exit 0, zero warnings, matching the pre-change baseline linted in-place
- Rendered both replacement strings in a standalone Qt 6 QML window at the theme's colors and sizes, confirming they resolve to the base font and honor `color:` where `⚙` does not
- Glyph coverage checked directly against `iAWriterMonoS-Regular.ttf`'s cmap via fontTools

<img width="1381" height="1846" alt="blueferry-settings-buttons" src="https://github.com/user-attachments/assets/5638394b-fbe5-4232-bf1a-58d80d38a01e" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
