### PR TITLE
Retry libnotify when the notification server starts late

### DIFF
--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -572,6 +572,7 @@ class Daemon:
         if self.ancs is not None:
             self.ancs.stop()
         self.solicitation.stop()
+        self.events.stop()
         if self._sleep_match is not None:
             try:
                 self._sleep_match.remove()

--- a/src/blueferry/event_dispatcher.py
+++ b/src/blueferry/event_dispatcher.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import json
 import logging
 from collections import OrderedDict
+from collections.abc import Callable
 from hashlib import blake2b
 
+from gi.repository import GLib
+
 from blueferry.ancs.constants import MESSAGES_APP_ID
+from blueferry.bus import get_session_bus
 from blueferry.events import sms_group_sent_event, sms_sent_event
 from blueferry.limits import MAX_ANCS_FINGERPRINTS
 from blueferry.sinks import Sink
@@ -15,6 +19,11 @@ from blueferry.sinks.libnotify import LibnotifySink
 from blueferry.sinks.sqlite import SqliteSink
 
 log = logging.getLogger(__name__)
+
+_NOTIFICATION_BUS_NAME = "org.freedesktop.Notifications"
+_DBUS_BUS_NAME = "org.freedesktop.DBus"
+_DBUS_INTERFACE = "org.freedesktop.DBus"
+_LIBNOTIFY_RETRY_SECONDS = 5
 
 _ANCS_FINGERPRINT_FIELDS = (
     "notification_id",
@@ -46,6 +55,10 @@ class EventDispatcher:
         notification_policy=None,
         storage=None,
         on_incoming_message=None,
+        notification_sink_factory: Callable[..., Sink] = LibnotifySink,
+        session_bus=None,
+        schedule: Callable[[int, Callable[[], bool]], int] = GLib.timeout_add_seconds,
+        cancel: Callable[[int], object] = GLib.source_remove,
     ) -> None:
         self.contacts = contacts
         self.submit_obex = submit_obex
@@ -54,6 +67,14 @@ class EventDispatcher:
         self.notification_policy = notification_policy
         self.storage = storage
         self.on_incoming_message = on_incoming_message
+        self._notification_sink_factory = notification_sink_factory
+        self._session_bus = session_bus
+        self._schedule = schedule
+        self._cancel = cancel
+        self._notification_owner_match = None
+        self._notification_retry_id: int | None = None
+        self._setup_complete = False
+        self._setup_logged = False
         self._seen_ancs: OrderedDict[bytes, None] = OrderedDict()
         self.seed_historical_ancs(historical_ancs)
 
@@ -66,20 +87,124 @@ class EventDispatcher:
             self._seen_ancs.popitem(last=False)
 
     def setup(self) -> None:
-        if self.sinks:
+        if self._setup_complete:
             return
         self.sinks.append(SqliteSink(storage=self.storage))
+        self._setup_complete = True
+        self._watch_notification_owner()
+        self._ensure_libnotify_sink()
+        log.info("sinks ready: %s", self.names)
+        self._setup_logged = True
+
+    def stop(self) -> None:
+        """Release notification-service watches and transient sink state."""
+        self._setup_complete = False
+        self._cancel_notification_retry()
+        if self._notification_owner_match is not None:
+            try:
+                self._notification_owner_match.remove()
+            except Exception:
+                log.debug("could not remove notification owner watch", exc_info=True)
+            self._notification_owner_match = None
+        self._remove_libnotify_sink(log_change=False)
+
+    def _watch_notification_owner(self) -> None:
+        if self._notification_owner_match is not None:
+            return
         try:
-            self.sinks.append(
-                LibnotifySink(
-                    submit_obex=self.submit_obex,
-                    notification_policy=self.notification_policy,
-                    on_open_message=self._open_message,
-                )
+            bus = self._session_bus or get_session_bus()
+            self._session_bus = bus
+            self._notification_owner_match = bus.add_signal_receiver(
+                self._on_notification_owner_changed,
+                dbus_interface=_DBUS_INTERFACE,
+                signal_name="NameOwnerChanged",
+                bus_name=_DBUS_BUS_NAME,
+                arg0=_NOTIFICATION_BUS_NAME,
+            )
+        except Exception:
+            log.exception(
+                "could not watch the desktop notification service; "
+                "late libnotify activation is unavailable"
+            )
+
+    def _on_notification_owner_changed(self, _name, old_owner, new_owner) -> None:
+        if not self._setup_complete:
+            return
+        if old_owner:
+            self._cancel_notification_retry()
+            self._remove_libnotify_sink(log_change=True)
+        if new_owner:
+            self._ensure_libnotify_sink()
+
+    def _ensure_libnotify_sink(self) -> bool:
+        if not self._setup_complete:
+            return False
+        if any(sink.name == "libnotify" for sink in self.sinks):
+            return True
+        try:
+            sink = self._notification_sink_factory(
+                submit_obex=self.submit_obex,
+                notification_policy=self.notification_policy,
+                on_open_message=self._open_message,
             )
         except Exception:
             log.exception("libnotify sink failed to init — continuing")
-        log.info("sinks ready: %s", self.names)
+            if self._notification_server_owned():
+                self._schedule_notification_retry()
+            return False
+        self.sinks.append(sink)
+        self._cancel_notification_retry()
+        if self._setup_logged:
+            log.info("desktop notification service available; sinks ready: %s", self.names)
+        return True
+
+    def _remove_libnotify_sink(self, *, log_change: bool) -> None:
+        removed = [sink for sink in self.sinks if sink.name == "libnotify"]
+        if not removed:
+            return
+        self.sinks = [sink for sink in self.sinks if sink.name != "libnotify"]
+        for sink in removed:
+            close = getattr(sink, "close", None)
+            if close is None:
+                continue
+            try:
+                close()
+            except Exception:
+                log.debug("could not close libnotify sink", exc_info=True)
+        if log_change:
+            log.info("desktop notification service unavailable; sinks ready: %s", self.names)
+
+    def _notification_server_owned(self) -> bool:
+        try:
+            bus = self._session_bus or get_session_bus()
+            self._session_bus = bus
+            return bool(bus.name_has_owner(_NOTIFICATION_BUS_NAME))
+        except Exception:
+            log.debug("could not query desktop notification owner", exc_info=True)
+            return False
+
+    def _schedule_notification_retry(self) -> None:
+        if not self._setup_complete or self._notification_retry_id is not None:
+            return
+        self._notification_retry_id = self._schedule(
+            _LIBNOTIFY_RETRY_SECONDS,
+            self._retry_libnotify_sink,
+        )
+
+    def _retry_libnotify_sink(self) -> bool:
+        self._notification_retry_id = None
+        if self._setup_complete and self._notification_server_owned():
+            self._ensure_libnotify_sink()
+        return False
+
+    def _cancel_notification_retry(self) -> None:
+        if self._notification_retry_id is None:
+            return
+        try:
+            self._cancel(self._notification_retry_id)
+        except Exception:
+            log.debug("could not remove libnotify retry timer", exc_info=True)
+        self._notification_retry_id = None
 
     @property
     def names(self) -> list[str]:

--- a/src/blueferry/sinks/libnotify.py
+++ b/src/blueferry/sinks/libnotify.py
@@ -109,6 +109,25 @@ class LibnotifySink:
         )
         log.info("libnotify sink ready (expiring + bidirectional read-sync)")
 
+    def close(self) -> None:
+        """Release signal watches before a notification-daemon replacement."""
+        for attribute in ("_match", "_action_match"):
+            match = getattr(self, attribute, None)
+            if match is not None:
+                try:
+                    match.remove()
+                except Exception:
+                    log.debug("could not remove libnotify signal watch", exc_info=True)
+                setattr(self, attribute, None)
+        for subscription in self._msg_subs.values():
+            try:
+                subscription.remove()
+            except Exception:
+                log.debug("could not remove message read-state watch", exc_info=True)
+        self._msg_subs.clear()
+        self._pending.clear()
+        self._open_messages.clear()
+
     def _policy(self) -> str:
         provider = getattr(self, "_notification_policy", None)
         return (

--- a/tests/test_event_dispatcher.py
+++ b/tests/test_event_dispatcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+from blueferry import event_dispatcher
 from blueferry.event_dispatcher import EventDispatcher
 from blueferry.events import sms_sent_event
 
@@ -27,6 +28,63 @@ class _Service:
 
     def emit_open_message(self, handle: str) -> None:
         self.events.append(("open", handle))
+
+
+class _Match:
+    def __init__(self) -> None:
+        self.removed = False
+
+    def remove(self) -> None:
+        self.removed = True
+
+
+class _Bus:
+    def __init__(self, *, owner: bool = False) -> None:
+        self.owner = owner
+        self.callback = None
+        self.match = _Match()
+
+    def add_signal_receiver(self, callback, **kwargs):
+        assert kwargs == {
+            "dbus_interface": "org.freedesktop.DBus",
+            "signal_name": "NameOwnerChanged",
+            "bus_name": "org.freedesktop.DBus",
+            "arg0": "org.freedesktop.Notifications",
+        }
+        self.callback = callback
+        return self.match
+
+    def name_has_owner(self, name: str) -> bool:
+        assert name == "org.freedesktop.Notifications"
+        return self.owner
+
+    def change_owner(self, old_owner: str, new_owner: str) -> None:
+        self.owner = bool(new_owner)
+        assert self.callback is not None
+        self.callback("org.freedesktop.Notifications", old_owner, new_owner)
+
+
+class _SqliteSink:
+    name = "sqlite"
+
+    def __init__(self, *, storage=None) -> None:
+        self.storage = storage
+
+    def handle(self, _event) -> None:
+        pass
+
+
+class _NotificationSink:
+    name = "libnotify"
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def handle(self, _event) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def _event(body: str = "hello"):
@@ -154,3 +212,115 @@ def test_notification_action_is_broadcast_through_current_dbus_service():
     dispatcher._open_message("message-opaque-42")
 
     assert service.events == [("open", "message-opaque-42")]
+
+
+def test_libnotify_is_added_when_notification_server_appears(monkeypatch):
+    monkeypatch.setattr(event_dispatcher, "SqliteSink", _SqliteSink)
+    bus = _Bus()
+    attempts = []
+
+    def create_sink(**_kwargs):
+        # Install the owner watch before the fallible construction so the
+        # server cannot appear in an unobserved gap.
+        assert bus.callback is not None
+        attempts.append(bus.owner)
+        if not bus.owner:
+            raise RuntimeError("notification server is not ready")
+        return _NotificationSink()
+
+    dispatcher = EventDispatcher(
+        object(),
+        submit_obex=lambda *_args, **_kwargs: None,
+        notification_sink_factory=create_sink,
+        session_bus=bus,
+    )
+
+    dispatcher.setup()
+    assert dispatcher.names == ["sqlite"]
+
+    bus.change_owner("", ":1.42")
+
+    assert attempts == [False, True]
+    assert dispatcher.names == ["sqlite", "libnotify"]
+
+
+def test_owned_but_not_ready_notification_server_is_retried(monkeypatch):
+    monkeypatch.setattr(event_dispatcher, "SqliteSink", _SqliteSink)
+    bus = _Bus(owner=True)
+    scheduled = []
+    attempts = []
+
+    def create_sink(**_kwargs):
+        attempts.append(True)
+        if len(attempts) < 3:
+            raise RuntimeError("object has not been exported yet")
+        return _NotificationSink()
+
+    dispatcher = EventDispatcher(
+        object(),
+        submit_obex=lambda *_args, **_kwargs: None,
+        notification_sink_factory=create_sink,
+        session_bus=bus,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or len(scheduled),
+    )
+
+    dispatcher.setup()
+    assert dispatcher.names == ["sqlite"]
+    assert scheduled[-1][0] == event_dispatcher._LIBNOTIFY_RETRY_SECONDS
+
+    scheduled[-1][1]()
+    assert dispatcher.names == ["sqlite"]
+    scheduled[-1][1]()
+
+    assert len(attempts) == 3
+    assert dispatcher.names == ["sqlite", "libnotify"]
+
+
+def test_notification_owner_replacement_rebuilds_sink(monkeypatch):
+    monkeypatch.setattr(event_dispatcher, "SqliteSink", _SqliteSink)
+    bus = _Bus(owner=True)
+    sinks = []
+
+    def create_sink(**_kwargs):
+        sink = _NotificationSink()
+        sinks.append(sink)
+        return sink
+
+    dispatcher = EventDispatcher(
+        object(),
+        submit_obex=lambda *_args, **_kwargs: None,
+        notification_sink_factory=create_sink,
+        session_bus=bus,
+    )
+    dispatcher.setup()
+
+    bus.change_owner(":1.42", ":1.84")
+
+    assert len(sinks) == 2
+    assert sinks[0].closed is True
+    assert sinks[1].closed is False
+    assert dispatcher.names == ["sqlite", "libnotify"]
+
+
+def test_dispatcher_stop_removes_owner_watch_and_retry(monkeypatch):
+    monkeypatch.setattr(event_dispatcher, "SqliteSink", _SqliteSink)
+    bus = _Bus(owner=True)
+    cancelled = []
+
+    def unavailable_sink(**_kwargs):
+        raise RuntimeError("not ready")
+
+    dispatcher = EventDispatcher(
+        object(),
+        submit_obex=lambda *_args, **_kwargs: None,
+        notification_sink_factory=unavailable_sink,
+        session_bus=bus,
+        schedule=lambda _delay, _callback: 9,
+        cancel=cancelled.append,
+    )
+    dispatcher.setup()
+
+    dispatcher.stop()
+
+    assert bus.match.removed is True
+    assert cancelled == [9]

--- a/tests/test_libnotify.py
+++ b/tests/test_libnotify.py
@@ -25,6 +25,14 @@ class _FakeNotifications:
         self.calls.append(("close", int(notification_id)))
 
 
+class _Match:
+    def __init__(self) -> None:
+        self.removed = False
+
+    def remove(self) -> None:
+        self.removed = True
+
+
 def test_ancs_popup_is_transient_and_expires(
     monkeypatch,
 ) -> None:
@@ -243,3 +251,26 @@ def test_expiry_and_phone_read_do_not_write_read_state(reason) -> None:
     sink._on_closed(7, reason)
 
     assert queued == []
+
+
+def test_close_releases_all_signal_watches_and_trackers() -> None:
+    sink = LibnotifySink.__new__(LibnotifySink)
+    sink._match = _Match()
+    sink._action_match = _Match()
+    message_match = _Match()
+    sink._msg_subs = {7: message_match}
+    sink._pending = {7: "/session/message1"}
+    sink._open_messages = {7: "opaque-handle"}
+
+    owner_match = sink._match
+    action_match = sink._action_match
+    sink.close()
+
+    assert owner_match.removed is True
+    assert action_match.removed is True
+    assert message_match.removed is True
+    assert sink._match is None
+    assert sink._action_match is None
+    assert sink._msg_subs == {}
+    assert sink._pending == {}
+    assert sink._open_messages == {}


### PR DESCRIPTION
## Summary

- watch `org.freedesktop.Notifications` ownership before the first libnotify sink initialization attempt
- add the sink when a late notification server appears instead of leaving desktop notifications disabled for the daemon lifetime
- retry every five seconds while the bus name is owned but its notification object is not exported yet
- remove and rebuild the sink across notification-daemon owner replacement, cleaning up signal and per-message read-state watches
- release the owner watch and retry timer during BlueFerry shutdown

## Why

Desktop clients can D-Bus-activate BlueFerry before a Quickshell, Hyprland, or Sway notification server has acquired and fully exported `org.freedesktop.Notifications`. The previous one-shot constructor failure permanently left only the SQLite sink active.

Registering the owner watch first closes the missing-owner race. The bounded retry closes the second race between acquiring the bus name and exporting the notification object. Future events start reaching libnotify as soon as the server is usable; persistence remains active throughout.

## Validation

- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q` — 759 passed, 3 skipped
- regression coverage for late owner appearance, delayed object export, owner replacement, retry teardown, and libnotify signal cleanup

Closes #88
