### PR TITLE
Make Quickshell message text selectable without layout regressions

### DIFF
--- a/data/quickshell/QuickshellMessageBubble.qml
+++ b/data/quickshell/QuickshellMessageBubble.qml
@@ -13,8 +13,12 @@ Rectangle {
   readonly property int contentSpacing: ferryTheme.scaled(5)
   readonly property real maximumHeight: Math.max(
     0, availableHeight - ferryTheme.scaled(3))
-  readonly property real bodyLineHeight: Math.max(
+  readonly property real bodyFontLineHeight: Math.max(
     1, Math.ceil(Math.max(bodyFontMetrics.height, bodyFontMetrics.lineSpacing)))
+  readonly property real bodyLineHeight: messageBody.lineCount > 0
+    ? Math.max(bodyFontLineHeight,
+               messageBody.contentHeight / messageBody.lineCount)
+    : bodyFontLineHeight
   readonly property real minimumBodyHeight: bubblePadding * 2 + bodyLineHeight
   readonly property bool canRenderBody: maximumHeight >= minimumBodyHeight
   readonly property bool showSenderChrome: canRenderBody && showSender
@@ -35,13 +39,19 @@ Rectangle {
        ? messageSender.implicitHeight + contentSpacing : 0)
     + (showTimestampChrome
        ? messageTimestamp.implicitHeight + contentSpacing : 0)
+  readonly property real maximumBodyHeight: canRenderBody
+    ? Math.max(0, maximumHeight - nonBodyHeight) : 0
   readonly property int maximumBodyLines: canRenderBody
-    ? Math.max(1, Math.floor(
-        Math.max(0, maximumHeight - nonBodyHeight) / bodyLineHeight))
-    : 1
-  readonly property bool bodyTruncated: canRenderBody && messageBody.truncated
+    ? Math.max(1, Math.floor(maximumBodyHeight / bodyLineHeight)) : 1
+  readonly property real renderedBodyHeight: canRenderBody
+    ? Math.min(maximumBodyHeight,
+               Math.min(Math.ceil(messageBody.contentHeight),
+                        maximumBodyLines * bodyLineHeight))
+    : 0
+  readonly property bool bodyTruncated: canRenderBody
+    && messageBody.contentHeight > renderedBodyHeight
   readonly property real naturalHeight: canRenderBody
-    ? nonBodyHeight + messageBody.implicitHeight : 0
+    ? nonBodyHeight + renderedBodyHeight : 0
 
   width: Math.min(availableWidth * 0.76,
                   Math.max(ferryTheme.scaled(92),
@@ -79,6 +89,7 @@ Rectangle {
 
   Column {
     id: bubbleContent
+    objectName: "bubbleContent"
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.top: parent.top
@@ -97,22 +108,53 @@ Rectangle {
       font.bold: true
     }
 
-    Text {
+    TextEdit {
       id: messageBody
+      objectName: "messageBody"
       width: parent.width
+      height: root.renderedBodyHeight
       text: root.message.body
-      textFormat: Text.PlainText
+      textFormat: TextEdit.PlainText
       color: root.ferryTheme.windowText
+      selectionColor: root.ferryTheme.accent
+      selectedTextColor: root.ferryTheme.highlightedText
       font.family: root.ferryTheme.fontFamily
       font.pixelSize: root.ferryTheme.baseFontSize
-      wrapMode: Text.Wrap
+      wrapMode: TextEdit.Wrap
       visible: root.canRenderBody
-      maximumLineCount: root.maximumBodyLines
-      elide: Text.ElideRight
+      readOnly: true
+      selectByMouse: true
+      activeFocusOnTab: false
+      persistentSelection: true
+      clip: true
+      Accessible.name: "Message body"
+
+      Rectangle {
+        id: overflowIndicator
+        objectName: "messageOverflowIndicator"
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        width: overflowGlyph.implicitWidth + root.ferryTheme.scaled(4)
+        height: overflowGlyph.implicitHeight
+        visible: root.bodyTruncated
+        color: root.color
+        z: 1
+
+        Text {
+          id: overflowGlyph
+          objectName: "messageOverflowGlyph"
+          anchors.right: parent.right
+          anchors.bottom: parent.bottom
+          text: "…"
+          color: root.ferryTheme.windowText
+          font: messageBody.font
+        }
+      }
     }
 
     Text {
       id: messageTimestamp
+      objectName: "messageTimestamp"
       width: parent.width
       visible: root.showTimestampChrome
       text: root.message.display_timestamp || ""

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -336,6 +336,11 @@ def test_quickshell_outgoing_bubbles_match_qt_accent_tint() -> None:
     assert "availableHeight: messageList.height" in shell
     assert "Math.min(maximumHeight, naturalHeight)" in quickshell
     assert "clip: true" in quickshell
+    assert "TextEdit {" in quickshell
+    assert "selectByMouse: true" in quickshell
+    assert "maximumBodyHeight" in quickshell
+    assert "messageBody.contentHeight > renderedBodyHeight" in quickshell
+    assert "visible: root.bodyTruncated" in quickshell
     assert "? ferryTheme.selectedSurface : ferryTheme.raisedSurface" in quickshell
     assert "color: root.ferryTheme.windowText" in quickshell
 

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -13,7 +13,7 @@ os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 pytest.importorskip("PySide6")
 
-from PySide6.QtCore import Property, QObject, QUrl, Slot
+from PySide6.QtCore import Property, QMetaObject, QObject, QUrl, Slot
 from PySide6.QtGui import QColor, QGuiApplication
 from PySide6.QtQml import QQmlComponent, QQmlEngine
 
@@ -59,6 +59,14 @@ class _BubbleTheme(QObject):
     @Property(QColor, constant=True)
     def muted(self) -> QColor:
         return QColor("#999999")
+
+    @Property(QColor, constant=True)
+    def accent(self) -> QColor:
+        return QColor("#4488cc")
+
+    @Property(QColor, constant=True)
+    def highlightedText(self) -> QColor:
+        return QColor("#ffffff")
 
     @Property(str, constant=True)
     def fontFamily(self) -> str:
@@ -152,6 +160,29 @@ def test_quickshell_long_message_is_truncated_to_the_timeline_height(
     assert bubble.property("showSenderChrome") is True
     assert bubble.property("showTimestampChrome") is True
 
+    body = bubble.findChild(QObject, "messageBody")
+    content = bubble.findChild(QObject, "bubbleContent")
+    timestamp = bubble.findChild(QObject, "messageTimestamp")
+    overflow = bubble.findChild(QObject, "messageOverflowIndicator")
+    overflow_glyph = bubble.findChild(QObject, "messageOverflowGlyph")
+    assert body is not None
+    assert content is not None
+    assert timestamp is not None
+    assert overflow is not None
+    assert overflow_glyph is not None
+    assert body.property("height") <= bubble.property("maximumBodyHeight")
+    assert overflow_glyph.property("text") == "…"
+    assert overflow.property("y") + overflow.property("height") <= body.property(
+        "height"
+    )
+    timestamp_bottom = (
+        content.property("y")
+        + timestamp.property("y")
+        + timestamp.property("height")
+        + bubble.property("bubblePadding")
+    )
+    assert timestamp_bottom <= bubble.property("height")
+
     assert bubble.setProperty("availableHeight", 0)
     QGuiApplication.processEvents()
     assert bubble.property("height") == 0
@@ -229,6 +260,45 @@ def test_quickshell_short_message_uses_its_natural_height(qml_engine) -> None:
     assert 0 < bubble.property("height") < 217
     assert bubble.property("height") == bubble.property("naturalHeight")
     assert bubble.property("bodyTruncated") is False
+    bubble.deleteLater()
+
+
+def test_quickshell_message_body_is_selectable_and_copyable(qml_engine) -> None:
+    component = _component(
+        qml_engine,
+        "data/quickshell/QuickshellMessageBubble.qml",
+    )
+    theme = _BubbleTheme()
+    message_text = "Verification code: 123456 " + "more details " * 200
+    bubble = component.createWithInitialProperties({
+        "message": {
+            "outgoing": False,
+            "sender": "A friend",
+            "body": message_text,
+            "display_timestamp": "10:44 PM",
+        },
+        "availableWidth": 480.0,
+        "availableHeight": 220.0,
+        "showSender": False,
+        "ferryTheme": theme,
+    })
+    QGuiApplication.processEvents()
+
+    assert bubble is not None
+    body = bubble.findChild(QObject, "messageBody")
+    assert body is not None
+    assert body.property("readOnly") is True
+    assert body.property("selectByMouse") is True
+    assert body.property("activeFocusOnTab") is False
+    assert bubble.property("bodyTruncated") is True
+    assert QMetaObject.invokeMethod(body, "selectAll") is True
+    assert body.property("selectedText") == message_text
+
+    clipboard = QGuiApplication.clipboard()
+    clipboard.clear()
+    assert QMetaObject.invokeMethod(body, "copy") is True
+    assert clipboard.text() == message_text
+    clipboard.clear()
     bubble.deleteLater()
 
 


### PR DESCRIPTION
## Summary

- render message bodies with a read-only TextEdit so text can be selected with the mouse and copied
- constrain the selectable editor to a whole-line viewport derived from its actual rendered line height
- preserve the bubble height cap, truncation indicator, and in-bounds timestamp for long and fallback-font messages
- keep the complete underlying message selectable so Select All and Copy include text beyond the visible cap

This is a regression-safe alternative to #86.

## Testing

- pytest -q (718 passed, 3 skipped)
- ruff check .
- mypy src/blueferry
- /usr/lib/qt6/bin/qmllint data/quickshell/*.qml
- offscreen visual render of a capped long message with emoji and CJK fallback glyphs