### PR TITLE
Fix Classic bearer reconnect detection

### DIFF
--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -73,6 +73,21 @@ def preferred_bearer_unavailable(error: Exception) -> bool:
     return "no such property" in detail and "preferredbearer" in detail
 
 
+def bearer_connected_unavailable(error: Exception) -> bool:
+    """True when a BlueZ bearer interface has no Connected property."""
+    if not isinstance(error, dbus.exceptions.DBusException):
+        return False
+    name = error.get_dbus_name() or ""
+    if name in {
+        "org.freedesktop.DBus.Error.UnknownInterface",
+        "org.freedesktop.DBus.Error.UnknownMethod",
+        "org.freedesktop.DBus.Error.UnknownProperty",
+    }:
+        return True
+    detail = (error.get_dbus_message() or "").casefold()
+    return "no such property" in detail and "connected" in detail
+
+
 ReadConnected = Callable[[str], bool | None]
 Connect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
 Disconnect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
@@ -463,10 +478,29 @@ class BearerSupervisor:
         obj = get_system_bus().get_object("org.bluez", self.device_path)
         properties = dbus.Interface(obj, "org.freedesktop.DBus.Properties")
         if kind == "bredr":
-            # Bearer.BREDR1 is marker-only on some packaged BlueZ builds (no
-            # Connected property). Before LE is up, Device1.Connected is the
-            # observable Classic ACL state.
-            return bool(properties.Get("org.bluez.Device1", "Connected", timeout=5.0))
+            # Device1.Connected is true when *either* bearer is up. Prefer the
+            # bearer-specific property so an LE-only link is not mistaken for
+            # the Classic connection required by MAP/PBAP. Bearer.BREDR1 is
+            # marker-only on some older packaged BlueZ builds, where the
+            # aggregate property remains the only available fallback.
+            try:
+                return bool(
+                    properties.Get(
+                        _INTERFACES["bredr"],
+                        "Connected",
+                        timeout=5.0,
+                    )
+                )
+            except dbus.exceptions.DBusException as error:
+                if not bearer_connected_unavailable(error):
+                    raise
+                return bool(
+                    properties.Get(
+                        "org.bluez.Device1",
+                        "Connected",
+                        timeout=5.0,
+                    )
+                )
         return bool(properties.Get(_INTERFACES[kind], "Connected", timeout=5.0))
 
     def _connect_bluez(

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -205,6 +205,76 @@ def test_bluez_preference_selects_requested_bearer(monkeypatch) -> None:
     ]
 
 
+def test_bluez_reads_classic_bearer_instead_of_aggregate_device_state(
+    monkeypatch,
+) -> None:
+    calls = []
+
+    class Properties:
+        @staticmethod
+        def Get(interface, name, *, timeout):
+            calls.append((interface, name, timeout))
+            if interface == "org.bluez.Bearer.BREDR1":
+                return False
+            if interface == "org.bluez.Device1":
+                return True
+            raise AssertionError(interface)
+
+    class Bus:
+        @staticmethod
+        def get_object(service, path):
+            calls.append((service, path))
+            return object()
+
+    monkeypatch.setattr(bearer_supervisor, "get_system_bus", Bus)
+    monkeypatch.setattr(
+        bearer_supervisor.dbus,
+        "Interface",
+        lambda _object, interface: calls.append(("interface", interface))
+        or Properties(),
+    )
+
+    connected = BearerSupervisor("/device")._read_bluez_connected("bredr")
+
+    assert connected is False
+    assert ("org.bluez.Device1", "Connected", 5.0) not in calls
+
+
+def test_bluez_falls_back_when_classic_bearer_is_marker_only(monkeypatch) -> None:
+    calls = []
+
+    class Properties:
+        @staticmethod
+        def Get(interface, name, *, timeout):
+            calls.append((interface, name, timeout))
+            if interface == "org.bluez.Bearer.BREDR1":
+                raise bearer_supervisor.dbus.exceptions.DBusException(
+                    "No such property 'Connected'",
+                    name="org.freedesktop.DBus.Error.UnknownProperty",
+                )
+            return True
+
+    class Bus:
+        @staticmethod
+        def get_object(_service, _path):
+            return object()
+
+    monkeypatch.setattr(bearer_supervisor, "get_system_bus", Bus)
+    monkeypatch.setattr(
+        bearer_supervisor.dbus,
+        "Interface",
+        lambda _object, _interface: Properties(),
+    )
+
+    connected = BearerSupervisor("/device")._read_bluez_connected("bredr")
+
+    assert connected is True
+    assert calls == [
+        ("org.bluez.Bearer.BREDR1", "Connected", 5.0),
+        ("org.bluez.Device1", "Connected", 5.0),
+    ]
+
+
 def test_bluez_preference_ignores_a_missing_preferred_bearer_property(monkeypatch) -> None:
     class Properties:
         @staticmethod


### PR DESCRIPTION
## Summary

- read `Bearer.BREDR1.Connected` instead of aggregate `Device1.Connected` when determining Classic connectivity
- avoid treating an LE-only iPhone connection as an active BR/EDR connection
- retain the aggregate-property fallback for older marker-only BlueZ bearer interfaces
- add regression and compatibility coverage

## Why

When LE remained connected after the Classic bearer dropped, `Device1.Connected` stayed true. BlueFerry therefore believed BR/EDR was still connected and did not explicitly restore the bearer required by MAP/PBAP.

## Verification

- `pytest -q` (720 passed, 3 skipped)
- `ruff check src/blueferry/bearer_supervisor.py tests/test_bearer_supervisor.py`
- `mypy src/blueferry/bearer_supervisor.py`