### PR TITLE
Fix Quickshell long-message layout

### DIFF
--- a/data/quickshell/QuickshellMessageBubble.qml
+++ b/data/quickshell/QuickshellMessageBubble.qml
@@ -1,0 +1,112 @@
+import QtQuick
+
+Rectangle {
+  id: root
+
+  required property var message
+  required property real availableWidth
+  required property real availableHeight
+  required property bool showSender
+  required property var ferryTheme
+
+  readonly property int bubblePadding: ferryTheme.scaled(12)
+  readonly property int contentSpacing: ferryTheme.scaled(5)
+  readonly property real maximumHeight: Math.max(
+    0, availableHeight - ferryTheme.scaled(3))
+  readonly property real naturalContentWidth: Math.max(
+    messageSender.visible ? senderMetrics.advanceWidth : 0,
+    Math.max(bodyMetrics.advanceWidth,
+             messageTimestamp.visible ? timestampMetrics.advanceWidth : 0))
+  readonly property real nonBodyHeight: bubblePadding * 2
+    + (messageSender.visible
+       ? messageSender.implicitHeight + contentSpacing : 0)
+    + (messageTimestamp.visible
+       ? messageTimestamp.implicitHeight + contentSpacing : 0)
+  readonly property int maximumBodyLines: Math.max(
+    1, Math.floor((maximumHeight - nonBodyHeight) / bodyFontMetrics.lineSpacing))
+  readonly property bool bodyTruncated: messageBody.truncated
+
+  width: Math.min(availableWidth * 0.76,
+                  Math.max(ferryTheme.scaled(92),
+                           naturalContentWidth + bubblePadding * 2))
+  height: Math.min(maximumHeight,
+                   bubbleContent.implicitHeight + bubblePadding * 2)
+  clip: true
+  color: message.outgoing
+    ? ferryTheme.selectedSurface : ferryTheme.raisedSurface
+  border.color: message.outgoing ? "transparent" : ferryTheme.divider
+  radius: ferryTheme.controlRadius
+
+  TextMetrics {
+    id: senderMetrics
+    font: messageSender.font
+    text: messageSender.text
+  }
+
+  TextMetrics {
+    id: bodyMetrics
+    font: messageBody.font
+    text: messageBody.text
+  }
+
+  TextMetrics {
+    id: timestampMetrics
+    font: messageTimestamp.font
+    text: messageTimestamp.text
+  }
+
+  FontMetrics {
+    id: bodyFontMetrics
+    font: messageBody.font
+  }
+
+  Column {
+    id: bubbleContent
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: parent.top
+    anchors.margins: root.bubblePadding
+    spacing: root.contentSpacing
+
+    Text {
+      id: messageSender
+      width: parent.width
+      visible: root.showSender
+      text: root.message.outgoing ? "You" : (root.message.sender || "")
+      textFormat: Text.PlainText
+      color: root.ferryTheme.windowText
+      font.family: root.ferryTheme.fontFamily
+      font.pixelSize: root.ferryTheme.captionSize
+      font.bold: true
+    }
+
+    Text {
+      id: messageBody
+      width: parent.width
+      text: root.message.body
+      textFormat: Text.PlainText
+      color: root.ferryTheme.windowText
+      font.family: root.ferryTheme.fontFamily
+      font.pixelSize: root.ferryTheme.baseFontSize
+      wrapMode: Text.Wrap
+      maximumLineCount: root.maximumBodyLines
+      elide: Text.ElideRight
+    }
+
+    Text {
+      id: messageTimestamp
+      width: parent.width
+      visible: text !== ""
+      text: root.message.display_timestamp || ""
+      textFormat: Text.PlainText
+      color: root.message.outgoing
+        ? Qt.rgba(root.ferryTheme.windowText.r,
+                  root.ferryTheme.windowText.g,
+                  root.ferryTheme.windowText.b, 0.62)
+        : root.ferryTheme.muted
+      font.family: root.ferryTheme.fontFamily
+      font.pixelSize: root.ferryTheme.captionSize
+      horizontalAlignment: Text.AlignRight
+    }
+  }
+}

--- a/data/quickshell/QuickshellMessageBubble.qml
+++ b/data/quickshell/QuickshellMessageBubble.qml
@@ -46,8 +46,9 @@ Rectangle {
   width: Math.min(availableWidth * 0.76,
                   Math.max(ferryTheme.scaled(92),
                            naturalContentWidth + bubblePadding * 2))
-  height: naturalHeight
+  height: canRenderBody ? Math.min(maximumHeight, naturalHeight) : 0
   visible: canRenderBody
+  clip: true
   color: message.outgoing
     ? ferryTheme.selectedSurface : ferryTheme.raisedSurface
   border.color: message.outgoing ? "transparent" : ferryTheme.divider

--- a/data/quickshell/QuickshellMessageBubble.qml
+++ b/data/quickshell/QuickshellMessageBubble.qml
@@ -13,25 +13,41 @@ Rectangle {
   readonly property int contentSpacing: ferryTheme.scaled(5)
   readonly property real maximumHeight: Math.max(
     0, availableHeight - ferryTheme.scaled(3))
+  readonly property real bodyLineHeight: Math.max(
+    1, Math.ceil(Math.max(bodyFontMetrics.height, bodyFontMetrics.lineSpacing)))
+  readonly property real minimumBodyHeight: bubblePadding * 2 + bodyLineHeight
+  readonly property bool canRenderBody: maximumHeight >= minimumBodyHeight
+  readonly property bool showSenderChrome: canRenderBody && showSender
+    && maximumHeight >= minimumBodyHeight
+      + messageSender.implicitHeight + contentSpacing
+  readonly property bool showTimestampChrome: canRenderBody
+    && messageTimestamp.text !== ""
+    && maximumHeight >= minimumBodyHeight
+      + (showSenderChrome
+         ? messageSender.implicitHeight + contentSpacing : 0)
+      + messageTimestamp.implicitHeight + contentSpacing
   readonly property real naturalContentWidth: Math.max(
-    messageSender.visible ? senderMetrics.advanceWidth : 0,
+    showSenderChrome ? senderMetrics.advanceWidth : 0,
     Math.max(bodyMetrics.advanceWidth,
-             messageTimestamp.visible ? timestampMetrics.advanceWidth : 0))
+             showTimestampChrome ? timestampMetrics.advanceWidth : 0))
   readonly property real nonBodyHeight: bubblePadding * 2
-    + (messageSender.visible
+    + (showSenderChrome
        ? messageSender.implicitHeight + contentSpacing : 0)
-    + (messageTimestamp.visible
+    + (showTimestampChrome
        ? messageTimestamp.implicitHeight + contentSpacing : 0)
-  readonly property int maximumBodyLines: Math.max(
-    1, Math.floor((maximumHeight - nonBodyHeight) / bodyFontMetrics.lineSpacing))
-  readonly property bool bodyTruncated: messageBody.truncated
+  readonly property int maximumBodyLines: canRenderBody
+    ? Math.max(1, Math.floor(
+        Math.max(0, maximumHeight - nonBodyHeight) / bodyLineHeight))
+    : 1
+  readonly property bool bodyTruncated: canRenderBody && messageBody.truncated
+  readonly property real naturalHeight: canRenderBody
+    ? nonBodyHeight + messageBody.implicitHeight : 0
 
   width: Math.min(availableWidth * 0.76,
                   Math.max(ferryTheme.scaled(92),
                            naturalContentWidth + bubblePadding * 2))
-  height: Math.min(maximumHeight,
-                   bubbleContent.implicitHeight + bubblePadding * 2)
-  clip: true
+  height: naturalHeight
+  visible: canRenderBody
   color: message.outgoing
     ? ferryTheme.selectedSurface : ferryTheme.raisedSurface
   border.color: message.outgoing ? "transparent" : ferryTheme.divider
@@ -71,7 +87,7 @@ Rectangle {
     Text {
       id: messageSender
       width: parent.width
-      visible: root.showSender
+      visible: root.showSenderChrome
       text: root.message.outgoing ? "You" : (root.message.sender || "")
       textFormat: Text.PlainText
       color: root.ferryTheme.windowText
@@ -89,6 +105,7 @@ Rectangle {
       font.family: root.ferryTheme.fontFamily
       font.pixelSize: root.ferryTheme.baseFontSize
       wrapMode: Text.Wrap
+      visible: root.canRenderBody
       maximumLineCount: root.maximumBodyLines
       elide: Text.ElideRight
     }
@@ -96,7 +113,7 @@ Rectangle {
     Text {
       id: messageTimestamp
       width: parent.width
-      visible: text !== ""
+      visible: root.showTimestampChrome
       text: root.message.display_timestamp || ""
       textFormat: Text.PlainText
       color: root.message.outgoing

--- a/data/quickshell/QuickshellThreadPreview.qml
+++ b/data/quickshell/QuickshellThreadPreview.qml
@@ -1,0 +1,23 @@
+import QtQuick
+
+Text {
+  id: root
+
+  required property var thread
+  required property var ferryTheme
+
+  readonly property var latestMessage: thread.messages.length
+    ? thread.messages[thread.messages.length - 1] : null
+
+  text: latestMessage
+    ? (latestMessage.outgoing ? "You: " : "") + latestMessage.body
+    : "No messages"
+  textFormat: Text.PlainText
+  color: ferryTheme.muted
+  font.family: ferryTheme.fontFamily
+  font.pixelSize: ferryTheme.captionSize
+  wrapMode: Text.NoWrap
+  maximumLineCount: 1
+  elide: Text.ElideRight
+  clip: true
+}

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -790,6 +790,7 @@ ShellRoot {
                     root.confirmedGroupSignature = ""
                   }
                   contentItem: Row {
+                    clip: true
                     spacing: theme.scaled(10)
 
                     Rectangle {
@@ -825,19 +826,15 @@ ShellRoot {
                         font.family: theme.fontFamily
                         font.pixelSize: theme.baseFontSize
                         font.bold: threadDelegate.highlighted
+                        wrapMode: Text.NoWrap
+                        maximumLineCount: 1
                         elide: Text.ElideRight
+                        clip: true
                       }
-                      Text {
+                      QuickshellThreadPreview {
                         width: parent.width
-                        text: threadDelegate.modelData.messages.length
-                          ? (threadDelegate.modelData.messages[threadDelegate.modelData.messages.length - 1].outgoing ? "You: " : "")
-                            + threadDelegate.modelData.messages[threadDelegate.modelData.messages.length - 1].body
-                          : "No messages"
-                        textFormat: Text.PlainText
-                        color: theme.muted
-                        font.family: theme.fontFamily
-                        font.pixelSize: theme.captionSize
-                        elide: Text.ElideRight
+                        thread: threadDelegate.modelData
+                        ferryTheme: theme
                       }
                     }
                   }

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -977,7 +977,8 @@ ShellRoot {
                   id: messageRow
                   required property var modelData
                   width: messageList.width
-                  height: bubble.height + theme.scaled(3)
+                  height: bubble.height > 0
+                    ? bubble.height + theme.scaled(3) : 0
 
                   QuickshellMessageBubble {
                     id: bubble

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -980,72 +980,18 @@ ShellRoot {
                   id: messageRow
                   required property var modelData
                   width: messageList.width
-                  implicitHeight: bubble.implicitHeight + theme.scaled(3)
+                  height: bubble.height + theme.scaled(3)
 
-                  Rectangle {
+                  QuickshellMessageBubble {
                     id: bubble
-                    readonly property int bubblePadding: theme.scaled(12)
-                    width: Math.min(messageList.width * 0.76,
-                                    Math.max(theme.scaled(92),
-                                      Math.max(messageSender.implicitWidth,
-                                        Math.max(messageBody.implicitWidth,
-                                                 messageTimestamp.implicitWidth))
-                                        + bubblePadding * 2))
-                    implicitHeight: bubbleContent.implicitHeight + bubblePadding * 2
+                    message: messageRow.modelData
+                    availableWidth: messageList.width
+                    availableHeight: messageList.height
+                    showSender: conversationPane.thread
+                      && conversationPane.thread.is_group
+                    ferryTheme: theme
                     anchors.right: messageRow.modelData.outgoing ? parent.right : undefined
                     anchors.left: messageRow.modelData.outgoing ? undefined : parent.left
-                    color: messageRow.modelData.outgoing
-                      ? theme.selectedSurface : theme.raisedSurface
-                    border.color: messageRow.modelData.outgoing
-                      ? "transparent" : theme.divider
-                    radius: theme.controlRadius
-
-                    Column {
-                      id: bubbleContent
-                      anchors.left: parent.left
-                      anchors.right: parent.right
-                      anchors.top: parent.top
-                      anchors.margins: bubble.bubblePadding
-                      spacing: theme.scaled(5)
-
-                      Text {
-                        id: messageSender
-                        width: parent.width
-                        visible: conversationPane.thread
-                          && conversationPane.thread.is_group
-                        text: messageRow.modelData.outgoing
-                          ? "You" : (messageRow.modelData.sender || "")
-                        textFormat: Text.PlainText
-                        color: theme.windowText
-                        font.family: theme.fontFamily
-                        font.pixelSize: theme.captionSize
-                        font.bold: true
-                      }
-                      Text {
-                        id: messageBody
-                        width: parent.width
-                        text: messageRow.modelData.body
-                        textFormat: Text.PlainText
-                        color: theme.windowText
-                        font.family: theme.fontFamily
-                        font.pixelSize: theme.baseFontSize
-                        wrapMode: Text.Wrap
-                      }
-                      Text {
-                        id: messageTimestamp
-                        width: parent.width
-                        visible: text !== ""
-                        text: messageRow.modelData.display_timestamp || ""
-                        textFormat: Text.PlainText
-                        color: messageRow.modelData.outgoing
-                          ? Qt.rgba(theme.windowText.r, theme.windowText.g,
-                                    theme.windowText.b, 0.62)
-                          : theme.muted
-                        font.family: theme.fontFamily
-                        font.pixelSize: theme.captionSize
-                        horizontalAlignment: Text.AlignRight
-                      }
-                    }
                   }
                 }
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -331,8 +331,11 @@ def test_quickshell_outgoing_bubbles_match_qt_accent_tint() -> None:
     ).read_text()
 
     assert "QuickshellMessageBubble {" in shell
-    assert "height: bubble.height + theme.scaled(3)" in shell
+    assert "height: bubble.height > 0" in shell
+    assert "? bubble.height + theme.scaled(3) : 0" in shell
     assert "availableHeight: messageList.height" in shell
+    assert "Math.min(maximumHeight, naturalHeight)" in quickshell
+    assert "clip: true" in quickshell
     assert "? ferryTheme.selectedSurface : ferryTheme.raisedSurface" in quickshell
     assert "color: root.ferryTheme.windowText" in quickshell
 
@@ -348,6 +351,14 @@ def test_quickshell_thread_preview_is_single_line() -> None:
     assert "maximumLineCount: 1" in preview
     assert "elide: Text.ElideRight" in preview
     assert "clip: true" in preview
+
+    title = shell.split("text: threadDelegate.modelData.name", 1)[1].split(
+        "QuickshellThreadPreview {", 1
+    )[0]
+    assert "wrapMode: Text.NoWrap" in title
+    assert "maximumLineCount: 1" in title
+    assert "elide: Text.ElideRight" in title
+    assert "clip: true" in title
 
 
 def test_group_message_bubbles_show_the_individual_sender() -> None:

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -331,6 +331,8 @@ def test_quickshell_outgoing_bubbles_match_qt_accent_tint() -> None:
     ).read_text()
 
     assert "QuickshellMessageBubble {" in shell
+    assert "height: bubble.height + theme.scaled(3)" in shell
+    assert "availableHeight: messageList.height" in shell
     assert "? ferryTheme.selectedSurface : ferryTheme.raisedSurface" in quickshell
     assert "color: root.ferryTheme.windowText" in quickshell
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -337,6 +337,19 @@ def test_quickshell_outgoing_bubbles_match_qt_accent_tint() -> None:
     assert "color: root.ferryTheme.windowText" in quickshell
 
 
+def test_quickshell_thread_preview_is_single_line() -> None:
+    shell = (ROOT / "data/quickshell/shell.qml").read_text()
+    preview = (
+        ROOT / "data/quickshell/QuickshellThreadPreview.qml"
+    ).read_text()
+
+    assert "QuickshellThreadPreview {" in shell
+    assert "wrapMode: Text.NoWrap" in preview
+    assert "maximumLineCount: 1" in preview
+    assert "elide: Text.ElideRight" in preview
+    assert "clip: true" in preview
+
+
 def test_group_message_bubbles_show_the_individual_sender() -> None:
     gtk = (ROOT / "src/blueferry/ui/conversations.py").read_text()
     qt_bubble = (ROOT / "src/blueferry/qt/qml/MessageBubble.qml").read_text()

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -325,22 +325,28 @@ def test_qt_message_bubbles_do_not_use_full_selection_color() -> None:
 
 
 def test_quickshell_outgoing_bubbles_match_qt_accent_tint() -> None:
-    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+    shell = (ROOT / "data/quickshell/shell.qml").read_text()
+    quickshell = (
+        ROOT / "data/quickshell/QuickshellMessageBubble.qml"
+    ).read_text()
 
-    assert "? theme.selectedSurface : theme.raisedSurface" in quickshell
-    assert "color: theme.windowText" in quickshell
+    assert "QuickshellMessageBubble {" in shell
+    assert "? ferryTheme.selectedSurface : ferryTheme.raisedSurface" in quickshell
+    assert "color: root.ferryTheme.windowText" in quickshell
 
 
 def test_group_message_bubbles_show_the_individual_sender() -> None:
     gtk = (ROOT / "src/blueferry/ui/conversations.py").read_text()
     qt_bubble = (ROOT / "src/blueferry/qt/qml/MessageBubble.qml").read_text()
     qt_view = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
-    quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
+    quickshell = (
+        ROOT / "data/quickshell/QuickshellMessageBubble.qml"
+    ).read_text()
 
     assert 'label=_("You") if message.outgoing else message.sender' in gtk
     assert 'text: root.message.outgoing ? qsTr("You")' in qt_bubble
     assert "&& messagesPage.thread.is_group" in qt_view
-    assert '? "You" : (messageRow.modelData.sender || "")' in quickshell
+    assert '? "You" : (root.message.sender || "")' in quickshell
 
 
 def test_group_roster_editors_explain_local_and_same_name_limits() -> None:

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -141,9 +141,58 @@ def test_quickshell_long_message_is_truncated_to_the_timeline_height(
     QGuiApplication.processEvents()
 
     assert bubble is not None
+    assert bubble.property("height") > 0
     assert bubble.property("height") <= 217
     assert bubble.property("bodyTruncated") is True
+    assert bubble.property("naturalHeight") <= bubble.property("maximumHeight")
+    assert bubble.property("canRenderBody") is True
     assert bubble.property("width") <= 480 * 0.76
+
+    assert bubble.setProperty("availableHeight", 0)
+    QGuiApplication.processEvents()
+    assert bubble.property("height") == 0
+    assert bubble.property("canRenderBody") is False
+    assert bubble.property("bodyTruncated") is False
+
+    minimum_viewport_height = bubble.property("minimumBodyHeight") + 3
+    assert bubble.setProperty("availableHeight", minimum_viewport_height)
+    QGuiApplication.processEvents()
+    assert bubble.property("height") > 0
+    assert bubble.property("naturalHeight") <= bubble.property("maximumHeight")
+    assert bubble.property("showSenderChrome") is False
+    assert bubble.property("showTimestampChrome") is False
+
+    assert bubble.setProperty("availableHeight", 220.0)
+    QGuiApplication.processEvents()
+    assert bubble.property("height") > 0
+    assert bubble.property("bodyTruncated") is True
+    bubble.deleteLater()
+
+
+def test_quickshell_short_message_uses_its_natural_height(qml_engine) -> None:
+    component = _component(
+        qml_engine,
+        "data/quickshell/QuickshellMessageBubble.qml",
+    )
+    theme = _BubbleTheme()
+    bubble = component.createWithInitialProperties({
+        "message": {
+            "outgoing": True,
+            "sender": "",
+            "body": "A short message",
+            "display_timestamp": "10:43 PM",
+        },
+        "availableWidth": 480.0,
+        "availableHeight": 220.0,
+        "showSender": False,
+        "ferryTheme": theme,
+    })
+    QGuiApplication.processEvents()
+
+    assert bubble is not None
+    assert 0 < bubble.property("height") < 217
+    assert bubble.property("height") == bubble.property("naturalHeight")
+    assert bubble.property("bodyTruncated") is False
     bubble.deleteLater()
 
 

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -144,9 +144,13 @@ def test_quickshell_long_message_is_truncated_to_the_timeline_height(
     assert bubble.property("height") > 0
     assert bubble.property("height") <= 217
     assert bubble.property("bodyTruncated") is True
-    assert bubble.property("naturalHeight") <= bubble.property("maximumHeight")
+    assert bubble.property("height") == min(
+        bubble.property("naturalHeight"), bubble.property("maximumHeight")
+    )
     assert bubble.property("canRenderBody") is True
     assert bubble.property("width") <= 480 * 0.76
+    assert bubble.property("showSenderChrome") is True
+    assert bubble.property("showTimestampChrome") is True
 
     assert bubble.setProperty("availableHeight", 0)
     QGuiApplication.processEvents()
@@ -166,6 +170,38 @@ def test_quickshell_long_message_is_truncated_to_the_timeline_height(
     QGuiApplication.processEvents()
     assert bubble.property("height") > 0
     assert bubble.property("bodyTruncated") is True
+    assert bubble.property("showSenderChrome") is True
+    assert bubble.property("showTimestampChrome") is True
+    bubble.deleteLater()
+
+
+def test_quickshell_fallback_glyphs_cannot_overflow_timeline(qml_engine) -> None:
+    component = _component(
+        qml_engine,
+        "data/quickshell/QuickshellMessageBubble.qml",
+    )
+    theme = _BubbleTheme()
+    bubble = component.createWithInitialProperties({
+        "message": {
+            "outgoing": False,
+            "sender": "A friend",
+            "body": "emoji 🚀 漢字 " * 200,
+            "display_timestamp": "10:42 PM",
+        },
+        "availableWidth": 480.0,
+        "availableHeight": 220.0,
+        "showSender": True,
+        "ferryTheme": theme,
+    })
+    QGuiApplication.processEvents()
+
+    assert bubble is not None
+    assert bubble.property("height") <= bubble.property("maximumHeight")
+    assert bubble.property("height") == min(
+        bubble.property("naturalHeight"), bubble.property("maximumHeight")
+    )
+    assert bubble.property("bodyTruncated") is True
+    assert bubble.property("clip") is True
     bubble.deleteLater()
 
 

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -13,8 +13,8 @@ os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 pytest.importorskip("PySide6")
 
-from PySide6.QtCore import QUrl
-from PySide6.QtGui import QGuiApplication
+from PySide6.QtCore import Property, QObject, QUrl, Slot
+from PySide6.QtGui import QColor, QGuiApplication
 from PySide6.QtQml import QQmlComponent, QQmlEngine
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -37,6 +37,48 @@ def _component(engine: QQmlEngine, relative_path: str) -> QQmlComponent:
         error.toString() for error in component.errors()
     )
     return component
+
+
+class _BubbleTheme(QObject):
+    @Property(QColor, constant=True)
+    def windowText(self) -> QColor:
+        return QColor("#f4f4f4")
+
+    @Property(QColor, constant=True)
+    def selectedSurface(self) -> QColor:
+        return QColor("#334455")
+
+    @Property(QColor, constant=True)
+    def raisedSurface(self) -> QColor:
+        return QColor("#222222")
+
+    @Property(QColor, constant=True)
+    def divider(self) -> QColor:
+        return QColor("#555555")
+
+    @Property(QColor, constant=True)
+    def muted(self) -> QColor:
+        return QColor("#999999")
+
+    @Property(str, constant=True)
+    def fontFamily(self) -> str:
+        return "Sans Serif"
+
+    @Property(int, constant=True)
+    def captionSize(self) -> int:
+        return 10
+
+    @Property(int, constant=True)
+    def baseFontSize(self) -> int:
+        return 12
+
+    @Property(int, constant=True)
+    def controlRadius(self) -> int:
+        return 8
+
+    @Slot(float, result=int)
+    def scaled(self, value: float) -> int:
+        return max(1, round(value))
 
 
 def test_quickshell_onboarding_state_derives_ready_stage(qml_engine) -> None:
@@ -74,6 +116,35 @@ def test_quickshell_unverified_controller_still_reaches_device_selection(
     assert presenter is not None
     assert presenter.property("stage") == "select-device"
     presenter.deleteLater()
+
+
+def test_quickshell_long_message_is_truncated_to_the_timeline_height(
+    qml_engine,
+) -> None:
+    component = _component(
+        qml_engine,
+        "data/quickshell/QuickshellMessageBubble.qml",
+    )
+    theme = _BubbleTheme()
+    bubble = component.createWithInitialProperties({
+        "message": {
+            "outgoing": False,
+            "sender": "A friend",
+            "body": " ".join(["long message"] * 300),
+            "display_timestamp": "10:42 PM",
+        },
+        "availableWidth": 480.0,
+        "availableHeight": 220.0,
+        "showSender": True,
+        "ferryTheme": theme,
+    })
+    QGuiApplication.processEvents()
+
+    assert bubble is not None
+    assert bubble.property("height") <= 217
+    assert bubble.property("bodyTruncated") is True
+    assert bubble.property("width") <= 480 * 0.76
+    bubble.deleteLater()
 
 
 def test_qt_onboarding_summary_renders_stage_from_properties(qml_engine) -> None:

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -196,6 +196,34 @@ def test_quickshell_short_message_uses_its_natural_height(qml_engine) -> None:
     bubble.deleteLater()
 
 
+def test_quickshell_thread_preview_stays_inside_one_line(qml_engine) -> None:
+    component = _component(
+        qml_engine,
+        "data/quickshell/QuickshellThreadPreview.qml",
+    )
+    theme = _BubbleTheme()
+    preview = component.createWithInitialProperties({
+        "thread": {
+            "messages": [{
+                "outgoing": True,
+                "body": (
+                    "A long opening line that cannot fit in the sidebar\n"
+                    "and a second line that must not escape the thread row"
+                ),
+            }],
+        },
+        "ferryTheme": theme,
+        "width": 120.0,
+    })
+    QGuiApplication.processEvents()
+
+    assert preview is not None
+    assert preview.property("lineCount") == 1
+    assert preview.property("truncated") is True
+    assert preview.property("height") == preview.property("implicitHeight")
+    preview.deleteLater()
+
+
 def test_qt_onboarding_summary_renders_stage_from_properties(qml_engine) -> None:
     component = _component(
         qml_engine, "src/blueferry/qt/qml/OnboardingSummary.qml"


### PR DESCRIPTION
## Summary

- cap timeline message bubbles to the live viewport while preserving natural sizing for short messages
- keep sidebar thread titles and latest-message previews to one clipped, elided line
- handle tiny layout passes without leaving blank message-row spacing
- add behavioral coverage for long messages, fallback glyphs, viewport recovery, and sidebar previews

## Review

Reviewed with Grok 4.6 before opening. Its fallback-font overflow finding was reproduced and fixed; the reported chrome binding cycle was checked against Qt runtime behavior and did not reproduce.

## Testing

- pytest -q (717 passed, 3 skipped)
- ruff check .
- mypy src/blueferry
- /usr/lib/qt6/bin/qmllint data/quickshell/*.qml