### PR TITLE
Recover Bluetooth profiles across real reconnects

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,6 +125,13 @@ attempt; compatibility mode leaves LE disabled. Pairing reports record the
 resolved policy, controller capability, ordered timeline, package build ID, and
 full source-content SHA.
 
+The adapter Class-of-Device is volatile controller state. The unprivileged
+daemon checks it at startup, after a BlueZ owner change, and periodically. On
+drift it starts one fixed, capability-bounded systemd helper that can only set
+the validated adapter index to A/V Hands-Free; a narrow Polkit rule permits
+that operation for an active local session without exposing general `btmgmt`
+or systemd control.
+
 ## Lifecycle
 
 The backend unit is a systemd user service with `Type=dbus`. Session D-Bus can

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,12 +113,15 @@ Pairing has two independent axes rather than a growing table of device quirks:
   interactive confirmation path.
 
 ANCS connection policy and ANCS solicitation are deliberately separate. After
-the Classic bond is trusted and settled, setup broadcasts the short-lived
-solicitation whenever the controller can advertise, including compatibility
-mode. Real-device testing indicates that older iOS uses this signal to expose
-its MAP/PBAP permission toggles even though BlueFerry must not connect ANCS.
-Full mode starts the daemon with LE held back until its first MAP/PBAP attempt
-completes; compatibility mode leaves LE disabled. Pairing reports record the
+the Classic bond is trusted and settled, setup broadcasts solicitation whenever
+the controller can advertise, including compatibility mode. Real-device testing
+indicates that older iOS uses this signal to expose its MAP/PBAP permission
+toggles even though BlueFerry must not connect ANCS. At runtime a dedicated
+supervisor keeps solicitation on air until MAP/PBAP and an end-to-end ANCS
+Control Point round trip are both healthy, preserves a three-minute permission
+window, and re-registers the advertisement if BlueZ releases it or changes
+D-Bus owner. Full mode holds a missing LE bearer behind every MAP/PBAP reconnect
+attempt; compatibility mode leaves LE disabled. Pairing reports record the
 resolved policy, controller capability, ordered timeline, package build ID, and
 full source-content SHA.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,6 +147,12 @@ MAP/PBAP connectivity moves through explicit initializing, connecting, ready,
 degraded, reconnecting, authorization-required, map-connection-refused, and
 stopping states. Failed profile opens poll every 5 seconds until the first
 successful MAP/PBAP connection, then every 15 seconds for later reconnects.
+Three consecutive transport-level failures while BlueZ still reports Classic
+connected escalate to one targeted `Bearer.BREDR1.Disconnect`. Profile retry
+waits until the supervisor observes Classic disconnect and reconnect; a live
+LE/ANCS bearer is left alone. Recovery cycles are rate-limited, and a missing
+or ineffective bearer-specific disconnect API falls back to ordinary profile
+polling instead of blocking it.
 Suspend/resume and observed OBEX loss enter the same reconnection path. The
 refusal state preserves the iPhone's
 `Connection refused (111)` detail so clients can explain that another computer

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -121,9 +121,12 @@ supervisor keeps solicitation on air until MAP/PBAP and an end-to-end ANCS
 Control Point round trip are both healthy, preserves a three-minute permission
 window, and re-registers the advertisement if BlueZ releases it or changes
 D-Bus owner. Full mode holds a missing LE bearer behind every MAP/PBAP reconnect
-attempt; compatibility mode leaves LE disabled. Pairing reports record the
-resolved policy, controller capability, ordered timeline, package build ID, and
-full source-content SHA.
+attempt. A genuine LE disconnect grants one fresh outbound bootstrap, and a
+later Classic return grants another if that attempt was spent while the phone
+was absent; solicitation remains the durable fallback between those lifecycle
+events. Compatibility mode leaves LE disabled. Pairing reports record the
+resolved policy, controller capability, ordered timeline, package build ID,
+and full source-content SHA.
 
 The adapter Class-of-Device is volatile controller state. The unprivileged
 daemon checks it at startup, after a BlueZ owner change, and periodically. On
@@ -147,12 +150,9 @@ MAP/PBAP connectivity moves through explicit initializing, connecting, ready,
 degraded, reconnecting, authorization-required, map-connection-refused, and
 stopping states. Failed profile opens poll every 5 seconds until the first
 successful MAP/PBAP connection, then every 15 seconds for later reconnects.
-Three consecutive transport-level failures while BlueZ still reports Classic
-connected escalate to one targeted `Bearer.BREDR1.Disconnect`. Profile retry
-waits until the supervisor observes Classic disconnect and reconnect; a live
-LE/ANCS bearer is left alone. Recovery cycles are rate-limited, and a missing
-or ineffective bearer-specific disconnect API falls back to ordinary profile
-polling instead of blocking it.
+MAP and PBAP opens are independent: if iOS rejects one profile, the other
+session and its consumers remain available while only the missing profile is
+retried. Full readiness still requires both profiles.
 Suspend/resume and observed OBEX loss enter the same reconnection path. The
 refusal state preserves the iPhone's
 `Connection refused (111)` detail so clients can explain that another computer

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -269,6 +269,9 @@ remain available. Removing the bond invalidates the saved runtime target and
 stops the daemon's connection attempts.
 
 - Keep one MAP and one PBAP session open for the daemon lifetime.
+- Open and retry MAP and PBAP independently. A successful sibling session must
+  remain available when iOS rejects the other profile; in particular, a MAP
+  refusal must not prevent PBAP contacts access.
 - Serialize blocking MAP/PBAP operations on one worker.
 - Before opening, remove only stale sessions for the target phone and profile.
 - On `Forbidden`, retry once after targeted stale-session cleanup rather than
@@ -278,13 +281,6 @@ stops the daemon's connection attempts.
   connection, then every 15 seconds for later reconnects. Preserve an iPhone
   `Connection refused (111)` response as a distinct MAP refusal state because
   another computer may currently own the phone's single MAP connection.
-- If three consecutive opens fail because the OBEX transport disconnected or
-  timed out while BlueZ still reports BR/EDR connected, cycle only
-  `Bearer.BREDR1`, wait for an observed disconnect and reconnect, then retry
-  MAP/PBAP. Do not apply this to authorization errors or an explicit MAP
-  refusal. Rate-limit repeated cycles, preserve a healthy LE bearer, and
-  abandon the targeted reset after bounded failures so an incomplete bearer
-  API cannot strand ordinary polling.
 - A transfer object can disappear after successful completion. `complete` and
   a disappearance after observable progress are successful terminal outcomes;
   explicit `error`, a timeout, or a missing output file is not.
@@ -316,13 +312,17 @@ idle. BlueFerry supervises both connections for the daemon lifetime and backs
 off exponentially when a bearer keeps refusing to connect: a rejected
 `Connect` repeated every five seconds against the iPhone was observed to keep
 the bond in a half-connected flapping state. Classic remains actively
-supervised. LE receives one speculative outbound dial per BlueZ generation;
-after that, the solicitation advertisement is the durable reconnect primitive.
-A returning inbound LE link clears Classic backoff accumulated while the phone
-was absent, and limits later Classic backoff to 30 seconds while LE remains
-healthy. A deliberate stale-GATT reset receives one new outbound bootstrap.
-If BlueZ cannot keep the solicitation registered, bounded outbound LE retries
-remain enabled rather than treating an unavailable inbound path as primed.
+supervised. LE receives one speculative outbound dial, then yields to the
+solicitation advertisement instead of repeatedly calling `Connect`. A genuine
+connected-to-disconnected LE transition grants one fresh outbound bootstrap.
+If that attempt is spent while the phone remains absent, an observed Classic
+return grants one more for the new presence generation. A returning inbound LE
+link clears Classic backoff accumulated while the phone was absent, and limits
+later Classic backoff to 30 seconds while LE remains healthy. A deliberate
+stale-GATT reset and a new BlueZ generation also receive a new outbound
+bootstrap. If BlueZ cannot keep the solicitation registered, bounded outbound
+LE retries remain enabled rather than treating an unavailable inbound path as
+primed.
 
 Solicitation remains registered until both MAP/PBAP and end-to-end ANCS are
 healthy, subject to a three-minute minimum permission window. It is restored

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -115,6 +115,11 @@ reapply the same gate; compatibility mode leaves LE disabled. Before later
 connection requests the daemon selects the corresponding BlueZ
 `PreferredBearer` when that property is available.
 
+Because `btmgmt class` is reset by controller and bluetoothd lifecycles, the
+daemon also reconciles the A/V Hands-Free Class-of-Device at startup, after a
+BlueZ owner change, and once per minute. Repair goes through the packaged fixed
+systemd helper rather than granting the daemon raw Bluetooth capabilities.
+
 On a clean iOS 26 test this ordering opened MAP/PBAP first; the pending LE
 request completed three seconds later, resolved all three ANCS characteristics,
 and presented the system-notification consent prompt. The first Control Point

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -278,6 +278,13 @@ stops the daemon's connection attempts.
   connection, then every 15 seconds for later reconnects. Preserve an iPhone
   `Connection refused (111)` response as a distinct MAP refusal state because
   another computer may currently own the phone's single MAP connection.
+- If three consecutive opens fail because the OBEX transport disconnected or
+  timed out while BlueZ still reports BR/EDR connected, cycle only
+  `Bearer.BREDR1`, wait for an observed disconnect and reconnect, then retry
+  MAP/PBAP. Do not apply this to authorization errors or an explicit MAP
+  refusal. Rate-limit repeated cycles, preserve a healthy LE bearer, and
+  abandon the targeted reset after bounded failures so an incomplete bearer
+  API cannot strand ordinary polling.
 - A transfer object can disappear after successful completion. `complete` and
   a disappearance after observable progress are successful terminal outcomes;
   explicit `error`, a timeout, or a missing output file is not.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -108,10 +108,12 @@ After authentication, setup trusts the bond, selects BR/EDR as the preferred
 bearer, lets the existing Classic ACL settle, and only then registers the
 short-lived solicitation advertisement. The daemon starts while that advert
 and BlueFerry's temporary pairing agent are still present, and its first
-profile operation is MAP/PBAP. Full mode enables LE after that first profile
-attempt completes, whether it succeeds or fails; compatibility mode leaves LE
-disabled. Before later connection requests the daemon selects the corresponding
-BlueZ `PreferredBearer` when that property is available.
+profile operation is MAP/PBAP. Full mode enables LE after a MAP/PBAP attempt
+made while Classic is observable, or immediately after a successful profile
+open that itself proves Classic reachability. Later whole-device reconnects
+reapply the same gate; compatibility mode leaves LE disabled. Before later
+connection requests the daemon selects the corresponding BlueZ
+`PreferredBearer` when that property is available.
 
 On a clean iOS 26 test this ordering opened MAP/PBAP first; the pending LE
 request completed three seconds later, resolved all three ANCS characteristics,
@@ -298,16 +300,33 @@ During first-time setup, `Device1.PreferredBearer=le` followed by
 5.87. `PreferredBearer` is treated as an instruction for the next outbound
 connection, not a durable preference: the supervisor selects `bredr` or `le`
 immediately before requesting that bearer and does not leave LE preferred while
-idle. BlueFerry supervises both connections for the daemon lifetime, repeats
-the sequence after disconnects and system resume, and backs off exponentially
-when a bearer keeps refusing to connect: a rejected `Connect` repeated every
-five seconds against the iPhone was observed to keep the bond in a
-half-connected flapping state.
+idle. BlueFerry supervises both connections for the daemon lifetime and backs
+off exponentially when a bearer keeps refusing to connect: a rejected
+`Connect` repeated every five seconds against the iPhone was observed to keep
+the bond in a half-connected flapping state. Classic remains actively
+supervised. LE receives one speculative outbound dial per BlueZ generation;
+after that, the solicitation advertisement is the durable reconnect primitive.
+A returning inbound LE link clears Classic backoff accumulated while the phone
+was absent, and limits later Classic backoff to 30 seconds while LE remains
+healthy. A deliberate stale-GATT reset receives one new outbound bootstrap.
+If BlueZ cannot keep the solicitation registered, bounded outbound LE retries
+remain enabled rather than treating an unavailable inbound path as primed.
+
+Solicitation remains registered until both MAP/PBAP and end-to-end ANCS are
+healthy, subject to a three-minute minimum permission window. It is restored
+when LE or either protocol becomes unhealthy, when BlueZ releases it, and when
+bluetoothd changes D-Bus owner. This both preserves the iOS permission signal
+and avoids occupying an advertising instance indefinitely after recovery.
 
 After LE connects, BlueFerry waits for BlueZ to enumerate the ANCS service and
 its Notification Source, Data Source, and Control Point characteristics. A
 `StartNotify` call can race GATT readiness even after the characteristics have
 appeared, so subscription failures are retried without requiring rediscovery.
+After a physical reconnect, notification registrations owned by the previous
+ATT session are explicitly stopped and started again rather than trusting a
+cached `Notifying=true`. A previously authorized Control Point failure or
+timeout escalates to one serialized `Bearer.LE1.Disconnect`; MAP/PBAP stay
+available and LE rebuilds behind the profile-ordering gate.
 
 This works on the MediaTek MT7922 and the Intel AX210 while MAP and PBAP stay
 connected over BR/EDR; on the AX210 the LE half of the bond exists only when

--- a/src/blueferry/adapter_class_supervisor.py
+++ b/src/blueferry/adapter_class_supervisor.py
@@ -1,0 +1,107 @@
+"""Keep the Bluetooth adapter identity required by iOS MAP/PBAP."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from gi.repository import GLib
+
+from blueferry import bluez_setup
+
+log = logging.getLogger(__name__)
+
+RECONCILE_SECONDS = 60
+
+ReadClass = Callable[[str], int | None]
+Matches = Callable[[int | None], bool]
+Repair = Callable[[str], bool]
+Schedule = Callable[[int, Callable[[], bool]], int]
+Cancel = Callable[[int], object]
+
+
+def _repair_with_packaged_helper(adapter: str) -> bool:
+    return bluez_setup.set_cod(adapter=adapter, authorize=True)
+
+
+class AdapterClassSupervisor:
+    """Repair Class-of-Device drift through the constrained system helper.
+
+    ``btmgmt class`` is volatile across controller and bluetoothd resets. A
+    stale generic-computer class leaves an existing LE/ANCS bond usable while
+    iOS refuses the Classic MAP/PBAP accessory path, so startup-only pairing
+    configuration is not sufficient.
+    """
+
+    def __init__(
+        self,
+        adapter: str,
+        *,
+        read_class: ReadClass = bluez_setup.current_cod,
+        matches: Matches = bluez_setup.desired_cod_matches,
+        repair: Repair = _repair_with_packaged_helper,
+        schedule: Schedule = GLib.timeout_add_seconds,
+        cancel: Cancel = GLib.source_remove,
+    ) -> None:
+        self.adapter = adapter
+        self._read_class = read_class
+        self._matches = matches
+        self._repair = repair
+        self._schedule = schedule
+        self._cancel = cancel
+        self._running = False
+        self._timer_id: int | None = None
+
+    def start(self) -> None:
+        if self._running:
+            self.poke()
+            return
+        self._running = True
+        self._reconcile()
+        self._timer_id = self._schedule(RECONCILE_SECONDS, self._tick)
+
+    def poke(self) -> None:
+        """Recheck immediately, notably after bluetoothd changes owner."""
+        if self._running:
+            self._reconcile()
+
+    def stop(self) -> None:
+        self._running = False
+        if self._timer_id is None:
+            return
+        try:
+            self._cancel(self._timer_id)
+        except Exception:
+            log.debug("could not remove adapter-class health timer", exc_info=True)
+        self._timer_id = None
+
+    def _tick(self) -> bool:
+        if not self._running:
+            return False
+        self._reconcile()
+        return True
+
+    def _reconcile(self) -> None:
+        try:
+            cod = self._read_class(self.adapter)
+        except Exception:
+            log.debug("could not inspect adapter Class-of-Device", exc_info=True)
+            return
+        if cod is None:
+            log.debug("adapter Class-of-Device is temporarily unavailable")
+            return
+        if self._matches(cod):
+            return
+        log.warning(
+            "adapter Class-of-Device drifted to 0x%06x; restoring A/V Hands-Free",
+            cod,
+        )
+        try:
+            repaired = self._repair(self.adapter)
+        except Exception:
+            log.warning("could not restore adapter Class-of-Device", exc_info=True)
+            return
+        if repaired:
+            log.info("adapter Class-of-Device restored through packaged helper")
+        else:
+            log.warning("packaged adapter-class helper did not repair the adapter")

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -148,6 +148,7 @@ class AncsClient:
         self._bearer_ready = False
         self._transport_blocked = False
         self._owned_notify_paths: set[str] = set()
+        self._notify_rearm_pending = False
 
         # In-flight per-notification attribute requests + app-name cache
         self._app_name_cache: OrderedDict[str, str] = OrderedDict()
@@ -310,6 +311,7 @@ class AncsClient:
             self._bearer_ready = False
             self._transport_blocked = False
             self._owned_notify_paths.clear()
+            self._notify_rearm_pending = False
             self._ns_path = self._ds_path = self._cp_path = None
             if was_connected and self.on_status is not None:
                 self.on_status()
@@ -405,6 +407,7 @@ class AncsClient:
                 self._notify_started
                 or self._authorized
                 or self._characteristic_signal_matches
+                or self._owned_notify_paths
                 or self._active_request is not None
                 or self._request_queue
             )
@@ -413,8 +416,9 @@ class AncsClient:
             log.info("iPhone LE bearer disconnected; resetting ANCS subscription")
             self._cancel_subscribe_retry()
             # StopNotify can block or fail while the ATT link is down. Remove
-            # our local receivers now and replace BlueZ's registration once
-            # the bearer is observably connected again.
+            # our local receivers now, remember any BlueZ registrations that
+            # we own, and replace them after the new bearer has settled.
+            self._notify_rearm_pending = bool(self._owned_notify_paths)
             self._clear_characteristic_subscription(stop_notify=False)
             if self.on_status is not None:
                 self.on_status()
@@ -509,6 +513,8 @@ class AncsClient:
         self._clear_characteristic_subscription(
             stop_notify=self._bearer_connected is True and self._bearer_ready,
         )
+        self._owned_notify_paths.clear()
+        self._notify_rearm_pending = False
         self._remove_manager_watches()
         if self._owner_signal_match is not None:
             try:
@@ -553,6 +559,8 @@ class AncsClient:
                 self._cancel_authorization_retry()
                 self._clear_characteristic_subscription(stop_notify=False)
                 self._owned_notify_paths.discard(path_s)
+                if not self._owned_notify_paths:
+                    self._notify_rearm_pending = False
                 log.warning("ANCS char gone: %s", path_s)
                 if was_connected and self.on_status is not None:
                     self.on_status()
@@ -573,18 +581,33 @@ class AncsClient:
         self._authorized = False
         self._reset_requests()
 
-    def _stop_bluez_notifications(self) -> None:
-        """Best-effort removal of notification ownership created by us."""
-        for path in tuple(self._owned_notify_paths):
+    def _stop_bluez_notifications(self) -> bool:
+        """Remove notification ownership created by us.
+
+        Keep failed paths recorded so a settled reconnect can retry the local
+        BlueZ operation without cycling the physical LE bearer again.
+        """
+        current_paths = tuple(
+            path
+            for path in (self._ns_path, self._ds_path)
+            if path is not None and path in self._owned_notify_paths
+        )
+        remaining_paths = tuple(sorted(
+            self._owned_notify_paths.difference(current_paths)
+        ))
+        stopped_all = True
+        for path in current_paths + remaining_paths:
             try:
                 dbus.Interface(
                     get_system_bus().get_object("org.bluez", path),
                     "org.bluez.GattCharacteristic1",
                 ).StopNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
             except dbus.exceptions.DBusException:
+                stopped_all = False
                 log.debug("could not stop ANCS notification", exc_info=True)
-            finally:
+            else:
                 self._owned_notify_paths.discard(path)
+        return stopped_all
 
     def _try_subscribe(self) -> None:
         if self._notify_started:
@@ -605,6 +628,12 @@ class AncsClient:
             return
         if not (self._ns_path and self._ds_path and self._cp_path):
             return
+        if self._notify_rearm_pending:
+            log.info("re-arming stale ANCS notifications after LE reconnect")
+            if not self._stop_bluez_notifications():
+                self._schedule_subscribe_retry()
+                return
+            self._notify_rearm_pending = False
         generation = self._bluez_owner_generation
         ns_path = self._ns_path
         ds_path = self._ds_path
@@ -649,14 +678,14 @@ class AncsClient:
                 bus.get_object("org.bluez", ds_path),
                 "org.bluez.GattCharacteristic1",
             )
-            if not self._characteristic_is_notifying(bus, ns_path):
+            if ns_path not in self._owned_notify_paths:
                 ns.StartNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
                 if current_attempt():
                     self._owned_notify_paths.add(ns_path)
             if not current_attempt():
                 remove_attempt_matches(matches)
                 return
-            if not self._characteristic_is_notifying(bus, ds_path):
+            if ds_path not in self._owned_notify_paths:
                 ds.StartNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
                 if current_attempt():
                     self._owned_notify_paths.add(ds_path)
@@ -675,8 +704,8 @@ class AncsClient:
                 self._mark_transport_failed()
             else:
                 # Do not StopNotify a characteristic that succeeded before a
-                # later CCC write failed. On retry its Notifying property lets
-                # us resume without racing ATT teardown in bluetoothd. Before
+                # later CCC write failed. Our ownership set lets the retry
+                # resume without racing ATT teardown in bluetoothd. Before
                 # first authorization, a disconnected error is also retried:
                 # the pending subscription is part of the LE bootstrap.
                 self._schedule_subscribe_retry()
@@ -691,21 +720,6 @@ class AncsClient:
             "ANCS characteristic subscriptions active; requesting notification access"
         )
         self._queue_authorization_probe()
-
-    @staticmethod
-    def _characteristic_is_notifying(bus, path: str) -> bool:
-        try:
-            properties = dbus.Interface(
-                bus.get_object("org.bluez", path),
-                "org.freedesktop.DBus.Properties",
-            )
-            return bool(properties.Get(
-                "org.bluez.GattCharacteristic1",
-                "Notifying",
-                timeout=DBUS_CALL_TIMEOUT_SECONDS,
-            ))
-        except (AttributeError, dbus.exceptions.DBusException):
-            return False
 
     def _schedule_subscribe_retry(self) -> None:
         if (

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -101,6 +101,25 @@ def _connection_was_lost(error: dbus.exceptions.DBusException) -> bool:
     return name.endswith(".notconnected") or "not connected" in detail
 
 
+def _notification_is_already_stopped(
+    error: dbus.exceptions.DBusException,
+) -> bool:
+    """Return whether BlueZ has already discarded our notify registration."""
+    name = (error.get_dbus_name() or "").casefold()
+    detail = (error.get_dbus_message() or str(error)).casefold()
+    if name.endswith((".unknownobject", ".unknowninterface")):
+        return True
+    return any(
+        marker in detail
+        for marker in (
+            "not notifying",
+            "no notify session",
+            "no notification session",
+            "notify session not started",
+        )
+    )
+
+
 class AncsClient:
     """Tracks ANCS characteristics under one target device and subscribes
     when all three are present.
@@ -602,9 +621,17 @@ class AncsClient:
                     get_system_bus().get_object("org.bluez", path),
                     "org.bluez.GattCharacteristic1",
                 ).StopNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
-            except dbus.exceptions.DBusException:
-                stopped_all = False
-                log.debug("could not stop ANCS notification", exc_info=True)
+            except dbus.exceptions.DBusException as error:
+                if _notification_is_already_stopped(error):
+                    # StopNotify is an ownership release, so BlueZ reporting
+                    # that the registration is already gone is idempotent
+                    # success. Keeping the path would otherwise make rearm
+                    # retry StopNotify forever and never reach StartNotify.
+                    self._owned_notify_paths.discard(path)
+                    log.debug("ANCS notification was already stopped: %s", path)
+                else:
+                    stopped_all = False
+                    log.debug("could not stop ANCS notification", exc_info=True)
             else:
                 self._owned_notify_paths.discard(path)
         return stopped_all

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -26,8 +26,6 @@ BACKOFF_CAP_SECONDS = 300
 # may still decline a page temporarily, but it must not inherit the five-minute
 # absence backoff while ANCS is demonstrably reachable.
 LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS = 30
-CLASSIC_RECOVERY_COOLDOWN_SECONDS = 30
-CLASSIC_RECOVERY_DISCONNECT_ATTEMPTS = 3
 _INTERFACES = {
     "bredr": "org.bluez.Bearer.BREDR1",
     "le": "org.bluez.Bearer.LE1",
@@ -159,12 +157,6 @@ class BearerSupervisor:
         self._le_reset_pending = False
         self._le_reset_failures = 0
         self._next_le_reset_attempt = 0.0
-        self._classic_recovery_pending = False
-        self._classic_recovery_saw_disconnect = False
-        self._classic_disconnect_attempts = 0
-        self._next_classic_disconnect_attempt = 0.0
-        self._classic_recovery_cycles = 0
-        self._next_classic_recovery_allowed = 0.0
         self._last_errors: dict[str, tuple[str, str]] = {}
         self._states: dict[str, bool | None] = {"bredr": None, "le": None}
         self._failures: dict[str, int] = {"bredr": 0, "le": 0}
@@ -173,11 +165,6 @@ class BearerSupervisor:
     @property
     def bredr_connected(self) -> bool:
         return self._states["bredr"] is True
-
-    @property
-    def bredr_ready(self) -> bool:
-        """True when Classic is connected and no targeted reset is active."""
-        return self.bredr_connected and not self._classic_recovery_pending
 
     @property
     def le_connected(self) -> bool:
@@ -244,7 +231,6 @@ class BearerSupervisor:
         self._le_reset_pending = False
         self._le_reset_failures = 0
         self._next_le_reset_attempt = 0.0
-        self._reset_classic_recovery()
         self._cancel_le_settle()
         self._states = {"bredr": None, "le": None}
         self._failures = {"bredr": 0, "le": 0}
@@ -275,54 +261,6 @@ class BearerSupervisor:
         else:
             log.debug("deferring the ANCS LE reset until the profile attempt completes")
 
-    def recover_classic_transport(self) -> bool:
-        """Cycle only BR/EDR after repeated OBEX transport failures.
-
-        A true Bearer.BREDR1 state is not proof that its RFCOMM transport can
-        still carry MAP. Serialize one targeted disconnect/reconnect cycle and
-        keep healthy LE/ANCS untouched. The caller uses the return value to
-        decide whether to wait for that cycle before its next profile open.
-        """
-        if not self._running:
-            return False
-        if self._classic_recovery_pending:
-            return True
-        now = self._clock()
-        if now < self._next_classic_recovery_allowed:
-            log.debug(
-                "targeted BR/EDR recovery is rate-limited for another %.0fs",
-                self._next_classic_recovery_allowed - now,
-            )
-            return False
-
-        self._classic_recovery_cycles += 1
-        cooldown = min(
-            CLASSIC_RECOVERY_COOLDOWN_SECONDS
-            * (2 ** (self._classic_recovery_cycles - 1)),
-            BACKOFF_CAP_SECONDS,
-        )
-        self._next_classic_recovery_allowed = now + cooldown
-        self._classic_recovery_pending = True
-        self._classic_recovery_saw_disconnect = self._states["bredr"] is False
-        self._classic_disconnect_attempts = 0
-        self._next_classic_disconnect_attempt = 0.0
-        self._failures["bredr"] = 0
-        self._next_attempt["bredr"] = 0.0
-        self._cancel_le_settle()
-        log.warning(
-            "requesting targeted iPhone BR/EDR recovery; preserving the LE bearer"
-        )
-        if self._classic_recovery_saw_disconnect:
-            self._tick()
-        else:
-            self._request_classic_disconnect()
-        return True
-
-    def confirm_classic_transport(self) -> None:
-        """Clear recovery penalties after MAP/PBAP prove Classic usable."""
-        self._classic_recovery_cycles = 0
-        self._next_classic_recovery_allowed = 0.0
-
     def stop(self) -> None:
         self._running = False
         self._generation += 1
@@ -331,7 +269,6 @@ class BearerSupervisor:
         self._le_hold_disconnect_pending = False
         self._le_dial_spent = False
         self._le_reset_pending = False
-        self._reset_classic_recovery()
         self._cancel_le_settle()
         if self._timer_id is not None:
             try:
@@ -371,29 +308,6 @@ class BearerSupervisor:
             self._request_le_disconnect(force=True)
         else:
             self._update_state("le", le)
-
-        if self._classic_recovery_pending:
-            if bredr is False:
-                if not self._classic_recovery_saw_disconnect:
-                    log.info("observed iPhone BR/EDR disconnect; reconnecting it")
-                self._classic_recovery_saw_disconnect = True
-                self._disconnecting.discard("bredr")
-                self._failures["bredr"] = 0
-                self._next_attempt["bredr"] = 0.0
-            elif bredr is None:
-                return True
-
-            if not self._classic_recovery_saw_disconnect:
-                self._request_classic_disconnect()
-                return True
-            if bredr is False:
-                self._request_connect("bredr")
-                return True
-            log.info("targeted iPhone BR/EDR bearer recovery completed")
-            self._classic_recovery_pending = False
-            self._classic_recovery_saw_disconnect = False
-            self._classic_disconnect_attempts = 0
-            self._next_classic_disconnect_attempt = 0.0
 
         if self._le_reset_pending and self._le_enabled:
             if le is False:
@@ -471,6 +385,22 @@ class BearerSupervisor:
         if previous != value:
             label = "unknown" if value is None else ("connected" if value else "disconnected")
             log.debug("iPhone %s bearer state: %s", kind.upper(), label)
+        if (
+            kind == "bredr"
+            and previous is False
+            and value is True
+            and self._states["le"] is not True
+        ):
+            # A Classic return is fresh evidence that the phone is reachable.
+            # The one LE dial granted by the earlier disconnect may have been
+            # spent while the phone was still away, so give this presence
+            # generation one new bootstrap before yielding to solicitation.
+            self._rearm_le_dial("iPhone BR/EDR returned")
+        if kind == "le" and previous is True and value is False:
+            # A real bearer lifecycle transition invalidates the previous
+            # one-shot budget. This is deliberately transition-driven: a
+            # device that remains absent still receives only one attempt.
+            self._rearm_le_dial("iPhone LE disconnected")
         if value is True:
             self._last_errors.pop(kind, None)
             self._failures[kind] = 0
@@ -582,6 +512,15 @@ class BearerSupervisor:
         """Yield to inbound solicitation only when it is actually on air."""
         return self._le_dial_spent and self._inbound_le_primed()
 
+    def _rearm_le_dial(self, reason: str) -> None:
+        """Grant one outbound LE bootstrap for a new presence generation."""
+        was_spent = self._le_dial_spent
+        self._le_dial_spent = False
+        self._failures["le"] = 0
+        self._next_attempt["le"] = 0.0
+        if was_spent:
+            log.info("re-arming outbound iPhone LE bootstrap: %s", reason)
+
     def _backoff_cap(self, kind: str) -> int:
         if kind == "bredr" and self.le_connected:
             return LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS
@@ -602,101 +541,6 @@ class BearerSupervisor:
             )
         except Exception as error:
             self._disconnect_failed(error, generation)
-
-    def _request_classic_disconnect(self) -> None:
-        if "bredr" in self._disconnecting:
-            return
-        if self._clock() < self._next_classic_disconnect_attempt:
-            return
-        if self._classic_disconnect_attempts >= CLASSIC_RECOVERY_DISCONNECT_ATTEMPTS:
-            self._abandon_classic_recovery(
-                "BR/EDR stayed connected after targeted disconnect requests"
-            )
-            return
-        self._disconnecting.add("bredr")
-        generation = self._generation
-        try:
-            self._disconnect(
-                "bredr",
-                lambda: self._classic_disconnect_succeeded(generation),
-                lambda error: self._classic_disconnect_failed(error, generation),
-            )
-        except Exception as error:
-            self._classic_disconnect_failed(error, generation)
-
-    def _classic_disconnect_succeeded(self, generation: int) -> None:
-        if generation != self._generation:
-            return
-        self._disconnecting.discard("bredr")
-        self._classic_disconnect_attempts += 1
-        delay = min(
-            POLL_SECONDS * (2 ** self._classic_disconnect_attempts),
-            BACKOFF_CAP_SECONDS,
-        )
-        self._next_classic_disconnect_attempt = self._clock() + delay
-        log.info(
-            "iPhone BR/EDR reset requested successfully; "
-            "waiting up to %ds for state change",
-            delay,
-        )
-
-    def _classic_disconnect_failed(
-        self,
-        error: Exception,
-        generation: int,
-    ) -> None:
-        if generation != self._generation:
-            return
-        self._disconnecting.discard("bredr")
-        name, message = _connect_error_parts(error)
-        if name in {
-            "org.bluez.Error.NotConnected",
-            "org.bluez.Error.AlreadyDisconnected",
-        } or "not connected" in message.casefold():
-            self._classic_recovery_saw_disconnect = True
-            self._update_state("bredr", False)
-            self._failures["bredr"] = 0
-            self._next_attempt["bredr"] = 0.0
-            return
-        if name in {
-            "org.freedesktop.DBus.Error.UnknownInterface",
-            "org.freedesktop.DBus.Error.UnknownMethod",
-            "org.bluez.Error.NotSupported",
-        }:
-            self._abandon_classic_recovery(
-                f"targeted BR/EDR disconnect is unavailable ({name})"
-            )
-            return
-
-        self._classic_disconnect_attempts += 1
-        delay = min(
-            POLL_SECONDS * (2 ** self._classic_disconnect_attempts),
-            BACKOFF_CAP_SECONDS,
-        )
-        self._next_classic_disconnect_attempt = self._clock() + delay
-        detail = f"{name}: {message}" if message else name
-        log.warning(
-            "could not reset iPhone BR/EDR bearer: %s (next attempt in %ds)",
-            detail,
-            delay,
-        )
-
-    def _abandon_classic_recovery(self, reason: str) -> None:
-        log.warning("abandoning targeted iPhone BR/EDR recovery: %s", reason)
-        self._classic_recovery_pending = False
-        self._classic_recovery_saw_disconnect = False
-        self._classic_disconnect_attempts = 0
-        self._next_classic_disconnect_attempt = 0.0
-        self._disconnecting.discard("bredr")
-
-    def _reset_classic_recovery(self) -> None:
-        self._classic_recovery_pending = False
-        self._classic_recovery_saw_disconnect = False
-        self._classic_disconnect_attempts = 0
-        self._next_classic_disconnect_attempt = 0.0
-        self._classic_recovery_cycles = 0
-        self._next_classic_recovery_allowed = 0.0
-        self._disconnecting.discard("bredr")
 
     def _disconnect_succeeded(self, generation: int) -> None:
         if generation != self._generation:

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -26,6 +26,8 @@ BACKOFF_CAP_SECONDS = 300
 # may still decline a page temporarily, but it must not inherit the five-minute
 # absence backoff while ANCS is demonstrably reachable.
 LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS = 30
+CLASSIC_RECOVERY_COOLDOWN_SECONDS = 30
+CLASSIC_RECOVERY_DISCONNECT_ATTEMPTS = 3
 _INTERFACES = {
     "bredr": "org.bluez.Bearer.BREDR1",
     "le": "org.bluez.Bearer.LE1",
@@ -157,6 +159,12 @@ class BearerSupervisor:
         self._le_reset_pending = False
         self._le_reset_failures = 0
         self._next_le_reset_attempt = 0.0
+        self._classic_recovery_pending = False
+        self._classic_recovery_saw_disconnect = False
+        self._classic_disconnect_attempts = 0
+        self._next_classic_disconnect_attempt = 0.0
+        self._classic_recovery_cycles = 0
+        self._next_classic_recovery_allowed = 0.0
         self._last_errors: dict[str, tuple[str, str]] = {}
         self._states: dict[str, bool | None] = {"bredr": None, "le": None}
         self._failures: dict[str, int] = {"bredr": 0, "le": 0}
@@ -165,6 +173,11 @@ class BearerSupervisor:
     @property
     def bredr_connected(self) -> bool:
         return self._states["bredr"] is True
+
+    @property
+    def bredr_ready(self) -> bool:
+        """True when Classic is connected and no targeted reset is active."""
+        return self.bredr_connected and not self._classic_recovery_pending
 
     @property
     def le_connected(self) -> bool:
@@ -231,6 +244,7 @@ class BearerSupervisor:
         self._le_reset_pending = False
         self._le_reset_failures = 0
         self._next_le_reset_attempt = 0.0
+        self._reset_classic_recovery()
         self._cancel_le_settle()
         self._states = {"bredr": None, "le": None}
         self._failures = {"bredr": 0, "le": 0}
@@ -261,6 +275,54 @@ class BearerSupervisor:
         else:
             log.debug("deferring the ANCS LE reset until the profile attempt completes")
 
+    def recover_classic_transport(self) -> bool:
+        """Cycle only BR/EDR after repeated OBEX transport failures.
+
+        A true Bearer.BREDR1 state is not proof that its RFCOMM transport can
+        still carry MAP. Serialize one targeted disconnect/reconnect cycle and
+        keep healthy LE/ANCS untouched. The caller uses the return value to
+        decide whether to wait for that cycle before its next profile open.
+        """
+        if not self._running:
+            return False
+        if self._classic_recovery_pending:
+            return True
+        now = self._clock()
+        if now < self._next_classic_recovery_allowed:
+            log.debug(
+                "targeted BR/EDR recovery is rate-limited for another %.0fs",
+                self._next_classic_recovery_allowed - now,
+            )
+            return False
+
+        self._classic_recovery_cycles += 1
+        cooldown = min(
+            CLASSIC_RECOVERY_COOLDOWN_SECONDS
+            * (2 ** (self._classic_recovery_cycles - 1)),
+            BACKOFF_CAP_SECONDS,
+        )
+        self._next_classic_recovery_allowed = now + cooldown
+        self._classic_recovery_pending = True
+        self._classic_recovery_saw_disconnect = self._states["bredr"] is False
+        self._classic_disconnect_attempts = 0
+        self._next_classic_disconnect_attempt = 0.0
+        self._failures["bredr"] = 0
+        self._next_attempt["bredr"] = 0.0
+        self._cancel_le_settle()
+        log.warning(
+            "requesting targeted iPhone BR/EDR recovery; preserving the LE bearer"
+        )
+        if self._classic_recovery_saw_disconnect:
+            self._tick()
+        else:
+            self._request_classic_disconnect()
+        return True
+
+    def confirm_classic_transport(self) -> None:
+        """Clear recovery penalties after MAP/PBAP prove Classic usable."""
+        self._classic_recovery_cycles = 0
+        self._next_classic_recovery_allowed = 0.0
+
     def stop(self) -> None:
         self._running = False
         self._generation += 1
@@ -269,6 +331,7 @@ class BearerSupervisor:
         self._le_hold_disconnect_pending = False
         self._le_dial_spent = False
         self._le_reset_pending = False
+        self._reset_classic_recovery()
         self._cancel_le_settle()
         if self._timer_id is not None:
             try:
@@ -308,6 +371,29 @@ class BearerSupervisor:
             self._request_le_disconnect(force=True)
         else:
             self._update_state("le", le)
+
+        if self._classic_recovery_pending:
+            if bredr is False:
+                if not self._classic_recovery_saw_disconnect:
+                    log.info("observed iPhone BR/EDR disconnect; reconnecting it")
+                self._classic_recovery_saw_disconnect = True
+                self._disconnecting.discard("bredr")
+                self._failures["bredr"] = 0
+                self._next_attempt["bredr"] = 0.0
+            elif bredr is None:
+                return True
+
+            if not self._classic_recovery_saw_disconnect:
+                self._request_classic_disconnect()
+                return True
+            if bredr is False:
+                self._request_connect("bredr")
+                return True
+            log.info("targeted iPhone BR/EDR bearer recovery completed")
+            self._classic_recovery_pending = False
+            self._classic_recovery_saw_disconnect = False
+            self._classic_disconnect_attempts = 0
+            self._next_classic_disconnect_attempt = 0.0
 
         if self._le_reset_pending and self._le_enabled:
             if le is False:
@@ -516,6 +602,101 @@ class BearerSupervisor:
             )
         except Exception as error:
             self._disconnect_failed(error, generation)
+
+    def _request_classic_disconnect(self) -> None:
+        if "bredr" in self._disconnecting:
+            return
+        if self._clock() < self._next_classic_disconnect_attempt:
+            return
+        if self._classic_disconnect_attempts >= CLASSIC_RECOVERY_DISCONNECT_ATTEMPTS:
+            self._abandon_classic_recovery(
+                "BR/EDR stayed connected after targeted disconnect requests"
+            )
+            return
+        self._disconnecting.add("bredr")
+        generation = self._generation
+        try:
+            self._disconnect(
+                "bredr",
+                lambda: self._classic_disconnect_succeeded(generation),
+                lambda error: self._classic_disconnect_failed(error, generation),
+            )
+        except Exception as error:
+            self._classic_disconnect_failed(error, generation)
+
+    def _classic_disconnect_succeeded(self, generation: int) -> None:
+        if generation != self._generation:
+            return
+        self._disconnecting.discard("bredr")
+        self._classic_disconnect_attempts += 1
+        delay = min(
+            POLL_SECONDS * (2 ** self._classic_disconnect_attempts),
+            BACKOFF_CAP_SECONDS,
+        )
+        self._next_classic_disconnect_attempt = self._clock() + delay
+        log.info(
+            "iPhone BR/EDR reset requested successfully; "
+            "waiting up to %ds for state change",
+            delay,
+        )
+
+    def _classic_disconnect_failed(
+        self,
+        error: Exception,
+        generation: int,
+    ) -> None:
+        if generation != self._generation:
+            return
+        self._disconnecting.discard("bredr")
+        name, message = _connect_error_parts(error)
+        if name in {
+            "org.bluez.Error.NotConnected",
+            "org.bluez.Error.AlreadyDisconnected",
+        } or "not connected" in message.casefold():
+            self._classic_recovery_saw_disconnect = True
+            self._update_state("bredr", False)
+            self._failures["bredr"] = 0
+            self._next_attempt["bredr"] = 0.0
+            return
+        if name in {
+            "org.freedesktop.DBus.Error.UnknownInterface",
+            "org.freedesktop.DBus.Error.UnknownMethod",
+            "org.bluez.Error.NotSupported",
+        }:
+            self._abandon_classic_recovery(
+                f"targeted BR/EDR disconnect is unavailable ({name})"
+            )
+            return
+
+        self._classic_disconnect_attempts += 1
+        delay = min(
+            POLL_SECONDS * (2 ** self._classic_disconnect_attempts),
+            BACKOFF_CAP_SECONDS,
+        )
+        self._next_classic_disconnect_attempt = self._clock() + delay
+        detail = f"{name}: {message}" if message else name
+        log.warning(
+            "could not reset iPhone BR/EDR bearer: %s (next attempt in %ds)",
+            detail,
+            delay,
+        )
+
+    def _abandon_classic_recovery(self, reason: str) -> None:
+        log.warning("abandoning targeted iPhone BR/EDR recovery: %s", reason)
+        self._classic_recovery_pending = False
+        self._classic_recovery_saw_disconnect = False
+        self._classic_disconnect_attempts = 0
+        self._next_classic_disconnect_attempt = 0.0
+        self._disconnecting.discard("bredr")
+
+    def _reset_classic_recovery(self) -> None:
+        self._classic_recovery_pending = False
+        self._classic_recovery_saw_disconnect = False
+        self._classic_disconnect_attempts = 0
+        self._next_classic_disconnect_attempt = 0.0
+        self._classic_recovery_cycles = 0
+        self._next_classic_recovery_allowed = 0.0
+        self._disconnecting.discard("bredr")
 
     def _disconnect_succeeded(self, generation: int) -> None:
         if generation != self._generation:

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -22,6 +22,10 @@ CLASSIC_SETTLE_SECONDS = 3
 # into a five-second hammer against the iPhone; back off exponentially
 # instead, up to this ceiling, and reset as soon as a bearer connects.
 BACKOFF_CAP_SECONDS = 300
+# A live LE bearer proves that the phone is in range and answering.  Classic
+# may still decline a page temporarily, but it must not inherit the five-minute
+# absence backoff while ANCS is demonstrably reachable.
+LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS = 30
 _INTERFACES = {
     "bredr": "org.bluez.Bearer.BREDR1",
     "le": "org.bluez.Bearer.LE1",
@@ -93,6 +97,7 @@ Connect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
 Disconnect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
 Prefer = Callable[[str], None]
 ObserveLeState = Callable[[bool | None], None]
+InboundLePrimed = Callable[[], bool]
 Schedule = Callable[[int, Callable[[], bool]], int]
 Cancel = Callable[[int], object]
 Clock = Callable[[], float]
@@ -117,6 +122,7 @@ class BearerSupervisor:
         connect: Connect | None = None,
         disconnect: Disconnect | None = None,
         prefer: Prefer | None = None,
+        inbound_le_primed: InboundLePrimed | None = None,
         schedule: Schedule = GLib.timeout_add_seconds,
         cancel: Cancel = GLib.source_remove,
         clock: Clock = time.monotonic,
@@ -130,6 +136,7 @@ class BearerSupervisor:
         self._prefer = prefer or (
             self._prefer_bluez if connect is None else lambda _kind: None
         )
+        self._inbound_le_primed = inbound_le_primed or (lambda: True)
         self._schedule = schedule
         self._cancel = cancel
         self._clock = clock
@@ -141,6 +148,12 @@ class BearerSupervisor:
         self._connecting: set[str] = set()
         self._disconnecting: set[str] = set()
         self._le_hold_disconnect_pending = False
+        # Outbound Bearer.LE1.Connect is only a bootstrap hint.  Real-device
+        # traces show the solicitation advertisement to be the reliable
+        # reconnect path, while repeating Connect can leave BlueZ in an
+        # InProgress loop.  Spend one dial, then leave the radio to solicitation
+        # until BlueZ is replaced or ANCS deliberately resets the transport.
+        self._le_dial_spent = False
         self._le_reset_pending = False
         self._le_reset_failures = 0
         self._next_le_reset_attempt = 0.0
@@ -214,6 +227,7 @@ class BearerSupervisor:
         # The old owner's live link is gone. While the profile gate is closed,
         # reject any LE link that appears under the replacement owner.
         self._le_hold_disconnect_pending = not self._le_enabled
+        self._le_dial_spent = False
         self._le_reset_pending = False
         self._le_reset_failures = 0
         self._next_le_reset_attempt = 0.0
@@ -237,6 +251,9 @@ class BearerSupervisor:
             log.warning(
                 "ANCS transport disagrees with BlueZ; resetting the LE bearer"
             )
+        # The targeted disconnect creates a new transport generation, so it is
+        # appropriate to give that generation one fresh outbound bootstrap.
+        self._le_dial_spent = False
         self._le_reset_pending = True
         self._cancel_le_settle()
         if self._le_enabled:
@@ -250,6 +267,7 @@ class BearerSupervisor:
         self._connecting.clear()
         self._disconnecting.clear()
         self._le_hold_disconnect_pending = False
+        self._le_dial_spent = False
         self._le_reset_pending = False
         self._cancel_le_settle()
         if self._timer_id is not None:
@@ -316,7 +334,7 @@ class BearerSupervisor:
         return True
 
     def _schedule_le_connect(self) -> None:
-        if self._le_settle_id is not None:
+        if self._le_settle_id is not None or self._le_dial_exhausted():
             return
         log.info(
             "iPhone BR/EDR connected; allowing %ds to settle before LE",
@@ -371,6 +389,12 @@ class BearerSupervisor:
             self._last_errors.pop(kind, None)
             self._failures[kind] = 0
             self._next_attempt[kind] = 0.0
+        if kind == "le" and value is True and previous is not True:
+            # An inbound LE connection is the missing presence event for a
+            # Classic backoff accumulated while the phone was out of range.
+            self._last_errors.pop("bredr", None)
+            self._failures["bredr"] = 0
+            self._next_attempt["bredr"] = 0.0
         # Repeating stale Connected=true after a failed GATT operation can
         # race BlueZ's pending CCC registration with ATT teardown. Consumers
         # therefore receive only genuine bearer lifecycle transitions.
@@ -382,8 +406,12 @@ class BearerSupervisor:
     def _request_connect(self, kind: str) -> None:
         if kind in self._connecting:
             return
+        if kind == "le" and self._le_dial_exhausted():
+            return
         if self._clock() < self._next_attempt[kind]:
             return
+        if kind == "le":
+            self._le_dial_spent = True
         self._connecting.add(kind)
         generation = self._generation
         log.info("connecting iPhone %s bearer", kind.upper())
@@ -407,6 +435,7 @@ class BearerSupervisor:
         self._last_errors.pop(kind, None)
         if kind == "le" and not self._le_enabled:
             self._le_hold_disconnect_pending = True
+            self._le_dial_spent = False
             self._request_le_disconnect(force=True)
             # The request completed only after policy closed the gate. Treat
             # rejecting it as cancellation, not as a failed connection that
@@ -420,7 +449,7 @@ class BearerSupervisor:
         self._failures[kind] += 1
         delay = min(
             POLL_SECONDS * (2 ** self._failures[kind]),
-            BACKOFF_CAP_SECONDS,
+            self._backoff_cap(kind),
         )
         self._next_attempt[kind] = self._clock() + delay
         log.info(
@@ -434,6 +463,11 @@ class BearerSupervisor:
         if generation != self._generation:
             return
         self._connecting.discard(kind)
+        if kind == "le" and not self._le_enabled:
+            # Policy closed the gate while the asynchronous request was in
+            # flight.  This generation never received its permitted attempt.
+            self._le_dial_spent = False
+            return
         name, message = _connect_error_parts(error)
         if name in {
             "org.bluez.Error.AlreadyConnected",
@@ -445,7 +479,7 @@ class BearerSupervisor:
         self._failures[kind] += 1
         delay = min(
             POLL_SECONDS * (2 ** self._failures[kind]),
-            BACKOFF_CAP_SECONDS,
+            self._backoff_cap(kind),
         )
         self._next_attempt[kind] = self._clock() + delay
         if self._last_errors.get(kind) != (name, message):
@@ -457,6 +491,15 @@ class BearerSupervisor:
                 delay,
             )
             self._last_errors[kind] = (name, message)
+
+    def _le_dial_exhausted(self) -> bool:
+        """Yield to inbound solicitation only when it is actually on air."""
+        return self._le_dial_spent and self._inbound_le_primed()
+
+    def _backoff_cap(self, kind: str) -> int:
+        if kind == "bredr" and self.le_connected:
+            return LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS
+        return BACKOFF_CAP_SECONDS
 
     def _request_le_disconnect(self, *, force: bool = False) -> None:
         if "le" in self._disconnecting:

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -288,8 +288,8 @@ class BearerSupervisor:
             # the profile gate closed, so allowing it to become usable here
             # would put GATT ahead of the MAP/PBAP attempt again.
             self._request_le_disconnect(force=True)
-            return True
-        self._update_state("le", le)
+        else:
+            self._update_state("le", le)
 
         if self._le_reset_pending and self._le_enabled:
             if le is False:
@@ -408,6 +408,12 @@ class BearerSupervisor:
         if kind == "le" and not self._le_enabled:
             self._le_hold_disconnect_pending = True
             self._request_le_disconnect(force=True)
+            # The request completed only after policy closed the gate. Treat
+            # rejecting it as cancellation, not as a failed connection that
+            # should delay the next permitted LE attempt.
+            self._failures[kind] = 0
+            self._next_attempt[kind] = 0.0
+            return
         # A successful method reply only means BlueZ accepted the request; it
         # does not mean the bearer connected. Keep widening the quiet window
         # until an observed Connected=true resets it.

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -140,6 +140,7 @@ class BearerSupervisor:
         self._generation = 0
         self._connecting: set[str] = set()
         self._disconnecting: set[str] = set()
+        self._le_hold_disconnect_pending = False
         self._le_reset_pending = False
         self._le_reset_failures = 0
         self._next_le_reset_attempt = 0.0
@@ -177,6 +178,7 @@ class BearerSupervisor:
         if self._le_enabled:
             return
         self._le_enabled = True
+        self._le_hold_disconnect_pending = False
         log.info("MAP/PBAP attempt completed; enabling iPhone LE bearer")
         if self._running:
             self._tick()
@@ -184,15 +186,19 @@ class BearerSupervisor:
     def hold_le(self) -> None:
         """Prevent a missing LE bearer from connecting during a MAP/PBAP attempt.
 
-        An LE link that is already established is left alone. The gate affects
-        only the next connection request, avoiding unnecessary bearer churn
-        when an OBEX session alone needs recovery.
+        An LE link that is already established is left alone. If LE is missing,
+        the gate also rejects a Connect that was already in flight, avoiding a
+        race with the MAP/PBAP attempt without churning a healthy LE link.
         """
-        if not self._le_enabled:
-            return
+        was_enabled = self._le_enabled
         self._le_enabled = False
+        if self._states["le"] is False:
+            self._le_hold_disconnect_pending = True
         self._cancel_le_settle()
-        log.info("holding iPhone LE bearer until the MAP/PBAP attempt completes")
+        if "le" in self._connecting:
+            self._request_le_disconnect(force=True)
+        if was_enabled:
+            log.info("holding iPhone LE bearer until the MAP/PBAP attempt completes")
 
     def poke(self) -> None:
         """Run a health check now, for example after system resume."""
@@ -205,6 +211,9 @@ class BearerSupervisor:
         self._generation += 1
         self._connecting.clear()
         self._disconnecting.clear()
+        # The old owner's live link is gone. While the profile gate is closed,
+        # reject any LE link that appears under the replacement owner.
+        self._le_hold_disconnect_pending = not self._le_enabled
         self._le_reset_pending = False
         self._le_reset_failures = 0
         self._next_le_reset_attempt = 0.0
@@ -222,7 +231,7 @@ class BearerSupervisor:
 
     def recover_le_transport(self) -> None:
         """Request one serialized LE reset after GATT and bearer state diverge."""
-        if not self._running or not self._le_enabled:
+        if not self._running:
             return
         if not self._le_reset_pending:
             log.warning(
@@ -230,13 +239,17 @@ class BearerSupervisor:
             )
         self._le_reset_pending = True
         self._cancel_le_settle()
-        self._request_le_disconnect()
+        if self._le_enabled:
+            self._request_le_disconnect()
+        else:
+            log.debug("deferring the ANCS LE reset until the profile attempt completes")
 
     def stop(self) -> None:
         self._running = False
         self._generation += 1
         self._connecting.clear()
         self._disconnecting.clear()
+        self._le_hold_disconnect_pending = False
         self._le_reset_pending = False
         self._cancel_le_settle()
         if self._timer_id is not None:
@@ -267,9 +280,18 @@ class BearerSupervisor:
         bredr = self._read("bredr")
         le = self._read("le")
         self._update_state("bredr", bredr)
+
+        if not self._le_enabled and le is False:
+            self._le_hold_disconnect_pending = True
+        if not self._le_enabled and self._le_hold_disconnect_pending and le is True:
+            # Do not publish the transient link to ANCS. It was missing when
+            # the profile gate closed, so allowing it to become usable here
+            # would put GATT ahead of the MAP/PBAP attempt again.
+            self._request_le_disconnect(force=True)
+            return True
         self._update_state("le", le)
 
-        if self._le_reset_pending:
+        if self._le_reset_pending and self._le_enabled:
             if le is False:
                 self._le_reset_pending = False
                 self._le_reset_failures = 0
@@ -383,6 +405,9 @@ class BearerSupervisor:
             return
         self._connecting.discard(kind)
         self._last_errors.pop(kind, None)
+        if kind == "le" and not self._le_enabled:
+            self._le_hold_disconnect_pending = True
+            self._request_le_disconnect(force=True)
         # A successful method reply only means BlueZ accepted the request; it
         # does not mean the bearer connected. Keep widening the quiet window
         # until an observed Connected=true resets it.
@@ -427,10 +452,10 @@ class BearerSupervisor:
             )
             self._last_errors[kind] = (name, message)
 
-    def _request_le_disconnect(self) -> None:
+    def _request_le_disconnect(self, *, force: bool = False) -> None:
         if "le" in self._disconnecting:
             return
-        if self._clock() < self._next_le_reset_attempt:
+        if not force and self._clock() < self._next_le_reset_attempt:
             return
         self._disconnecting.add("le")
         generation = self._generation
@@ -470,7 +495,7 @@ class BearerSupervisor:
         } or "not connected" in message.casefold():
             self._le_reset_pending = False
             self._update_state("le", False)
-            if self.bredr_connected:
+            if self.bredr_connected and self._le_enabled:
                 self._schedule_le_connect()
             return
         self._le_reset_failures += 1

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -169,11 +169,10 @@ class BearerSupervisor:
         self._timer_id = self._schedule(POLL_SECONDS, self._tick)
 
     def enable_le(self) -> None:
-        """Allow the LE bearer after the first Classic profile attempt.
+        """Allow the LE bearer after the current Classic profile attempt.
 
-        Pairing-time callers can hold LE back long enough for MAP/PBAP to be
-        the first post-pair profile transaction.  Calling this more than once
-        is harmless.
+        Callers hold LE during every whole-device reconnect so MAP/PBAP can be
+        the first profile transaction. Calling this more than once is harmless.
         """
         if self._le_enabled:
             return
@@ -181,6 +180,19 @@ class BearerSupervisor:
         log.info("MAP/PBAP attempt completed; enabling iPhone LE bearer")
         if self._running:
             self._tick()
+
+    def hold_le(self) -> None:
+        """Prevent a missing LE bearer from connecting during a MAP/PBAP attempt.
+
+        An LE link that is already established is left alone. The gate affects
+        only the next connection request, avoiding unnecessary bearer churn
+        when an OBEX session alone needs recovery.
+        """
+        if not self._le_enabled:
+            return
+        self._le_enabled = False
+        self._cancel_le_settle()
+        log.info("holding iPhone LE bearer until the MAP/PBAP attempt completes")
 
     def poke(self) -> None:
         """Run a health check now, for example after system resume."""

--- a/src/blueferry/bluez_setup.py
+++ b/src/blueferry/bluez_setup.py
@@ -158,6 +158,9 @@ class _AncsAdvert(dbus.service.Object):
     @dbus.service.method("org.bluez.LEAdvertisement1",
                          in_signature="", out_signature="")
     def Release(self) -> None:
+        global _advert_registered
+        _advert_registered = False
+        log.info("BlueZ released the ANCS solicitation advertisement")
         return None
 
     @dbus.service.method("org.freedesktop.DBus.Properties",
@@ -200,6 +203,17 @@ class _AncsAdvert(dbus.service.Object):
 
 _advert_instance: _AncsAdvert | None = None
 _advert_registered = False
+
+
+def advert_registered() -> bool:
+    """Return whether the current BlueZ owner accepted our advertisement."""
+    return _advert_registered
+
+
+def forget_advert_registration() -> None:
+    """Discard registration state that belonged to a departed BlueZ owner."""
+    global _advert_registered
+    _advert_registered = False
 
 
 def _active_advertisements(adapter: str | None = None) -> int | None:

--- a/src/blueferry/bluez_setup.py
+++ b/src/blueferry/bluez_setup.py
@@ -9,10 +9,10 @@ the Linux side:
    payloads keep the advertisement visible to iOS during first pairing.
 3. Adapter is powered.
 
-This module owns those three concerns. The daemon may verify them on startup,
-but privileged Class-of-Device changes are limited to the explicit pairing
-flow and run through a hardened, argument-validating systemd service after a
-fresh Polkit authorization.
+This module owns those three concerns. Class-of-Device changes run through a
+hardened, argument-validating systemd service; its fixed operation is available
+to an active local daemon so volatile controller state can be repaired after a
+Bluetooth reset without granting raw Bluetooth capabilities to BlueFerry.
 """
 from __future__ import annotations
 

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -47,6 +47,7 @@ from blueferry.setup_verification import (
     NOTIFICATION_ACCESS,
     SetupVerification,
 )
+from blueferry.solicitation_supervisor import SolicitationSupervisor
 from blueferry.storage_security import NO_STORAGE, StorageSecurity
 
 log = logging.getLogger(__name__)
@@ -86,6 +87,7 @@ class Daemon:
         )
         self.listener: MapEventListener | None = None
         self.ancs: AncsClient | None = None
+        self.solicitation = SolicitationSupervisor(config.ADAPTER)
         device_path = (
             f"/org/bluez/{config.ADAPTER}/"
             f"dev_{config.IPHONE_MAC.replace(':', '_')}"
@@ -98,6 +100,7 @@ class Daemon:
             le_enabled=False,
             on_status=self._emit_status,
             on_le_state=self._observe_le_state,
+            inbound_le_primed=self.solicitation.active,
         )
         self._contacts_refresh_id: int | None = None
         self._bus_name = None
@@ -143,8 +146,25 @@ class Daemon:
             emit()
 
     def _observe_le_state(self, connected: bool | None) -> None:
+        if connected is not True:
+            self.solicitation.set_needed(True)
         if self.ancs is not None:
             self.ancs.observe_bearer_state(connected)
+
+    def _on_ancs_status(self) -> None:
+        # StartNotify is not the success boundary.  Keep solicitation on air
+        # until a Control Point/Data Source round trip proves ANCS usable.
+        self._sync_solicitation()
+        self._emit_status()
+
+    def _sync_solicitation(self) -> None:
+        end_to_end_ready = bool(
+            config.ANCS_ENABLED
+            and self.ancs is not None
+            and self.ancs.connected
+            and self.profiles.ready
+        )
+        self.solicitation.set_needed(not end_to_end_ready)
 
     def _mark_setup_task(self, task: str) -> bool:
         try:
@@ -269,6 +289,7 @@ class Daemon:
                 "but MAP/PBAP may be refused. Re-pair on iPhone after the "
                 "adapter is in A/V Hands-Free CoD if the toggles aren't there."
             )
+        self.solicitation.start()
 
         # A bond records trust but does not guarantee a live connection.
         # The bearer supervisor establishes BR/EDR but deliberately holds LE
@@ -283,7 +304,7 @@ class Daemon:
             candidate = AncsClient(
                 device_path,
                 on_event=self.events.ancs,
-                on_status=self._emit_status,
+                on_status=self._on_ancs_status,
                 on_bluez_restart=self._on_bluez_restart,
                 on_transport_failure=self.bearers.recover_le_transport,
                 include_non_message_notifications=lambda: (
@@ -320,6 +341,9 @@ class Daemon:
 
     def _on_bluez_restart(self) -> None:
         """Reapply MAP-first ordering before accepting the new BlueZ owner."""
+        # The advertisement registration belonged to the old owner.  Prime
+        # inbound LE immediately instead of waiting for another link event.
+        self.solicitation.reset_after_bluez_restart()
         # Hold first because resetting bearer observations immediately probes
         # the replacement daemon. The old OBEX transport is already gone, so
         # discard its local sessions without asking obexd to remove them.
@@ -332,6 +356,7 @@ class Daemon:
 
     def _profiles_lost(self, _reason: str) -> None:
         """Stop consumers that hold objects belonging to old sessions."""
+        self.solicitation.set_needed(True)
         if self.listener is not None:
             self.listener.stop()
             self.listener = None
@@ -382,6 +407,8 @@ class Daemon:
                 submit_obex=self.obex_worker.submit,
             )
             self.listener.start()
+
+        self._sync_solicitation()
 
         log.info(
             "=== BlueFerry ready (contacts=%d, sinks=%s) ===",
@@ -532,6 +559,7 @@ class Daemon:
             self.listener.stop()
         if self.ancs is not None:
             self.ancs.stop()
+        self.solicitation.stop()
         if self._sleep_match is not None:
             try:
                 self._sleep_match.remove()
@@ -543,7 +571,6 @@ class Daemon:
         self.obex_worker.shutdown(cleanup=self.sessions.close_all)
         self.storage.close()
         self.sessions.stop_monitoring()
-        bluez_setup.unregister_advert()
         main_loop.quit()
 
     def run(self) -> int:

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -133,14 +133,14 @@ class Daemon:
             on_ready=self._post_sessions_setup,
             on_lost=self._profiles_lost,
             on_status=self._emit_status,
+            on_partial_ready=self._post_available_sessions_setup,
             on_attempt_pending=(
                 self.bearers.hold_le if config.ANCS_ENABLED else None
             ),
             on_first_attempt_complete=(
                 self.bearers.enable_le if config.ANCS_ENABLED else None
             ),
-            on_transport_failure=self.bearers.recover_classic_transport,
-            attempt_ready=lambda: self.bearers.bredr_ready,
+            attempt_ready=lambda: self.bearers.bredr_connected,
         )
 
     def _emit_status(self) -> None:
@@ -391,24 +391,22 @@ class Daemon:
         self.bearers.poke()
         self.profiles.reconnect("system resumed")
 
-    def _post_sessions_setup(self) -> None:
-        """Everything that requires live MAP+PBAP sessions. Idempotent so
-        we can call it either at first-attempt success or at retry success."""
-        self.bearers.confirm_classic_transport()
+    def _post_available_sessions_setup(self) -> None:
+        """Start consumers for whichever OBEX profiles are currently live."""
         # Warm contacts; if empty, do a one-time pull. PBAP pull is cheap.
-        if self.contacts.count() == 0:
+        if self.sessions.pbap is not None and self.contacts.count() == 0:
             log.info("contacts cache empty — pulling from iPhone via PBAP")
             self._refresh_contacts()
 
         # Schedule periodic contacts refresh
-        if self._contacts_refresh_id is None:
+        if self.sessions.pbap is not None and self._contacts_refresh_id is None:
             self._contacts_refresh_id = GLib.timeout_add_seconds(
                 CONTACTS_REFRESH_SEC, self._periodic_refresh_contacts
             )
 
         # Wire up MAP MNS listener.
         # Resolve through the current cache; contacts refreshes in place.
-        if self.listener is None:
+        if self.sessions.map is not None and self.listener is None:
             self.listener = MapEventListener(
                 sessions=self.sessions,
                 on_sms=self.events.message,
@@ -416,6 +414,10 @@ class Daemon:
                 submit_obex=self.obex_worker.submit,
             )
             self.listener.start()
+
+    def _post_sessions_setup(self) -> None:
+        """Finish setup once both MAP and PBAP are live."""
+        self._post_available_sessions_setup()
 
         self._sync_solicitation()
 

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -284,7 +284,7 @@ class Daemon:
                 device_path,
                 on_event=self.events.ancs,
                 on_status=self._emit_status,
-                on_bluez_restart=self.bearers.reset_after_bluez_restart,
+                on_bluez_restart=self._on_bluez_restart,
                 on_transport_failure=self.bearers.recover_le_transport,
                 include_non_message_notifications=lambda: (
                     self.notification_policy.value == ALL_NOTIFICATIONS
@@ -317,6 +317,18 @@ class Daemon:
             log.warning("    No MAP/PBAP session yet; retry is automatic.")
         # The "ready" line in the happy path is emitted by
         # _post_sessions_setup, so we don't duplicate it here.
+
+    def _on_bluez_restart(self) -> None:
+        """Reapply MAP-first ordering before accepting the new BlueZ owner."""
+        # Hold first because resetting bearer observations immediately probes
+        # the replacement daemon. The old OBEX transport is already gone, so
+        # discard its local sessions without asking obexd to remove them.
+        self.bearers.hold_le()
+        self.profiles.reconnect(
+            "bluetoothd restarted",
+            remove_remote_sessions=False,
+        )
+        self.bearers.reset_after_bluez_restart()
 
     def _profiles_lost(self, _reason: str) -> None:
         """Stop consumers that hold objects belonging to old sessions."""

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -139,7 +139,8 @@ class Daemon:
             on_first_attempt_complete=(
                 self.bearers.enable_le if config.ANCS_ENABLED else None
             ),
-            attempt_ready=lambda: self.bearers.bredr_connected,
+            on_transport_failure=self.bearers.recover_classic_transport,
+            attempt_ready=lambda: self.bearers.bredr_ready,
         )
 
     def _emit_status(self) -> None:
@@ -393,6 +394,7 @@ class Daemon:
     def _post_sessions_setup(self) -> None:
         """Everything that requires live MAP+PBAP sessions. Idempotent so
         we can call it either at first-attempt success or at retry success."""
+        self.bearers.confirm_classic_transport()
         # Warm contacts; if empty, do a one-time pull. PBAP pull is cheap.
         if self.contacts.count() == 0:
             log.info("contacts cache empty — pulling from iPhone via PBAP")

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -128,9 +128,13 @@ class Daemon:
             on_ready=self._post_sessions_setup,
             on_lost=self._profiles_lost,
             on_status=self._emit_status,
+            on_attempt_pending=(
+                self.bearers.hold_le if config.ANCS_ENABLED else None
+            ),
             on_first_attempt_complete=(
                 self.bearers.enable_le if config.ANCS_ENABLED else None
             ),
+            attempt_ready=lambda: self.bearers.bredr_connected,
         )
 
     def _emit_status(self) -> None:

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -13,6 +13,7 @@ import dbus
 from gi.repository import GLib
 
 from blueferry import __version__, bluez_setup, config
+from blueferry.adapter_class_supervisor import AdapterClassSupervisor
 from blueferry.ancs.client import AncsClient
 from blueferry.backend_lifecycle import installed_release
 from blueferry.backend_operations import BackendDependencies
@@ -87,6 +88,7 @@ class Daemon:
         )
         self.listener: MapEventListener | None = None
         self.ancs: AncsClient | None = None
+        self.adapter_class = AdapterClassSupervisor(config.ADAPTER)
         self.solicitation = SolicitationSupervisor(config.ADAPTER)
         device_path = (
             f"/org/bluez/{config.ADAPTER}/"
@@ -283,6 +285,10 @@ class Daemon:
                 "the saved iPhone is not currently paired; open a client to pair it"
             )
 
+        # Class-of-Device is controller state, not durable configuration.
+        # Repair it before opening either bearer and continue supervising it
+        # for bluetoothd/controller resets during this daemon generation.
+        self.adapter_class.start()
         if not bluez_setup.prepare():
             log.warning(
                 "bluez_setup.prepare reported issues — continuing anyway, "
@@ -341,6 +347,7 @@ class Daemon:
 
     def _on_bluez_restart(self) -> None:
         """Reapply MAP-first ordering before accepting the new BlueZ owner."""
+        self.adapter_class.poke()
         # The advertisement registration belonged to the old owner.  Prime
         # inbound LE immediately instead of waiting for another link event.
         self.solicitation.reset_after_bluez_restart()
@@ -539,6 +546,7 @@ class Daemon:
 
     def stop(self) -> None:
         log.info("=== BlueFerry stopping ===")
+        self.adapter_class.stop()
         self.bearers.stop()
         self.profiles.stop()
         for tid_attr in (

--- a/src/blueferry/obex/sessions.py
+++ b/src/blueferry/obex/sessions.py
@@ -175,22 +175,30 @@ class SessionManager:
         self.start_monitoring()
         if self.map is not None and self.pbap is not None:
             return
-        # A previous partial open must not leak into this attempt. Otherwise
-        # removing it below can emit a loss signal that races the new session.
-        if self.map is not None or self.pbap is not None:
-            self.close_all()
-        _remove_stale_sessions({"MAP", "PBAP"})
-        try:
-            self.map = _create_session("MAP")
-            log.info("MAP session: %s", self.map.path)
-            self.pbap = _create_session("PBAP")
-            log.info("PBAP session: %s", self.pbap.path)
-        except Exception:
+        missing = {
+            target
+            for target, session in (("MAP", self.map), ("PBAP", self.pbap))
+            if session is None
+        }
+        _remove_stale_sessions(missing)
+        failures: list[Exception] = []
+        for target, attribute in (("MAP", "map"), ("PBAP", "pbap")):
+            if getattr(self, attribute) is not None:
+                continue
             try:
-                self.close_all()
-            except Exception:
-                log.debug("partial OBEX session cleanup failed", exc_info=True)
-            raise
+                session = _create_session(target)
+            except Exception as error:
+                failures.append(error)
+                continue
+            setattr(self, attribute, session)
+            log.info("%s session: %s", target, session.path)
+
+        if failures:
+            # Keep a successful sibling profile alive. iOS can reject its
+            # single MAP connection while PBAP remains independently usable;
+            # tearing PBAP down on every MAP retry hid that distinction and
+            # needlessly discarded contacts access.
+            raise failures[0]
 
     def open_pbap_only(self) -> None:
         """Open only PBAP for a standalone contacts operation.

--- a/src/blueferry/profile_supervisor.py
+++ b/src/blueferry/profile_supervisor.py
@@ -20,19 +20,6 @@ log = logging.getLogger(__name__)
 
 INITIAL_MAP_CONNECT_POLL_SECONDS = 5
 MAP_RECONNECT_POLL_SECONDS = 15
-TRANSPORT_FAILURES_BEFORE_RESET = 3
-
-
-def profile_transport_failed(error: Exception) -> bool:
-    """Recognize a dead OBEX transport behind a still-connected bearer."""
-    detail = str(error).casefold()
-    return any(
-        marker in detail
-        for marker in (
-            "transport got disconnected",
-            "timed out waiting for response",
-        )
-    )
 
 
 class ProfileSessions(Protocol):
@@ -72,9 +59,9 @@ class ProfileSupervisor:
         on_ready: Callable[[], None],
         on_lost: Callable[[str], None],
         on_status: Callable[[], None],
+        on_partial_ready: Callable[[], None] | None = None,
         on_attempt_pending: Callable[[], None] | None = None,
         on_first_attempt_complete: Callable[[], None] | None = None,
-        on_transport_failure: Callable[[], bool] | None = None,
         attempt_ready: Callable[[], bool] | None = None,
         schedule: Schedule = GLib.timeout_add_seconds,
         cancel: Cancel = GLib.source_remove,
@@ -85,9 +72,9 @@ class ProfileSupervisor:
         self._on_ready = on_ready
         self._on_lost = on_lost
         self._on_status = on_status
+        self._on_partial_ready = on_partial_ready
         self._on_attempt_pending = on_attempt_pending
         self._on_first_attempt_complete = on_first_attempt_complete
-        self._on_transport_failure = on_transport_failure
         self._attempt_ready = attempt_ready or (lambda: True)
         self._schedule = schedule
         self._cancel = cancel
@@ -99,8 +86,6 @@ class ProfileSupervisor:
         self._stopping = False
         self._generation = 0
         self._first_attempt_completed = False
-        self._transport_failures = 0
-        self._transport_recovery_pending = False
         self.sessions.set_on_lost(self.session_lost)
 
     @property
@@ -175,7 +160,6 @@ class ProfileSupervisor:
         self._ready = False
         self._opening = False
         self._closing = False
-        self._transport_recovery_pending = False
         self.connectivity.stopping()
         if self._retry_id is not None:
             try:
@@ -200,8 +184,6 @@ class ProfileSupervisor:
                 log.debug("could not remove stale profile retry timer", exc_info=True)
             self._retry_id = None
         self.connectivity.ready()
-        self._transport_failures = 0
-        self._transport_recovery_pending = False
         self._on_status()
         self._ever_ready = True
         if self._ready:
@@ -216,6 +198,16 @@ class ProfileSupervisor:
         self._complete_first_attempt()
         message = str(error)
         log.warning("could not open MAP/PBAP sessions: %s", message)
+        if (
+            self._on_partial_ready is not None
+            and (self.sessions.map is not None or self.sessions.pbap is not None)
+        ):
+            log.info(
+                "keeping partial OBEX availability (MAP=%s, PBAP=%s)",
+                self.sessions.map is not None,
+                self.sessions.pbap is not None,
+            )
+            self._on_partial_ready()
         authorization_required = isinstance(error, SessionError) and (
             "Forbidden" in message or "0x43" in message
         )
@@ -227,27 +219,6 @@ class ProfileSupervisor:
             log.warning(
                 "  → iPhone refused MAP; it may be connected to another computer."
             )
-        transport_failed = (
-            not authorization_required
-            and not map_connection_refused
-            and profile_transport_failed(error)
-        )
-        if transport_failed:
-            self._transport_failures += 1
-        else:
-            self._transport_failures = 0
-        if (
-            self._transport_failures >= TRANSPORT_FAILURES_BEFORE_RESET
-            and self._on_transport_failure is not None
-        ):
-            self._transport_failures = 0
-            if self._on_transport_failure():
-                log.warning(
-                    "repeated OBEX transport failures; cycling only the "
-                    "iPhone BR/EDR bearer"
-                )
-                self._transport_recovery_pending = True
-                self._begin_attempt_cycle()
         delay = self.connectivity.failed(
             error,
             authorization_required=authorization_required,
@@ -302,14 +273,6 @@ class ProfileSupervisor:
     def _retry(self) -> bool:
         self._retry_id = None
         if not self._stopping:
-            if self._transport_recovery_pending and not self._attempt_ready():
-                log.debug(
-                    "waiting for the targeted BR/EDR recovery before retrying "
-                    "MAP/PBAP"
-                )
-                self._schedule_retry(self._poll_seconds)
-                return False
-            self._transport_recovery_pending = False
             log.info("retrying MAP/PBAP session open ...")
             self.open()
         return False

--- a/src/blueferry/profile_supervisor.py
+++ b/src/blueferry/profile_supervisor.py
@@ -20,6 +20,19 @@ log = logging.getLogger(__name__)
 
 INITIAL_MAP_CONNECT_POLL_SECONDS = 5
 MAP_RECONNECT_POLL_SECONDS = 15
+TRANSPORT_FAILURES_BEFORE_RESET = 3
+
+
+def profile_transport_failed(error: Exception) -> bool:
+    """Recognize a dead OBEX transport behind a still-connected bearer."""
+    detail = str(error).casefold()
+    return any(
+        marker in detail
+        for marker in (
+            "transport got disconnected",
+            "timed out waiting for response",
+        )
+    )
 
 
 class ProfileSessions(Protocol):
@@ -61,6 +74,7 @@ class ProfileSupervisor:
         on_status: Callable[[], None],
         on_attempt_pending: Callable[[], None] | None = None,
         on_first_attempt_complete: Callable[[], None] | None = None,
+        on_transport_failure: Callable[[], bool] | None = None,
         attempt_ready: Callable[[], bool] | None = None,
         schedule: Schedule = GLib.timeout_add_seconds,
         cancel: Cancel = GLib.source_remove,
@@ -73,6 +87,7 @@ class ProfileSupervisor:
         self._on_status = on_status
         self._on_attempt_pending = on_attempt_pending
         self._on_first_attempt_complete = on_first_attempt_complete
+        self._on_transport_failure = on_transport_failure
         self._attempt_ready = attempt_ready or (lambda: True)
         self._schedule = schedule
         self._cancel = cancel
@@ -84,6 +99,8 @@ class ProfileSupervisor:
         self._stopping = False
         self._generation = 0
         self._first_attempt_completed = False
+        self._transport_failures = 0
+        self._transport_recovery_pending = False
         self.sessions.set_on_lost(self.session_lost)
 
     @property
@@ -158,6 +175,7 @@ class ProfileSupervisor:
         self._ready = False
         self._opening = False
         self._closing = False
+        self._transport_recovery_pending = False
         self.connectivity.stopping()
         if self._retry_id is not None:
             try:
@@ -182,6 +200,8 @@ class ProfileSupervisor:
                 log.debug("could not remove stale profile retry timer", exc_info=True)
             self._retry_id = None
         self.connectivity.ready()
+        self._transport_failures = 0
+        self._transport_recovery_pending = False
         self._on_status()
         self._ever_ready = True
         if self._ready:
@@ -207,6 +227,27 @@ class ProfileSupervisor:
             log.warning(
                 "  → iPhone refused MAP; it may be connected to another computer."
             )
+        transport_failed = (
+            not authorization_required
+            and not map_connection_refused
+            and profile_transport_failed(error)
+        )
+        if transport_failed:
+            self._transport_failures += 1
+        else:
+            self._transport_failures = 0
+        if (
+            self._transport_failures >= TRANSPORT_FAILURES_BEFORE_RESET
+            and self._on_transport_failure is not None
+        ):
+            self._transport_failures = 0
+            if self._on_transport_failure():
+                log.warning(
+                    "repeated OBEX transport failures; cycling only the "
+                    "iPhone BR/EDR bearer"
+                )
+                self._transport_recovery_pending = True
+                self._begin_attempt_cycle()
         delay = self.connectivity.failed(
             error,
             authorization_required=authorization_required,
@@ -261,6 +302,14 @@ class ProfileSupervisor:
     def _retry(self) -> bool:
         self._retry_id = None
         if not self._stopping:
+            if self._transport_recovery_pending and not self._attempt_ready():
+                log.debug(
+                    "waiting for the targeted BR/EDR recovery before retrying "
+                    "MAP/PBAP"
+                )
+                self._schedule_retry(self._poll_seconds)
+                return False
+            self._transport_recovery_pending = False
             log.info("retrying MAP/PBAP session open ...")
             self.open()
         return False

--- a/src/blueferry/profile_supervisor.py
+++ b/src/blueferry/profile_supervisor.py
@@ -59,7 +59,9 @@ class ProfileSupervisor:
         on_ready: Callable[[], None],
         on_lost: Callable[[str], None],
         on_status: Callable[[], None],
+        on_attempt_pending: Callable[[], None] | None = None,
         on_first_attempt_complete: Callable[[], None] | None = None,
+        attempt_ready: Callable[[], bool] | None = None,
         schedule: Schedule = GLib.timeout_add_seconds,
         cancel: Cancel = GLib.source_remove,
     ) -> None:
@@ -69,7 +71,9 @@ class ProfileSupervisor:
         self._on_ready = on_ready
         self._on_lost = on_lost
         self._on_status = on_status
+        self._on_attempt_pending = on_attempt_pending
         self._on_first_attempt_complete = on_first_attempt_complete
+        self._attempt_ready = attempt_ready or (lambda: True)
         self._schedule = schedule
         self._cancel = cancel
         self._retry_id: int | None = None
@@ -93,6 +97,7 @@ class ProfileSupervisor:
     def start(self) -> None:
         if self._stopping:
             return
+        self._begin_attempt_cycle()
         self.sessions.start_monitoring()
         self.open()
 
@@ -121,6 +126,7 @@ class ProfileSupervisor:
             log.debug("ignoring duplicate profile loss during cleanup: %s", reason)
             return
         log.warning("entering degraded mode after OBEX loss: %s", reason)
+        self._begin_attempt_cycle()
         self._generation += 1
         generation = self._generation
         self.connectivity.lost(reason)
@@ -164,7 +170,7 @@ class ProfileSupervisor:
         if self._stopping or generation != self._generation or self._closing:
             return
         self._opening = False
-        self._complete_first_attempt()
+        self._complete_first_attempt(force=True)
         log.info("MAP/PBAP sessions opened")
         self._mark_ready()
 
@@ -210,12 +216,25 @@ class ProfileSupervisor:
         self._on_status()
         self._schedule_retry(delay)
 
-    def _complete_first_attempt(self) -> None:
+    def _complete_first_attempt(self, *, force: bool = False) -> None:
         if self._first_attempt_completed:
+            return
+        if not force and not self._attempt_ready():
+            log.debug(
+                "MAP/PBAP attempt completed while BR/EDR was unavailable; "
+                "keeping LE held for the next attempt"
+            )
             return
         self._first_attempt_completed = True
         if self._on_first_attempt_complete is not None:
             self._on_first_attempt_complete()
+
+    def _begin_attempt_cycle(self) -> None:
+        if not self._first_attempt_completed and self._opening:
+            return
+        self._first_attempt_completed = False
+        if self._on_attempt_pending is not None:
+            self._on_attempt_pending()
 
     def _closed(self, generation: int) -> None:
         if self._stopping or generation != self._generation:

--- a/src/blueferry/solicitation_supervisor.py
+++ b/src/blueferry/solicitation_supervisor.py
@@ -1,0 +1,138 @@
+"""Keep the ANCS solicitation aligned with end-to-end notification health."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+
+from gi.repository import GLib
+
+from blueferry import bluez_setup
+
+log = logging.getLogger(__name__)
+
+RECONCILE_SECONDS = 30
+# Keep the post-pair/reconnect signal visible long enough for iOS to surface
+# its MAP/PBAP permission toggles even if ANCS authorizes immediately.
+MINIMUM_ON_SECONDS = 180
+
+Register = Callable[[str], bool]
+Unregister = Callable[[str], None]
+IsRegistered = Callable[[], bool]
+ForgetRegistration = Callable[[], None]
+Schedule = Callable[[int, Callable[[], bool]], int]
+Cancel = Callable[[int], object]
+Clock = Callable[[], float]
+
+
+class SolicitationSupervisor:
+    """Broadcast solicitation while ANCS needs an inbound LE connection.
+
+    The advertisement is a reconnect primitive rather than a pairing-only
+    side effect.  It remains on air while LE/GATT/authorization is incomplete,
+    is released once ANCS is proven usable, and is recreated after BlueZ
+    changes D-Bus owner.  A periodic reconciliation also repairs an
+    advertisement that BlueZ released without another bearer transition.
+    """
+
+    def __init__(
+        self,
+        adapter: str,
+        *,
+        needed: bool = True,
+        register: Register = bluez_setup.register_advert,
+        unregister: Unregister = bluez_setup.unregister_advert,
+        is_registered: IsRegistered = bluez_setup.advert_registered,
+        forget_registration: ForgetRegistration = (
+            bluez_setup.forget_advert_registration
+        ),
+        minimum_on_seconds: int = MINIMUM_ON_SECONDS,
+        schedule: Schedule = GLib.timeout_add_seconds,
+        cancel: Cancel = GLib.source_remove,
+        clock: Clock = time.monotonic,
+    ) -> None:
+        self.adapter = adapter
+        self._needed = needed
+        self._register = register
+        self._unregister = unregister
+        self._is_registered = is_registered
+        self._forget_registration = forget_registration
+        self._minimum_on_seconds = minimum_on_seconds
+        self._schedule = schedule
+        self._cancel = cancel
+        self._clock = clock
+        self._running = False
+        self._timer_id: int | None = None
+        self._hold_until = 0.0
+
+    @property
+    def needed(self) -> bool:
+        return self._needed
+
+    def active(self) -> bool:
+        """Return whether inbound LE reconnection is currently primed."""
+        return self._is_registered()
+
+    def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        if self._needed:
+            self._begin_hold()
+        self._reconcile()
+        self._timer_id = self._schedule(RECONCILE_SECONDS, self._tick)
+
+    def set_needed(self, needed: bool) -> None:
+        changed = needed != self._needed
+        self._needed = needed
+        if needed and changed:
+            self._begin_hold()
+        if self._running and (changed or needed != self._is_registered()):
+            self._reconcile()
+
+    def reset_after_bluez_restart(self) -> None:
+        """Forget the old owner's registration and prime inbound LE again."""
+        self._needed = True
+        self._begin_hold()
+        self._forget_registration()
+        if self._running:
+            self._reconcile()
+
+    def stop(self) -> None:
+        self._running = False
+        if self._timer_id is not None:
+            try:
+                self._cancel(self._timer_id)
+            except Exception:
+                log.debug("could not remove solicitation health timer", exc_info=True)
+            self._timer_id = None
+        if self._is_registered():
+            self._unregister(self.adapter)
+
+    def _tick(self) -> bool:
+        if not self._running:
+            return False
+        self._reconcile()
+        return True
+
+    def _reconcile(self) -> None:
+        registered = self._is_registered()
+        if self._needed and not registered:
+            if not self._register(self.adapter):
+                log.warning(
+                    "ANCS solicitation is unavailable; retrying in %ds",
+                    RECONCILE_SECONDS,
+                )
+        elif (
+            not self._needed
+            and registered
+            and self._clock() >= self._hold_until
+        ):
+            self._unregister(self.adapter)
+
+    def _begin_hold(self) -> None:
+        self._hold_until = max(
+            self._hold_until,
+            self._clock() + self._minimum_on_seconds,
+        )

--- a/systemd/49-blueferry-cod.rules
+++ b/systemd/49-blueferry-cod.rules
@@ -1,6 +1,8 @@
-// Require a fresh administrator authorization for BlueFerry's one narrowly
-// scoped system unit. In particular, do not inherit systemd's usual
-// auth_admin_keep decision after a previous manage-units operation.
+// Let an active local session repair volatile Bluetooth Class-of-Device state
+// through BlueFerry's one narrowly scoped system unit. The unit has a fixed
+// command, validates its numeric adapter index, sets only class 4/8, and has a
+// capability and syscall sandbox; this does not delegate arbitrary btmgmt or
+// systemd operations to the user daemon.
 polkit.addRule(function(action, subject) {
     if (action.id !== "org.freedesktop.systemd1.manage-units" ||
         action.lookup("verb") !== "start" ||
@@ -10,7 +12,7 @@ polkit.addRule(function(action, subject) {
 
     var unit = action.lookup("unit");
     if (unit && /^blueferry-btmgmt-set-class@[0-9]+\.service$/.test(unit)) {
-        return polkit.Result.AUTH_ADMIN;
+        return polkit.Result.YES;
     }
     return polkit.Result.NOT_HANDLED;
 });

--- a/tests/test_adapter_class_supervisor.py
+++ b/tests/test_adapter_class_supervisor.py
@@ -1,0 +1,113 @@
+"""Adapter Class-of-Device supervision without Bluetooth or systemd."""
+
+from blueferry import adapter_class_supervisor
+from blueferry.adapter_class_supervisor import AdapterClassSupervisor
+
+
+def _supervisor(calls, state, scheduled):
+    return AdapterClassSupervisor(
+        "hci7",
+        read_class=lambda adapter: (
+            calls.append(("read", adapter)),
+            state["class"],
+        )[-1],
+        matches=lambda value: value == 0x408,
+        repair=lambda adapter: (
+            calls.append(("repair", adapter)),
+            state.__setitem__("class", 0x408),
+            True,
+        )[-1],
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        cancel=lambda timer_id: calls.append(("cancel", timer_id)),
+    )
+
+
+def test_start_repairs_a_drifted_adapter_class() -> None:
+    calls = []
+    state = {"class": 0x104}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+
+    supervisor.start()
+
+    assert calls == [("read", "hci7"), ("repair", "hci7")]
+    assert state["class"] == 0x408
+    assert scheduled[0][0] == adapter_class_supervisor.RECONCILE_SECONDS
+
+
+def test_matching_adapter_class_is_left_alone() -> None:
+    calls = []
+    state = {"class": 0x408}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+
+    supervisor.start()
+
+    assert calls == [("read", "hci7")]
+
+
+def test_periodic_reconciliation_repairs_later_drift() -> None:
+    calls = []
+    state = {"class": 0x408}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+    supervisor.start()
+
+    state["class"] = 0x104
+    assert scheduled[0][1]() is True
+
+    assert calls[-2:] == [("read", "hci7"), ("repair", "hci7")]
+
+
+def test_unknown_adapter_state_waits_without_invoking_helper() -> None:
+    calls = []
+    state = {"class": None}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+
+    supervisor.start()
+
+    assert calls == [("read", "hci7")]
+
+
+def test_read_failure_does_not_stop_periodic_reconciliation() -> None:
+    scheduled = []
+
+    def fail(_adapter):
+        raise RuntimeError("gone")
+
+    supervisor = AdapterClassSupervisor(
+        "hci7",
+        read_class=fail,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+
+    supervisor.start()
+
+    assert scheduled[0][1]() is True
+
+
+def test_bluez_restart_poke_rechecks_immediately() -> None:
+    calls = []
+    state = {"class": 0x408}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+    supervisor.start()
+    state["class"] = 0x104
+
+    supervisor.poke()
+
+    assert calls[-2:] == [("read", "hci7"), ("repair", "hci7")]
+
+
+def test_stop_cancels_reconciliation() -> None:
+    calls = []
+    state = {"class": 0x408}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+    supervisor.start()
+
+    supervisor.stop()
+
+    assert calls[-1] == ("cancel", 7)
+    assert scheduled[0][1]() is False

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -835,6 +835,7 @@ def test_le_reconnect_replaces_stale_subscription_and_reauthorizes(
     client._notify_started = True
     client._authorized = True
     client._was_authorized = True
+    client._owned_notify_paths = {"/device/ns", "/device/ds"}
     old_matches = [_Match(), _Match()]
     client._characteristic_signal_matches = old_matches
 
@@ -854,6 +855,8 @@ def test_le_reconnect_replaces_stale_subscription_and_reauthorizes(
     scheduled[0][1]()
 
     assert calls == [
+        ("stop", "ns"),
+        ("stop", "ds"),
         ("start", "ns"),
         ("start", "ds"),
         ("write", "cp"),
@@ -863,6 +866,71 @@ def test_le_reconnect_replaces_stale_subscription_and_reauthorizes(
     _complete_authorization_probe(client)
     assert client.connected is True
     assert statuses == [True, True]
+
+
+def test_le_reconnect_retries_notification_rearm_without_cycling_bearer(
+    monkeypatch,
+) -> None:
+    scheduled = []
+
+    class _Characteristic:
+        def __init__(self, *, stop_fails_once: bool = False) -> None:
+            self.stop_fails_once = stop_fails_once
+            self.stop_calls = 0
+            self.start_calls = 0
+
+        def StartNotify(self, **_kwargs) -> None:
+            self.start_calls += 1
+
+        def StopNotify(self, **_kwargs) -> None:
+            self.stop_calls += 1
+            if self.stop_fails_once:
+                self.stop_fails_once = False
+                raise client_module.dbus.exceptions.DBusException(
+                    "still settling",
+                    name="org.bluez.Error.InProgress",
+                )
+
+        @staticmethod
+        def WriteValue(_value, _options, **_kwargs) -> None:
+            return None
+
+    ns = _Characteristic(stop_fails_once=True)
+    ds = _Characteristic()
+    cp = _Characteristic()
+    bus = _CharacteristicBus(
+        {"/device/ns": ns, "/device/ds": ds, "/device/cp": cp}
+    )
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        previously_authorized=True,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    client._started = True
+    client._bearer_connected = False
+    client._ns_path = "/device/ns"
+    client._ds_path = "/device/ds"
+    client._cp_path = "/device/cp"
+    client._owned_notify_paths = {"/device/ns", "/device/ds"}
+    client._notify_rearm_pending = True
+
+    client.observe_bearer_state(True)
+    scheduled.pop(0)[1]()
+
+    assert client.subscribed is False
+    assert ns.stop_calls == 1
+    assert ds.stop_calls == 1
+    assert scheduled[0][0] == client_module.SUBSCRIBE_RETRY_SECONDS
+
+    scheduled.pop(0)[1]()
+
+    assert ns.stop_calls == 2
+    assert ns.start_calls == 1
+    assert ds.start_calls == 1
+    assert client.subscribed is True
 
 
 def test_not_connected_control_point_failure_invalidates_ancs_health(

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -933,6 +933,65 @@ def test_le_reconnect_retries_notification_rearm_without_cycling_bearer(
     assert client.subscribed is True
 
 
+def test_le_reconnect_treats_missing_notify_session_as_already_stopped(
+    monkeypatch,
+) -> None:
+    scheduled = []
+
+    class _Characteristic:
+        def __init__(self, *, already_stopped: bool = False) -> None:
+            self.already_stopped = already_stopped
+            self.stop_calls = 0
+            self.start_calls = 0
+
+        def StartNotify(self, **_kwargs) -> None:
+            self.start_calls += 1
+
+        def StopNotify(self, **_kwargs) -> None:
+            self.stop_calls += 1
+            if self.already_stopped:
+                raise client_module.dbus.exceptions.DBusException(
+                    "No notify session started",
+                    name="org.bluez.Error.Failed",
+                )
+
+        @staticmethod
+        def WriteValue(_value, _options, **_kwargs) -> None:
+            return None
+
+    ns = _Characteristic(already_stopped=True)
+    ds = _Characteristic()
+    cp = _Characteristic()
+    bus = _CharacteristicBus(
+        {"/device/ns": ns, "/device/ds": ds, "/device/cp": cp}
+    )
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        previously_authorized=True,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    client._started = True
+    client._bearer_connected = False
+    client._ns_path = "/device/ns"
+    client._ds_path = "/device/ds"
+    client._cp_path = "/device/cp"
+    client._owned_notify_paths = {"/device/ns", "/device/ds"}
+    client._notify_rearm_pending = True
+
+    client.observe_bearer_state(True)
+    scheduled.pop(0)[1]()
+
+    assert ns.stop_calls == 1
+    assert ds.stop_calls == 1
+    assert ns.start_calls == 1
+    assert ds.start_calls == 1
+    assert client.subscribed is True
+    assert client._notify_rearm_pending is False
+
+
 def test_not_connected_control_point_failure_invalidates_ancs_health(
     monkeypatch,
 ) -> None:

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -150,6 +150,36 @@ def test_le_can_be_held_until_classic_profile_attempt_finishes() -> None:
     assert connections == ["le"]
 
 
+def test_le_can_be_held_again_during_a_later_profile_reconnect() -> None:
+    state = {"bredr": True, "le": False}
+    connections = []
+    scheduled = []
+    cancelled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, _on_error: (
+            connections.append(kind),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        cancel=cancelled.append,
+    )
+
+    supervisor.start()
+    assert scheduled[0][0] == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+
+    supervisor.hold_le()
+    assert cancelled == [7]
+    scheduled[0][1]()
+    assert connections == []
+
+    supervisor.enable_le()
+    assert scheduled[-1][0] == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    scheduled[-1][1]()
+    assert connections == ["le"]
+
+
 def test_selects_each_bearer_before_requesting_its_connection() -> None:
     state = {"bredr": False, "le": False}
     calls = []

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -228,10 +228,13 @@ def test_hold_rejects_an_le_connect_already_in_flight() -> None:
     health_check()
     supervisor.enable_le()
     assert observed == [False]
-    assert any(
-        delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
-        for delay, _callback in scheduled
+    next_settle = next(
+        callback
+        for delay, callback in reversed(scheduled)
+        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
     )
+    next_settle()
+    assert [kind for kind, _callback in connect_callbacks] == ["le", "le"]
 
 
 def test_selects_each_bearer_before_requesting_its_connection() -> None:
@@ -570,21 +573,25 @@ def test_gatt_transport_recovery_waits_for_profile_gate_to_reopen() -> None:
 
 def test_bluez_restart_rejects_new_le_link_while_profile_gate_is_closed() -> None:
     state = {"bredr": True, "le": True}
+    connections = []
     disconnects = []
     observed = []
     supervisor = BearerSupervisor(
         "/device",
         read_connected=state.get,
+        connect=lambda kind, _on_success, _on_error: connections.append(kind),
         disconnect=lambda kind, _on_success, _on_error: disconnects.append(kind),
         on_le_state=observed.append,
         schedule=lambda _delay, _callback: 7,
     )
     supervisor.start()
     supervisor.hold_le()
+    state["bredr"] = False
 
     supervisor.reset_after_bluez_restart()
 
     assert disconnects == ["le"]
+    assert connections == ["bredr"]
     assert observed == [True, None]
 
 

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -568,6 +568,88 @@ def test_le_outbound_dial_is_spent_once_then_solicitation_takes_over() -> None:
     assert connections == ["le"]
 
 
+def test_real_le_disconnect_refunds_one_outbound_dial() -> None:
+    state = {"bredr": True, "le": False}
+    connections = []
+    scheduled = []
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, _on_error: (
+            connections.append(kind),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    supervisor.start()
+    initial_settle = scheduled[0][1]
+    health_check = scheduled[1][1]
+    initial_settle()
+    assert connections == ["le"]
+
+    state["le"] = True
+    health_check()
+    state["le"] = False
+    health_check()
+    settle = next(
+        callback
+        for delay, callback in reversed(scheduled)
+        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    )
+    settle()
+
+    assert connections == ["le", "le"]
+
+    # The lifecycle event grants exactly one attempt. A phone that remains
+    # absent is still left to solicitation instead of being dialled forever.
+    health_check()
+    assert connections == ["le", "le"]
+
+
+def test_classic_return_refunds_le_dial_spent_while_phone_was_absent() -> None:
+    state = {"bredr": True, "le": True}
+    le_connections = []
+    scheduled = []
+
+    def connect(kind, on_success, _on_error):
+        if kind == "le":
+            le_connections.append(kind)
+        on_success()
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=connect,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    supervisor.start()
+    health_check = scheduled[0][1]
+
+    state["le"] = False
+    health_check()
+    first_settle = next(
+        callback
+        for delay, callback in reversed(scheduled)
+        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    )
+    first_settle()
+    assert le_connections == ["le"]
+
+    state["bredr"] = False
+    health_check()
+    state["bredr"] = True
+    health_check()
+    return_settle = next(
+        callback
+        for delay, callback in reversed(scheduled)
+        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    )
+    return_settle()
+
+    assert le_connections == ["le", "le"]
+
+
 def test_le_outbound_dial_retries_when_solicitation_is_unavailable() -> None:
     state = {"bredr": True, "le": False}
     connections = []
@@ -727,134 +809,6 @@ def test_gatt_transport_recovery_waits_for_profile_gate_to_reopen() -> None:
 
     supervisor.enable_le()
     assert disconnects == ["le"]
-
-
-def test_profile_transport_failure_cycles_only_classic() -> None:
-    state = {"bredr": True, "le": True}
-    disconnects = []
-    connections = []
-    scheduled = []
-    supervisor = BearerSupervisor(
-        "/device",
-        read_connected=state.get,
-        connect=lambda kind, on_success, _on_error: (
-            connections.append(kind),
-            on_success(),
-        ),
-        disconnect=lambda kind, on_success, _on_error: (
-            disconnects.append(kind),
-            on_success(),
-        ),
-        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
-    )
-    supervisor.start()
-    health_check = scheduled[0][1]
-
-    assert supervisor.recover_classic_transport() is True
-    assert supervisor.recover_classic_transport() is True
-    assert disconnects == ["bredr"]
-    assert supervisor.bredr_ready is False
-    assert supervisor.le_connected is True
-
-    state["bredr"] = False
-    health_check()
-    assert connections == ["bredr"]
-    assert supervisor.bredr_ready is False
-    assert state["le"] is True
-
-    state["bredr"] = True
-    health_check()
-    assert supervisor.bredr_ready is True
-    assert disconnects == ["bredr"]
-    assert connections == ["bredr"]
-
-
-def test_classic_recovery_is_rate_limited_until_profiles_succeed() -> None:
-    state = {"bredr": True, "le": True}
-    disconnects = []
-    scheduled = []
-    now = 0.0
-    supervisor = BearerSupervisor(
-        "/device",
-        read_connected=state.get,
-        connect=lambda _kind, on_success, _on_error: on_success(),
-        disconnect=lambda kind, on_success, _on_error: (
-            disconnects.append(kind),
-            on_success(),
-        ),
-        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
-        clock=lambda: now,
-    )
-    supervisor.start()
-    health_check = scheduled[0][1]
-
-    assert supervisor.recover_classic_transport() is True
-    state["bredr"] = False
-    health_check()
-    state["bredr"] = True
-    health_check()
-
-    now = 20.0
-    assert supervisor.recover_classic_transport() is False
-    assert disconnects == ["bredr"]
-
-    supervisor.confirm_classic_transport()
-    assert supervisor.recover_classic_transport() is True
-    assert disconnects == ["bredr", "bredr"]
-
-
-def test_missing_classic_disconnect_api_does_not_block_profile_retries() -> None:
-    import dbus
-
-    state = {"bredr": True, "le": True}
-
-    def disconnect(_kind, _on_success, on_error):
-        on_error(
-            dbus.exceptions.DBusException(
-                "Unknown method Disconnect",
-                name="org.freedesktop.DBus.Error.UnknownMethod",
-            )
-        )
-
-    supervisor = BearerSupervisor(
-        "/device",
-        read_connected=state.get,
-        disconnect=disconnect,
-        schedule=lambda _delay, _callback: 7,
-    )
-    supervisor.start()
-
-    assert supervisor.recover_classic_transport() is True
-    assert supervisor.bredr_ready is True
-    assert supervisor.le_connected is True
-
-
-def test_noop_classic_disconnect_is_abandoned_after_bounded_attempts() -> None:
-    state = {"bredr": True, "le": True}
-    disconnects = []
-    scheduled = []
-    clock = {"now": 0.0}
-    supervisor = BearerSupervisor(
-        "/device",
-        read_connected=state.get,
-        disconnect=lambda kind, on_success, _on_error: (
-            disconnects.append(kind),
-            on_success(),
-        ),
-        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
-        clock=lambda: clock["now"],
-    )
-    supervisor.start()
-    health_check = scheduled[0][1]
-
-    assert supervisor.recover_classic_transport() is True
-    for instant in (10.0, 30.0, 70.0):
-        clock["now"] = instant
-        health_check()
-
-    assert disconnects == ["bredr"] * 3
-    assert supervisor.bredr_ready is True
-    assert supervisor.le_connected is True
 
 
 def test_bluez_restart_rejects_new_le_link_while_profile_gate_is_closed() -> None:

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -729,6 +729,134 @@ def test_gatt_transport_recovery_waits_for_profile_gate_to_reopen() -> None:
     assert disconnects == ["le"]
 
 
+def test_profile_transport_failure_cycles_only_classic() -> None:
+    state = {"bredr": True, "le": True}
+    disconnects = []
+    connections = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, _on_error: (
+            connections.append(kind),
+            on_success(),
+        ),
+        disconnect=lambda kind, on_success, _on_error: (
+            disconnects.append(kind),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    supervisor.start()
+    health_check = scheduled[0][1]
+
+    assert supervisor.recover_classic_transport() is True
+    assert supervisor.recover_classic_transport() is True
+    assert disconnects == ["bredr"]
+    assert supervisor.bredr_ready is False
+    assert supervisor.le_connected is True
+
+    state["bredr"] = False
+    health_check()
+    assert connections == ["bredr"]
+    assert supervisor.bredr_ready is False
+    assert state["le"] is True
+
+    state["bredr"] = True
+    health_check()
+    assert supervisor.bredr_ready is True
+    assert disconnects == ["bredr"]
+    assert connections == ["bredr"]
+
+
+def test_classic_recovery_is_rate_limited_until_profiles_succeed() -> None:
+    state = {"bredr": True, "le": True}
+    disconnects = []
+    scheduled = []
+    now = 0.0
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda _kind, on_success, _on_error: on_success(),
+        disconnect=lambda kind, on_success, _on_error: (
+            disconnects.append(kind),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    health_check = scheduled[0][1]
+
+    assert supervisor.recover_classic_transport() is True
+    state["bredr"] = False
+    health_check()
+    state["bredr"] = True
+    health_check()
+
+    now = 20.0
+    assert supervisor.recover_classic_transport() is False
+    assert disconnects == ["bredr"]
+
+    supervisor.confirm_classic_transport()
+    assert supervisor.recover_classic_transport() is True
+    assert disconnects == ["bredr", "bredr"]
+
+
+def test_missing_classic_disconnect_api_does_not_block_profile_retries() -> None:
+    import dbus
+
+    state = {"bredr": True, "le": True}
+
+    def disconnect(_kind, _on_success, on_error):
+        on_error(
+            dbus.exceptions.DBusException(
+                "Unknown method Disconnect",
+                name="org.freedesktop.DBus.Error.UnknownMethod",
+            )
+        )
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        disconnect=disconnect,
+        schedule=lambda _delay, _callback: 7,
+    )
+    supervisor.start()
+
+    assert supervisor.recover_classic_transport() is True
+    assert supervisor.bredr_ready is True
+    assert supervisor.le_connected is True
+
+
+def test_noop_classic_disconnect_is_abandoned_after_bounded_attempts() -> None:
+    state = {"bredr": True, "le": True}
+    disconnects = []
+    scheduled = []
+    clock = {"now": 0.0}
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        disconnect=lambda kind, on_success, _on_error: (
+            disconnects.append(kind),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: clock["now"],
+    )
+    supervisor.start()
+    health_check = scheduled[0][1]
+
+    assert supervisor.recover_classic_transport() is True
+    for instant in (10.0, 30.0, 70.0):
+        clock["now"] = instant
+        health_check()
+
+    assert disconnects == ["bredr"] * 3
+    assert supervisor.bredr_ready is True
+    assert supervisor.le_connected is True
+
+
 def test_bluez_restart_rejects_new_le_link_while_profile_gate_is_closed() -> None:
     state = {"bredr": True, "le": True}
     connections = []

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -482,6 +482,164 @@ def test_backoff_resets_once_the_bearer_connects() -> None:
     assert attempts == ["bredr", "bredr"]
 
 
+def test_returning_le_link_clears_classic_absence_backoff() -> None:
+    state = {"bredr": False, "le": False}
+    attempts = []
+    scheduled = []
+    now = 0.0
+
+    def connect(kind, _on_success, on_error):
+        attempts.append(kind)
+        on_error(RuntimeError("phone absent"))
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=connect,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    assert attempts == ["bredr"]
+
+    # The old retry is ten seconds away, but an inbound LE link proves that
+    # the phone has returned and makes Classic retry on this health tick.
+    state["le"] = True
+    scheduled[0][1]()
+
+    assert attempts == ["bredr", "bredr"]
+
+
+def test_live_le_bounds_classic_backoff() -> None:
+    state = {"bredr": False, "le": True}
+    attempts = []
+    scheduled = []
+    now = 0.0
+
+    def connect(kind, _on_success, on_error):
+        attempts.append(kind)
+        on_error(RuntimeError("not now"))
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=connect,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
+    )
+    supervisor.start()
+
+    for instant in (10.0, 30.0, 60.0, 90.0):
+        now = instant
+        scheduled[0][1]()
+
+    assert attempts == ["bredr"] * 5
+    assert supervisor._next_attempt["bredr"] == 120.0
+
+
+def test_le_outbound_dial_is_spent_once_then_solicitation_takes_over() -> None:
+    state = {"bredr": True, "le": False}
+    connections = []
+    scheduled = []
+    now = 0.0
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, _on_error: (
+            connections.append(kind),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    settle = scheduled[0][1]
+    health_check = scheduled[1][1]
+
+    settle()
+    assert connections == ["le"]
+
+    # Even after the old exponential delay has elapsed, a missing LE bearer
+    # does not spend another outbound dial.  The ANCS solicitation remains the
+    # durable reconnect mechanism.
+    now = 600.0
+    health_check()
+    assert connections == ["le"]
+
+
+def test_le_outbound_dial_retries_when_solicitation_is_unavailable() -> None:
+    state = {"bredr": True, "le": False}
+    connections = []
+    scheduled = []
+    now = 0.0
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, _on_error: (
+            connections.append(kind),
+            on_success(),
+        ),
+        inbound_le_primed=lambda: False,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    settle = scheduled[0][1]
+    health_check = scheduled[1][1]
+
+    settle()
+    assert connections == ["le"]
+
+    # If BlueZ cannot keep the solicitation advertisement registered, retain
+    # the ordinary bounded outbound fallback instead of stranding ANCS.
+    now = 11.0
+    health_check()
+    scheduled[-1][1]()
+    assert connections == ["le", "le"]
+
+
+def test_ancs_transport_reset_refunds_one_le_dial() -> None:
+    state = {"bredr": True, "le": False}
+    connections = []
+    disconnects = []
+    scheduled = []
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, _on_error: (
+            connections.append(kind),
+            on_success(),
+        ),
+        disconnect=lambda kind, on_success, _on_error: (
+            disconnects.append(kind),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    supervisor.start()
+    scheduled[0][1]()
+    assert connections == ["le"]
+
+    state["le"] = True
+    scheduled[1][1]()
+    supervisor.recover_le_transport()
+    assert disconnects == ["le"]
+
+    state["le"] = False
+    scheduled[1][1]()
+    next_settle = next(
+        callback
+        for delay, callback in reversed(scheduled)
+        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    )
+    next_settle()
+
+    assert connections == ["le", "le"]
+
+
 def test_le_observer_receives_only_lifecycle_transitions() -> None:
     state = {"bredr": True, "le": True}
     observed = []

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -180,6 +180,60 @@ def test_le_can_be_held_again_during_a_later_profile_reconnect() -> None:
     assert connections == ["le"]
 
 
+def test_hold_rejects_an_le_connect_already_in_flight() -> None:
+    state = {"bredr": True, "le": False}
+    connect_callbacks = []
+    disconnect_callbacks = []
+    observed = []
+    scheduled = []
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, _on_error: connect_callbacks.append(
+            (kind, on_success)
+        ),
+        disconnect=lambda kind, on_success, _on_error: disconnect_callbacks.append(
+            (kind, on_success)
+        ),
+        on_le_state=observed.append,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    supervisor.start()
+    settle = next(
+        callback
+        for delay, callback in scheduled
+        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    )
+    health_check = next(
+        callback
+        for delay, callback in scheduled
+        if delay == bearer_supervisor.POLL_SECONDS
+    )
+    settle()
+    assert [kind for kind, _callback in connect_callbacks] == ["le"]
+
+    supervisor.hold_le()
+    connect_callbacks[0][1]()
+    state["le"] = True
+    health_check()
+
+    # The pending Connect is countered immediately, and its transient True
+    # state is not published to ANCS while the profile gate is closed.
+    assert [kind for kind, _callback in disconnect_callbacks] == ["le"]
+    assert observed == [False]
+
+    disconnect_callbacks[0][1]()
+    state["le"] = False
+    health_check()
+    supervisor.enable_le()
+    assert observed == [False]
+    assert any(
+        delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+        for delay, _callback in scheduled
+    )
+
+
 def test_selects_each_bearer_before_requesting_its_connection() -> None:
     state = {"bredr": False, "le": False}
     calls = []
@@ -490,6 +544,48 @@ def test_gatt_transport_failure_cycles_le_once_before_reconnecting() -> None:
 
     scheduled[-1][1]()
     assert connections == ["le"]
+
+
+def test_gatt_transport_recovery_waits_for_profile_gate_to_reopen() -> None:
+    state = {"bredr": True, "le": True}
+    disconnects = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        disconnect=lambda kind, on_success, _on_error: (
+            disconnects.append(kind),
+            on_success(),
+        ),
+        schedule=lambda _delay, _callback: 7,
+    )
+    supervisor.start()
+
+    supervisor.hold_le()
+    supervisor.recover_le_transport()
+    assert disconnects == []
+
+    supervisor.enable_le()
+    assert disconnects == ["le"]
+
+
+def test_bluez_restart_rejects_new_le_link_while_profile_gate_is_closed() -> None:
+    state = {"bredr": True, "le": True}
+    disconnects = []
+    observed = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        disconnect=lambda kind, _on_success, _on_error: disconnects.append(kind),
+        on_le_state=observed.append,
+        schedule=lambda _delay, _callback: 7,
+    )
+    supervisor.start()
+    supervisor.hold_le()
+
+    supervisor.reset_after_bluez_restart()
+
+    assert disconnects == ["le"]
+    assert observed == [True, None]
 
 
 def test_bluez_restart_discards_callbacks_from_the_previous_owner() -> None:

--- a/tests/test_bluez_setup.py
+++ b/tests/test_bluez_setup.py
@@ -30,6 +30,13 @@ class TestAncsAdvertisement:
         with pytest.raises(dbus.exceptions.DBusException):
             bluez_setup._AncsAdvert.GetAll(None, "not.the.advert.interface")
 
+    def test_release_clears_registration_state(self, monkeypatch):
+        monkeypatch.setattr(bluez_setup, "_advert_registered", True)
+
+        bluez_setup._AncsAdvert.Release(None)
+
+        assert bluez_setup.advert_registered() is False
+
 
 def test_daemon_run_cleans_up_when_start_raises(monkeypatch):
     """A partial startup must not leak a hardware advertisement."""

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -12,6 +12,9 @@ class _Bearer:
     def start(self):
         self.calls.append("bearers-start")
 
+    def hold_le(self):
+        self.calls.append("bearers-hold-le")
+
     def reset_after_bluez_restart(self):
         self.calls.append("bearers-reset")
 
@@ -39,6 +42,11 @@ class _Profiles:
 
     def start(self):
         self.calls.append("profiles-start")
+
+    def reconnect(self, reason, *, remove_remote_sessions=True):
+        self.calls.append(
+            ("profiles-reconnect", reason, remove_remote_sessions)
+        )
 
 
 def _daemon(calls):
@@ -148,3 +156,16 @@ def test_full_daemon_preserves_known_ancs_reconnect_protection(monkeypatch):
     value._initialize_bluetooth()
 
     assert ("previously-authorized", True) in calls
+
+
+def test_bluez_restart_reapplies_profile_gate_before_resetting_bearers():
+    calls = []
+    value = _daemon(calls)
+
+    value._on_bluez_restart()
+
+    assert calls == [
+        "bearers-hold-le",
+        ("profiles-reconnect", "bluetoothd restarted", False),
+        "bearers-reset",
+    ]

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -21,10 +21,6 @@ class _Bearer:
     def recover_le_transport(self):
         self.calls.append("bearers-recover-le")
 
-    def confirm_classic_transport(self):
-        self.calls.append("bearers-confirm-classic")
-
-
 class _Events:
     def __init__(self, calls):
         self.calls = calls
@@ -221,3 +217,68 @@ def test_solicitation_stays_up_until_profiles_and_ancs_are_ready(monkeypatch):
         ("solicitation-needed", True),
         ("solicitation-needed", False),
     ]
+
+
+def test_partial_pbap_starts_contacts_without_map_listener(monkeypatch):
+    calls = []
+    value = daemon.Daemon.__new__(daemon.Daemon)
+    value.sessions = type("Sessions", (), {"map": None, "pbap": object()})()
+    value.contacts = type(
+        "Contacts",
+        (),
+        {"count": lambda _self: 0, "resolve": lambda _self, raw: raw},
+    )()
+    value._contacts_refresh_id = None
+    value.listener = None
+    value._refresh_contacts = lambda: calls.append("refresh-contacts")
+    value._periodic_refresh_contacts = lambda: True
+    monkeypatch.setattr(
+        daemon.GLib,
+        "timeout_add_seconds",
+        lambda delay, _callback: calls.append(("schedule", delay)) or 77,
+    )
+    monkeypatch.setattr(
+        daemon,
+        "MapEventListener",
+        lambda **_kwargs: calls.append("unexpected-map-listener"),
+    )
+
+    value._post_available_sessions_setup()
+
+    assert calls == [
+        "refresh-contacts",
+        ("schedule", daemon.CONTACTS_REFRESH_SEC),
+    ]
+    assert value._contacts_refresh_id == 77
+    assert value.listener is None
+
+
+def test_partial_map_starts_listener_without_contacts_work(monkeypatch):
+    calls = []
+
+    class Listener:
+        def __init__(self, **_kwargs):
+            calls.append("map-listener")
+
+        def start(self):
+            calls.append("map-listener-start")
+
+    value = daemon.Daemon.__new__(daemon.Daemon)
+    value.sessions = type("Sessions", (), {"map": object(), "pbap": None})()
+    value.contacts = type(
+        "Contacts",
+        (),
+        {"count": lambda _self: 0, "resolve": lambda _self, raw: raw},
+    )()
+    value._contacts_refresh_id = None
+    value.listener = None
+    value._refresh_contacts = lambda: calls.append("unexpected-contacts-refresh")
+    value.events = type("Events", (), {"message": lambda *_args: None})()
+    value.obex_worker = type("Worker", (), {"submit": lambda *_args: None})()
+    monkeypatch.setattr(daemon, "MapEventListener", Listener)
+
+    value._post_available_sessions_setup()
+
+    assert calls == ["map-listener", "map-listener-start"]
+    assert isinstance(value.listener, Listener)
+    assert value._contacts_refresh_id is None

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -63,11 +63,23 @@ class _Solicitation:
         self.calls.append("solicitation-reset")
 
 
+class _AdapterClass:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def start(self):
+        self.calls.append("adapter-class-start")
+
+    def poke(self):
+        self.calls.append("adapter-class-poke")
+
+
 def _daemon(calls):
     value = daemon.Daemon.__new__(daemon.Daemon)
     value.bearers = _Bearer(calls)
     value.events = _Events(calls)
     value.profiles = _Profiles(calls)
+    value.adapter_class = _AdapterClass(calls)
     value.solicitation = _Solicitation(calls)
     value.notification_policy = type("Policy", (), {"value": "messages"})()
     value.setup_verification = type("Verification", (), {"verified": ()})()
@@ -100,6 +112,7 @@ def test_compatibility_daemon_solicits_but_never_starts_ancs(monkeypatch):
     value._initialize_bluetooth()
 
     assert calls == [
+        "adapter-class-start",
         "solicitation-prepare",
         "solicitation-start",
         "bearers-start",
@@ -182,6 +195,7 @@ def test_bluez_restart_reapplies_profile_gate_before_resetting_bearers():
     value._on_bluez_restart()
 
     assert calls == [
+        "adapter-class-poke",
         "solicitation-reset",
         "bearers-hold-le",
         ("profiles-reconnect", "bluetoothd restarted", False),

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -21,6 +21,9 @@ class _Bearer:
     def recover_le_transport(self):
         self.calls.append("bearers-recover-le")
 
+    def confirm_classic_transport(self):
+        self.calls.append("bearers-confirm-classic")
+
 
 class _Events:
     def __init__(self, calls):

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -49,14 +49,30 @@ class _Profiles:
         )
 
 
+class _Solicitation:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def start(self):
+        self.calls.append("solicitation-start")
+
+    def set_needed(self, needed):
+        self.calls.append(("solicitation-needed", needed))
+
+    def reset_after_bluez_restart(self):
+        self.calls.append("solicitation-reset")
+
+
 def _daemon(calls):
     value = daemon.Daemon.__new__(daemon.Daemon)
     value.bearers = _Bearer(calls)
     value.events = _Events(calls)
     value.profiles = _Profiles(calls)
+    value.solicitation = _Solicitation(calls)
     value.notification_policy = type("Policy", (), {"value": "messages"})()
     value.setup_verification = type("Verification", (), {"verified": ()})()
     value.ancs = None
+    value._dbus_service = None
     value._watch_sleep_resume = lambda: calls.append("sleep-watch")
     return value
 
@@ -85,6 +101,7 @@ def test_compatibility_daemon_solicits_but_never_starts_ancs(monkeypatch):
 
     assert calls == [
         "solicitation-prepare",
+        "solicitation-start",
         "bearers-start",
         "sleep-watch",
         "events-setup",
@@ -165,7 +182,25 @@ def test_bluez_restart_reapplies_profile_gate_before_resetting_bearers():
     value._on_bluez_restart()
 
     assert calls == [
+        "solicitation-reset",
         "bearers-hold-le",
         ("profiles-reconnect", "bluetoothd restarted", False),
         "bearers-reset",
+    ]
+
+
+def test_solicitation_stays_up_until_profiles_and_ancs_are_ready(monkeypatch):
+    calls = []
+    value = _daemon(calls)
+    monkeypatch.setattr(daemon.config, "ANCS_ENABLED", True)
+    value.ancs = type("Ancs", (), {"connected": True})()
+
+    value.profiles.ready = False
+    value._sync_solicitation()
+    value.profiles.ready = True
+    value._sync_solicitation()
+
+    assert calls == [
+        ("solicitation-needed", True),
+        ("solicitation-needed", False),
     ]

--- a/tests/test_native_packaging.py
+++ b/tests/test_native_packaging.py
@@ -201,8 +201,8 @@ def test_native_backends_ship_the_btmgmt_system_unit_template() -> None:
     assert "*[!0-9]*" in helper
     assert ': | /usr/bin/btmgmt --index "$1" class 4 8' in helper
     assert "org.freedesktop.systemd1.manage-units" in rule
-    assert "AUTH_ADMIN" in rule
-    assert "AUTH_ADMIN_KEEP" not in rule
+    assert "polkit.Result.YES" in rule
+    assert "AUTH_ADMIN" not in rule
     assert "@[0-9]+\\.service" in rule
     assert "[Install]" not in unit
     assert f"systemd/{unit_name}" in deb_rules

--- a/tests/test_profile_supervisor.py
+++ b/tests/test_profile_supervisor.py
@@ -5,7 +5,6 @@ from blueferry.obex.sessions import ObexSession, SessionError
 from blueferry.profile_supervisor import (
     INITIAL_MAP_CONNECT_POLL_SECONDS,
     MAP_RECONNECT_POLL_SECONDS,
-    TRANSPORT_FAILURES_BEFORE_RESET,
     ProfileSupervisor,
 )
 
@@ -63,10 +62,10 @@ class FakeWorker:
 
 def make_supervisor(
     *,
+    partial_ready=None,
     attempt_pending=None,
     first_attempt=None,
     attempt_ready=None,
-    transport_failure=None,
 ):
     sessions = FakeSessions()
     worker = FakeWorker()
@@ -81,9 +80,9 @@ def make_supervisor(
         on_ready=lambda: ready.append(True),
         on_lost=lost.append,
         on_status=lambda: statuses.append(True),
+        on_partial_ready=partial_ready,
         on_attempt_pending=attempt_pending,
         on_first_attempt_complete=first_attempt,
-        on_transport_failure=transport_failure,
         attempt_ready=attempt_ready,
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 99,
         cancel=lambda _source: True,
@@ -120,6 +119,22 @@ def test_forbidden_failure_polls_and_retries() -> None:
     assert scheduled[0][0] == INITIAL_MAP_CONNECT_POLL_SECONDS
     assert scheduled[0][1]() is False
     assert len(worker.jobs) == 1
+
+
+def test_partial_profile_availability_is_published_while_retrying() -> None:
+    partial = []
+    supervisor, sessions, worker, scheduled, _ready, _lost, _statuses = (
+        make_supervisor(partial_ready=lambda: partial.append(True))
+    )
+    supervisor.start()
+    sessions.pbap = ObexSession("PBAP", "/pbap")
+
+    worker.fail(SessionError("MAP transport got disconnected"))
+
+    assert partial == [True]
+    assert sessions.map is None
+    assert sessions.pbap is not None
+    assert scheduled[-1][0] == INITIAL_MAP_CONNECT_POLL_SECONDS
 
 
 def test_first_attempt_callback_runs_once_across_failure_and_retry() -> None:
@@ -212,97 +227,6 @@ def test_map_connection_refusal_is_exposed_and_polls_quickly_until_ready() -> No
     scheduled[-1][1]()
     worker.fail(RuntimeError("still offline"))
     assert scheduled[-1][0] == INITIAL_MAP_CONNECT_POLL_SECONDS
-
-
-def test_repeated_transport_failures_request_one_targeted_recovery() -> None:
-    recoveries = []
-    supervisor, _sessions, worker, scheduled, _ready, _lost, _statuses = (
-        make_supervisor(
-            transport_failure=lambda: recoveries.append(True) or True,
-        )
-    )
-    supervisor.start()
-
-    for failure in range(TRANSPORT_FAILURES_BEFORE_RESET):
-        worker.fail(
-            SessionError(
-                "CreateSession(MAP) failed: "
-                "org.bluez.obex.Error.Failed: Transport got disconnected"
-            )
-        )
-        if failure < TRANSPORT_FAILURES_BEFORE_RESET - 1:
-            scheduled[-1][1]()
-
-    assert recoveries == [True]
-
-
-def test_profile_retry_waits_for_targeted_classic_recovery() -> None:
-    classic = {"ready": True}
-
-    def recover() -> bool:
-        classic["ready"] = False
-        return True
-
-    supervisor, _sessions, worker, scheduled, _ready, _lost, _statuses = (
-        make_supervisor(
-            attempt_ready=lambda: classic["ready"],
-            transport_failure=recover,
-        )
-    )
-    supervisor.start()
-    for failure in range(TRANSPORT_FAILURES_BEFORE_RESET):
-        worker.fail(SessionError("Timed out waiting for response"))
-        if failure < TRANSPORT_FAILURES_BEFORE_RESET - 1:
-            scheduled[-1][1]()
-
-    scheduled[-1][1]()
-    assert worker.jobs == []
-
-    classic["ready"] = True
-    scheduled[-1][1]()
-    assert len(worker.jobs) == 1
-
-
-def test_nontransport_profile_failures_break_the_recovery_streak() -> None:
-    recoveries = []
-    supervisor, _sessions, worker, scheduled, _ready, _lost, _statuses = (
-        make_supervisor(
-            transport_failure=lambda: recoveries.append(True) or True,
-        )
-    )
-    supervisor.start()
-
-    worker.fail(SessionError("Transport got disconnected"))
-    scheduled[-1][1]()
-    worker.fail(SessionError("Transport got disconnected"))
-    scheduled[-1][1]()
-    worker.fail(SessionError("org.bluez.obex.Error.Forbidden"))
-    for _failure in range(TRANSPORT_FAILURES_BEFORE_RESET - 1):
-        scheduled[-1][1]()
-        worker.fail(SessionError("Transport got disconnected"))
-
-    assert recoveries == []
-
-
-def test_map_refusal_never_cycles_the_classic_bearer() -> None:
-    recoveries = []
-    supervisor, _sessions, worker, scheduled, _ready, _lost, _statuses = (
-        make_supervisor(
-            transport_failure=lambda: recoveries.append(True) or True,
-        )
-    )
-    supervisor.start()
-    error = SessionError(
-        "CreateSession(MAP) failed: org.bluez.obex.Error.Failed: "
-        "Connection refused (111) after transport got disconnected"
-    )
-
-    for failure in range(TRANSPORT_FAILURES_BEFORE_RESET):
-        worker.fail(error)
-        if failure < TRANSPORT_FAILURES_BEFORE_RESET - 1:
-            scheduled[-1][1]()
-
-    assert recoveries == []
 
 
 def test_loss_discards_once_then_reconnects() -> None:

--- a/tests/test_profile_supervisor.py
+++ b/tests/test_profile_supervisor.py
@@ -60,7 +60,7 @@ class FakeWorker:
         failure(error)
 
 
-def make_supervisor(*, first_attempt=None):
+def make_supervisor(*, attempt_pending=None, first_attempt=None, attempt_ready=None):
     sessions = FakeSessions()
     worker = FakeWorker()
     scheduled = []
@@ -74,7 +74,9 @@ def make_supervisor(*, first_attempt=None):
         on_ready=lambda: ready.append(True),
         on_lost=lost.append,
         on_status=lambda: statuses.append(True),
+        on_attempt_pending=attempt_pending,
         on_first_attempt_complete=first_attempt,
+        attempt_ready=attempt_ready,
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 99,
         cancel=lambda _source: True,
     )
@@ -125,6 +127,58 @@ def test_first_attempt_callback_runs_once_across_failure_and_retry() -> None:
     scheduled[-1][1]()
     worker.succeed()
     assert attempted == [True]
+
+
+def test_attempt_gate_is_reapplied_for_each_profile_reconnect_cycle() -> None:
+    pending = []
+    completed = []
+    supervisor, sessions, worker, scheduled, _ready, _lost, _statuses = (
+        make_supervisor(
+            attempt_pending=lambda: pending.append(True),
+            first_attempt=lambda: completed.append(True),
+        )
+    )
+
+    supervisor.start()
+    assert pending == [True]
+    worker.succeed()
+    assert completed == [True]
+
+    assert sessions.lost is not None
+    sessions.lost("phone disconnected")
+    assert pending == [True, True]
+    worker.succeed()
+    scheduled[-1][1]()
+    worker.fail(RuntimeError("profile unavailable"))
+
+    assert completed == [True, True]
+
+    scheduled[-1][1]()
+    worker.succeed()
+    assert completed == [True, True]
+
+
+def test_attempt_gate_stays_closed_while_classic_is_unavailable() -> None:
+    classic = {"connected": False}
+    pending = []
+    completed = []
+    supervisor, _sessions, worker, scheduled, _ready, _lost, _statuses = (
+        make_supervisor(
+            attempt_pending=lambda: pending.append(True),
+            first_attempt=lambda: completed.append(True),
+            attempt_ready=lambda: classic["connected"],
+        )
+    )
+
+    supervisor.start()
+    worker.fail(RuntimeError("phone out of range"))
+    assert pending == [True]
+    assert completed == []
+
+    classic["connected"] = True
+    scheduled[-1][1]()
+    worker.fail(RuntimeError("profile unavailable"))
+    assert completed == [True]
 
 
 def test_map_connection_refusal_is_exposed_and_polls_quickly_until_ready() -> None:

--- a/tests/test_profile_supervisor.py
+++ b/tests/test_profile_supervisor.py
@@ -5,6 +5,7 @@ from blueferry.obex.sessions import ObexSession, SessionError
 from blueferry.profile_supervisor import (
     INITIAL_MAP_CONNECT_POLL_SECONDS,
     MAP_RECONNECT_POLL_SECONDS,
+    TRANSPORT_FAILURES_BEFORE_RESET,
     ProfileSupervisor,
 )
 
@@ -60,7 +61,13 @@ class FakeWorker:
         failure(error)
 
 
-def make_supervisor(*, attempt_pending=None, first_attempt=None, attempt_ready=None):
+def make_supervisor(
+    *,
+    attempt_pending=None,
+    first_attempt=None,
+    attempt_ready=None,
+    transport_failure=None,
+):
     sessions = FakeSessions()
     worker = FakeWorker()
     scheduled = []
@@ -76,6 +83,7 @@ def make_supervisor(*, attempt_pending=None, first_attempt=None, attempt_ready=N
         on_status=lambda: statuses.append(True),
         on_attempt_pending=attempt_pending,
         on_first_attempt_complete=first_attempt,
+        on_transport_failure=transport_failure,
         attempt_ready=attempt_ready,
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 99,
         cancel=lambda _source: True,
@@ -204,6 +212,97 @@ def test_map_connection_refusal_is_exposed_and_polls_quickly_until_ready() -> No
     scheduled[-1][1]()
     worker.fail(RuntimeError("still offline"))
     assert scheduled[-1][0] == INITIAL_MAP_CONNECT_POLL_SECONDS
+
+
+def test_repeated_transport_failures_request_one_targeted_recovery() -> None:
+    recoveries = []
+    supervisor, _sessions, worker, scheduled, _ready, _lost, _statuses = (
+        make_supervisor(
+            transport_failure=lambda: recoveries.append(True) or True,
+        )
+    )
+    supervisor.start()
+
+    for failure in range(TRANSPORT_FAILURES_BEFORE_RESET):
+        worker.fail(
+            SessionError(
+                "CreateSession(MAP) failed: "
+                "org.bluez.obex.Error.Failed: Transport got disconnected"
+            )
+        )
+        if failure < TRANSPORT_FAILURES_BEFORE_RESET - 1:
+            scheduled[-1][1]()
+
+    assert recoveries == [True]
+
+
+def test_profile_retry_waits_for_targeted_classic_recovery() -> None:
+    classic = {"ready": True}
+
+    def recover() -> bool:
+        classic["ready"] = False
+        return True
+
+    supervisor, _sessions, worker, scheduled, _ready, _lost, _statuses = (
+        make_supervisor(
+            attempt_ready=lambda: classic["ready"],
+            transport_failure=recover,
+        )
+    )
+    supervisor.start()
+    for failure in range(TRANSPORT_FAILURES_BEFORE_RESET):
+        worker.fail(SessionError("Timed out waiting for response"))
+        if failure < TRANSPORT_FAILURES_BEFORE_RESET - 1:
+            scheduled[-1][1]()
+
+    scheduled[-1][1]()
+    assert worker.jobs == []
+
+    classic["ready"] = True
+    scheduled[-1][1]()
+    assert len(worker.jobs) == 1
+
+
+def test_nontransport_profile_failures_break_the_recovery_streak() -> None:
+    recoveries = []
+    supervisor, _sessions, worker, scheduled, _ready, _lost, _statuses = (
+        make_supervisor(
+            transport_failure=lambda: recoveries.append(True) or True,
+        )
+    )
+    supervisor.start()
+
+    worker.fail(SessionError("Transport got disconnected"))
+    scheduled[-1][1]()
+    worker.fail(SessionError("Transport got disconnected"))
+    scheduled[-1][1]()
+    worker.fail(SessionError("org.bluez.obex.Error.Forbidden"))
+    for _failure in range(TRANSPORT_FAILURES_BEFORE_RESET - 1):
+        scheduled[-1][1]()
+        worker.fail(SessionError("Transport got disconnected"))
+
+    assert recoveries == []
+
+
+def test_map_refusal_never_cycles_the_classic_bearer() -> None:
+    recoveries = []
+    supervisor, _sessions, worker, scheduled, _ready, _lost, _statuses = (
+        make_supervisor(
+            transport_failure=lambda: recoveries.append(True) or True,
+        )
+    )
+    supervisor.start()
+    error = SessionError(
+        "CreateSession(MAP) failed: org.bluez.obex.Error.Failed: "
+        "Connection refused (111) after transport got disconnected"
+    )
+
+    for failure in range(TRANSPORT_FAILURES_BEFORE_RESET):
+        worker.fail(error)
+        if failure < TRANSPORT_FAILURES_BEFORE_RESET - 1:
+            scheduled[-1][1]()
+
+    assert recoveries == []
 
 
 def test_loss_discards_once_then_reconnects() -> None:

--- a/tests/test_session_reconnect.py
+++ b/tests/test_session_reconnect.py
@@ -45,36 +45,64 @@ def test_unknown_object_send_error_triggers_reconnect() -> None:
     assert reasons
 
 
-def test_failed_pbap_open_cleans_partial_map_before_retry(monkeypatch) -> None:
+def test_failed_pbap_open_keeps_map_and_retries_only_pbap(monkeypatch) -> None:
     manager = SessionManager()
-    removed = []
-    targets = iter([
-        ObexSession("MAP", "/session/map"),
-        sessions_mod.SessionError("PBAP refused"),
-    ])
+    attempts = []
+    pbap_attempts = 0
 
-    def create(_target):
-        result = next(targets)
-        if isinstance(result, Exception):
-            raise result
-        return result
-
-    class Client:
-        @staticmethod
-        def RemoveSession(path, **_kwargs):
-            removed.append(str(path))
+    def create(target):
+        nonlocal pbap_attempts
+        attempts.append(target)
+        if target == "MAP":
+            return ObexSession("MAP", "/session/map")
+        pbap_attempts += 1
+        if pbap_attempts == 1:
+            raise sessions_mod.SessionError("PBAP refused")
+        return ObexSession("PBAP", "/session/pbap")
 
     monkeypatch.setattr(manager, "start_monitoring", lambda: None)
-    monkeypatch.setattr(sessions_mod, "_client", lambda: Client())
     monkeypatch.setattr(sessions_mod, "_remove_stale_sessions", lambda _x: None)
     monkeypatch.setattr(sessions_mod, "_create_session", create)
 
     with pytest.raises(sessions_mod.SessionError, match="PBAP refused"):
         manager.open_all()
 
-    assert removed == ["/session/map"]
-    assert manager.map is None
+    assert manager.map == ObexSession("MAP", "/session/map")
     assert manager.pbap is None
+
+    manager.open_all()
+
+    assert attempts == ["MAP", "PBAP", "PBAP"]
+    assert manager.map == ObexSession("MAP", "/session/map")
+    assert manager.pbap == ObexSession("PBAP", "/session/pbap")
+
+
+def test_failed_map_open_still_opens_and_keeps_pbap(monkeypatch) -> None:
+    manager = SessionManager()
+    attempts = []
+
+    def create(target):
+        attempts.append(target)
+        if target == "MAP":
+            raise sessions_mod.SessionError("MAP transport disconnected")
+        return ObexSession("PBAP", "/session/pbap")
+
+    monkeypatch.setattr(manager, "start_monitoring", lambda: None)
+    monkeypatch.setattr(sessions_mod, "_remove_stale_sessions", lambda _x: None)
+    monkeypatch.setattr(sessions_mod, "_create_session", create)
+
+    with pytest.raises(sessions_mod.SessionError, match="MAP transport"):
+        manager.open_all()
+
+    pbap = manager.pbap
+    assert manager.map is None
+    assert pbap == ObexSession("PBAP", "/session/pbap")
+
+    with pytest.raises(sessions_mod.SessionError, match="MAP transport"):
+        manager.open_all()
+
+    assert attempts == ["MAP", "PBAP", "MAP"]
+    assert manager.pbap is pbap
 
 
 def test_close_clears_state_even_when_obexd_is_unreachable(monkeypatch) -> None:

--- a/tests/test_solicitation_supervisor.py
+++ b/tests/test_solicitation_supervisor.py
@@ -1,0 +1,116 @@
+"""ANCS solicitation supervision without Bluetooth or D-Bus access."""
+
+from blueferry import solicitation_supervisor
+from blueferry.solicitation_supervisor import SolicitationSupervisor
+
+
+def _supervisor(
+    calls,
+    state,
+    scheduled,
+    *,
+    needed=True,
+    minimum_on_seconds=0,
+    clock=lambda: 0.0,
+):
+    return SolicitationSupervisor(
+        "hci7",
+        needed=needed,
+        register=lambda adapter: (
+            calls.append(("register", adapter)),
+            state.__setitem__("registered", True),
+            True,
+        )[-1],
+        unregister=lambda adapter: (
+            calls.append(("unregister", adapter)),
+            state.__setitem__("registered", False),
+        ),
+        is_registered=lambda: state["registered"],
+        forget_registration=lambda: (
+            calls.append("forget"),
+            state.__setitem__("registered", False),
+        ),
+        minimum_on_seconds=minimum_on_seconds,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        cancel=lambda timer_id: calls.append(("cancel", timer_id)),
+        clock=clock,
+    )
+
+
+def test_solicitation_stays_on_until_ancs_is_healthy() -> None:
+    calls = []
+    state = {"registered": False}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+
+    supervisor.start()
+    assert calls == [("register", "hci7")]
+    assert supervisor.active() is True
+    assert scheduled[0][0] == solicitation_supervisor.RECONCILE_SECONDS
+
+    supervisor.set_needed(False)
+    assert calls[-1] == ("unregister", "hci7")
+
+    supervisor.set_needed(True)
+    assert calls[-1] == ("register", "hci7")
+
+
+def test_periodic_reconciliation_repairs_a_bluez_release() -> None:
+    calls = []
+    state = {"registered": True}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+    supervisor.start()
+    assert calls == []
+
+    state["registered"] = False
+    assert scheduled[0][1]() is True
+    assert calls == [("register", "hci7")]
+
+
+def test_healthy_ancs_keeps_post_pair_solicitation_for_permission_window() -> None:
+    calls = []
+    state = {"registered": False}
+    scheduled = []
+    now = 0.0
+    supervisor = _supervisor(
+        calls,
+        state,
+        scheduled,
+        minimum_on_seconds=180,
+        clock=lambda: now,
+    )
+    supervisor.start()
+
+    supervisor.set_needed(False)
+    assert state["registered"] is True
+
+    now = 180.0
+    scheduled[0][1]()
+    assert calls[-1] == ("unregister", "hci7")
+
+
+def test_bluez_restart_forgets_registration_and_primes_inbound_le() -> None:
+    calls = []
+    state = {"registered": False}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled, needed=False)
+    supervisor.start()
+
+    supervisor.reset_after_bluez_restart()
+
+    assert supervisor.needed is True
+    assert calls == ["forget", ("register", "hci7")]
+
+
+def test_stop_cancels_reconciliation_and_removes_advertisement() -> None:
+    calls = []
+    state = {"registered": True}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+    supervisor.start()
+
+    supervisor.stop()
+
+    assert calls == [("cancel", 7), ("unregister", "hci7")]
+    assert scheduled[0][1]() is False


### PR DESCRIPTION
## Summary

- restore MAP/PBAP-first ordering after daemon, BlueZ, and physical-device reconnects while keeping MAP and PBAP independently available when iOS accepts only one
- supervise the ANCS solicitation advertisement across unhealthy protocol state and BlueZ owner changes, rebuild stale GATT subscriptions, and grant one fresh outbound LE bootstrap on genuine bearer lifecycle evidence
- repair volatile adapter Class-of-Device drift through the existing fixed, capability-bounded systemd helper
- retain exponential backoff and the one-shot LE policy so an absent phone is not hammered with repeated `Connect` calls

## Why

Live testing showed that the recovery boundaries are independent:

- restarting bluetoothd can rebuild local ANCS state but does not deterministically clear an iOS MAP refusal
- toggling Bluetooth on the phone resets the iOS MAP/PBAP servers, but can leave LE/ANCS disconnected
- cycling only the Linux BR/EDR bearer and restarting obexd did not clear the iOS-side MAP condition

The final implementation therefore preserves every healthy profile, retries only missing work, and drives LE recovery from observed disconnect/return events rather than process restarts.

The branch retains an intermediate targeted-BR/EDR experiment in its commit history; the final commit removes that mechanism after the hardware tests showed it was ineffective.

## Validation

- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q` — 754 passed, 3 skipped
- real iPhone Bluetooth off for more than one poll interval, then on:
  - observed the LE disconnect and logged `re-arming outbound iPhone LE bootstrap`
  - restored MAP and PBAP first
  - issued exactly one outbound LE connection
  - rebuilt ANCS subscriptions and completed authorization
  - all three profiles remained healthy without restarting bluetoothd or BlueFerry
