### PR TITLE
Add contacts-only message notifications

### DIFF
--- a/data/io.weirdware.BlueFerry.xml
+++ b/data/io.weirdware.BlueFerry.xml
@@ -77,6 +77,15 @@
       <annotation name="io.weirdware.BlueFerry.Errors"
                   value="InvalidArgs,NotReady"/>
     </method>
+    <method name="GetContactsOnlyNotifications">
+      <arg name="enabled" type="b" direction="out"/>
+    </method>
+    <method name="SetContactsOnlyNotifications">
+      <arg name="enabled" type="b" direction="in"/>
+      <arg name="selected" type="b" direction="out"/>
+      <annotation name="io.weirdware.BlueFerry.Errors"
+                  value="InvalidArgs,NotReady"/>
+    </method>
     <method name="GetStoragePolicy">
       <arg name="policy" type="s" direction="out"/>
     </method>

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -48,6 +48,7 @@ ShellRoot {
   property string onboardingStage: onboarding.stage
   property var backendStatus: ({})
   property string notificationPolicy: "messages"
+  property bool contactsOnlyNotifications: false
   property string storagePolicy: "encrypted"
   property string storageState: "locked"
   property string storageDetail: ""
@@ -61,6 +62,7 @@ ShellRoot {
   property bool groupParticipantsBusy: false
   property bool deleteThreadsBusy: false
   property bool notificationPolicyBusy: false
+  property bool contactsOnlyNotificationsBusy: false
   property bool storagePolicyBusy: false
   property bool storageUnlockBusy: false
 
@@ -334,6 +336,8 @@ ShellRoot {
         var policy = result.notification_policy || "messages"
         root.notificationPolicy = ["all", "messages", "none"].indexOf(policy) >= 0
           ? policy : "messages"
+        root.contactsOnlyNotifications =
+          result.contacts_only_notifications === true
         var storagePolicy = result.storage_policy || "encrypted"
         root.storagePolicy = ["encrypted", "plaintext", "none"].indexOf(storagePolicy) >= 0
           ? storagePolicy : "encrypted"
@@ -378,6 +382,10 @@ ShellRoot {
       } else if (method === "set_notification_policy") {
         root.notificationPolicyBusy = false
         root.notificationPolicy = String(result)
+        root.reload()
+      } else if (method === "set_contacts_only_notifications") {
+        root.contactsOnlyNotificationsBusy = false
+        root.contactsOnlyNotifications = result === true
         root.reload()
       } else if (method === "set_storage_policy") {
         root.storagePolicyBusy = false
@@ -424,6 +432,10 @@ ShellRoot {
       } else if (method === "set_notification_policy") {
         root.notificationPolicyBusy = false
         root.errorText = message || "Could not save notification preference"
+      } else if (method === "set_contacts_only_notifications") {
+        root.contactsOnlyNotificationsBusy = false
+        root.errorText = message || "Could not save notification preference"
+        root.reload()
       } else if (method === "set_storage_policy") {
         root.storagePolicyBusy = false
         root.errorText = message
@@ -439,6 +451,7 @@ ShellRoot {
         root.groupParticipantsBusy = false
         root.deleteThreadsBusy = false
         root.notificationPolicyBusy = false
+        root.contactsOnlyNotificationsBusy = false
         root.storagePolicyBusy = false
         root.storageUnlockBusy = false
         root.errorText = message
@@ -1431,6 +1444,20 @@ ShellRoot {
               root.notificationPolicyBusy = true
               backendBridge.request("set_notification_policy", {
                 policy: values[currentIndex]
+              })
+            }
+          }
+          FerryCheckBox {
+            text: "Only notify for contacts"
+            checked: root.contactsOnlyNotifications
+            enabled: root.configured && root.notificationPolicy !== "none"
+              && !root.contactsOnlyNotificationsBusy
+            Accessible.description: "Unknown senders remain available in message history"
+            onClicked: {
+              root.contactsOnlyNotifications = checked
+              root.contactsOnlyNotificationsBusy = true
+              backendBridge.request("set_contacts_only_notifications", {
+                enabled: checked
               })
             }
           }

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -101,7 +101,12 @@ class NotificationPolicy(Protocol):
     @property
     def value(self) -> str: ...
 
+    @property
+    def contacts_only(self) -> bool: ...
+
     def set(self, value: str) -> str: ...
+
+    def set_contacts_only(self, enabled: bool) -> bool: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -413,6 +418,9 @@ class BackendOperations:
             "map": self.sessions.map is not None,
             "pbap": self.sessions.pbap is not None,
             "notification_policy": self.get_notification_policy(),
+            "contacts_only_notifications": (
+                self.get_contacts_only_notifications()
+            ),
         }
         if self.dependencies.status_provider is not None:
             status.update(self.dependencies.status_provider())
@@ -640,6 +648,24 @@ class BackendOperations:
             raise NotReadyError("notification policy storage is unavailable")
         try:
             selected = self.dependencies.notification_policy.set(value)
+        except ValueError as error:
+            raise InvalidArgumentsError(str(error)) from error
+        if self.dependencies.on_notification_policy_changed is not None:
+            self.dependencies.on_notification_policy_changed()
+        return selected
+
+    def get_contacts_only_notifications(self) -> bool:
+        if self.dependencies.notification_policy is None:
+            return False
+        return bool(self.dependencies.notification_policy.contacts_only)
+
+    def set_contacts_only_notifications(self, enabled: bool) -> bool:
+        if self.dependencies.notification_policy is None:
+            raise NotReadyError("notification policy storage is unavailable")
+        try:
+            selected = self.dependencies.notification_policy.set_contacts_only(
+                enabled
+            )
         except ValueError as error:
             raise InvalidArgumentsError(str(error)) from error
         if self.dependencies.on_notification_policy_changed is not None:

--- a/src/blueferry/client.py
+++ b/src/blueferry/client.py
@@ -190,6 +190,26 @@ class BackendClient:
         except dbus.exceptions.DBusException as error:
             raise BackendError(error.get_dbus_message() or str(error)) from error
 
+    def contacts_only_notifications(self) -> bool:
+        try:
+            return bool(
+                self._iface(MESSAGES_IFACE).GetContactsOnlyNotifications(
+                    timeout=POLICY_CALL_TIMEOUT_SEC
+                )
+            )
+        except dbus.exceptions.DBusException as error:
+            raise BackendError(error.get_dbus_message() or str(error)) from error
+
+    def set_contacts_only_notifications(self, enabled: bool) -> bool:
+        try:
+            return bool(
+                self._iface(MESSAGES_IFACE).SetContactsOnlyNotifications(
+                    dbus.Boolean(enabled), timeout=POLICY_CALL_TIMEOUT_SEC
+                )
+            )
+        except dbus.exceptions.DBusException as error:
+            raise BackendError(error.get_dbus_message() or str(error)) from error
+
     def storage_policy(self) -> str:
         try:
             return str(self._iface(MESSAGES_IFACE).GetStoragePolicy(

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -83,6 +83,9 @@ class Daemon:
             self.contacts,
             submit_obex=self.obex_worker.submit,
             notification_policy=lambda: self.notification_policy.value,
+            contacts_only_notifications=(
+                lambda: self.notification_policy.contacts_only
+            ),
             storage=self.storage,
             on_incoming_message=lambda: self._verify_setup_task(MESSAGE_NOTIFICATIONS),
         )
@@ -464,6 +467,9 @@ class Daemon:
             "history_retention_days": config.HISTORY_RETENTION_DAYS,
             "notification_timeout_ms": config.NOTIFICATION_TIMEOUT_MS,
             "notification_policy": self.notification_policy.value,
+            "contacts_only_notifications": (
+                self.notification_policy.contacts_only
+            ),
             "storage_policy": self.storage.status.policy,
             "storage_state": self.storage.status.state,
             "storage_detail": self.storage.status.detail,

--- a/src/blueferry/dbus_service.py
+++ b/src/blueferry/dbus_service.py
@@ -231,6 +231,28 @@ class MessagesService(dbus.service.Object):
         ))
 
     @dbus.service.method(
+        IFACE, in_signature="", out_signature="b", sender_keyword="sender"
+    )
+    def GetContactsOnlyNotifications(self, sender=None) -> bool:
+        return self._sync(lambda: self._authorized(
+            sender, "status",
+            self.operations.get_contacts_only_notifications,
+        ))
+
+    @dbus.service.method(
+        IFACE, in_signature="b", out_signature="b", sender_keyword="sender"
+    )
+    def SetContactsOnlyNotifications(
+        self, enabled: bool, sender=None,
+    ) -> bool:
+        return self._sync(lambda: self._authorized(
+            sender, "settings",
+            lambda: self.operations.set_contacts_only_notifications(
+                bool(enabled)
+            ),
+        ))
+
+    @dbus.service.method(
         IFACE, in_signature="", out_signature="s", sender_keyword="sender"
     )
     def GetStoragePolicy(self, sender=None) -> str:

--- a/src/blueferry/event_dispatcher.py
+++ b/src/blueferry/event_dispatcher.py
@@ -53,6 +53,7 @@ class EventDispatcher:
         submit_obex,
         historical_ancs=(),
         notification_policy=None,
+        contacts_only_notifications=None,
         storage=None,
         on_incoming_message=None,
         notification_sink_factory: Callable[..., Sink] = LibnotifySink,
@@ -65,6 +66,7 @@ class EventDispatcher:
         self.sinks: list[Sink] = []
         self.dbus_service = None
         self.notification_policy = notification_policy
+        self.contacts_only_notifications = contacts_only_notifications
         self.storage = storage
         self.on_incoming_message = on_incoming_message
         self._notification_sink_factory = notification_sink_factory
@@ -145,6 +147,7 @@ class EventDispatcher:
             sink = self._notification_sink_factory(
                 submit_obex=self.submit_obex,
                 notification_policy=self.notification_policy,
+                contacts_only_notifications=self.contacts_only_notifications,
                 on_open_message=self._open_message,
             )
         except Exception:

--- a/src/blueferry/models.py
+++ b/src/blueferry/models.py
@@ -45,6 +45,7 @@ class BackendStatus:
     history_retention_days: int = 0
     notification_timeout_ms: int = 0
     notification_policy: str = "messages"
+    contacts_only_notifications: bool = False
     storage_policy: str = "encrypted"
     storage_state: str = "locked"
     storage_detail: str = ""
@@ -77,6 +78,7 @@ class BackendStatus:
             "history_retention_days",
             "notification_timeout_ms",
             "notification_policy",
+            "contacts_only_notifications",
             "storage_policy",
             "storage_state",
             "storage_detail",
@@ -103,6 +105,9 @@ class BackendStatus:
             history_retention_days=_int(value.get("history_retention_days")),
             notification_timeout_ms=_int(value.get("notification_timeout_ms")),
             notification_policy=_str(value.get("notification_policy"), "messages"),
+            contacts_only_notifications=_bool(
+                value.get("contacts_only_notifications")
+            ),
             storage_policy=_str(value.get("storage_policy"), "encrypted"),
             storage_state=_str(value.get("storage_state"), "locked"),
             storage_detail=_str(value.get("storage_detail")),
@@ -128,6 +133,7 @@ class BackendStatus:
             "history_retention_days": self.history_retention_days,
             "notification_timeout_ms": self.notification_timeout_ms,
             "notification_policy": self.notification_policy,
+            "contacts_only_notifications": self.contacts_only_notifications,
             "storage_policy": self.storage_policy,
             "storage_state": self.storage_state,
             "storage_detail": self.storage_detail,

--- a/src/blueferry/notification_policy.py
+++ b/src/blueferry/notification_policy.py
@@ -1,4 +1,4 @@
-"""Persistent daemon-owned desktop notification policy."""
+"""Persistent daemon-owned desktop notification preferences."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -18,22 +18,31 @@ NOTIFICATION_POLICIES = frozenset({
 
 
 class NotificationPolicyStore:
-    """Keep one validated policy in an owner-only XDG configuration file."""
+    """Keep validated popup preferences in an owner-only config file."""
 
     def __init__(self, path: Path | None = None) -> None:
         self.path = path or config.SETTINGS_JSON
         self._settings = SettingsStore(self.path)
-        self._value = self._load()
+        payload = self._load()
+        self._value = self._load_policy(payload)
+        self._contacts_only = payload.get("contacts_only_notifications") is True
 
     @property
     def value(self) -> str:
         return self._value
 
-    def _load(self) -> str:
+    @property
+    def contacts_only(self) -> bool:
+        return self._contacts_only
+
+    def _load(self) -> dict:
         try:
-            payload = self._settings.read()
+            return self._settings.read()
         except OSError:
-            payload = {}
+            return {}
+
+    @staticmethod
+    def _load_policy(payload: dict) -> str:
         value = str(payload.get("desktop_notifications", ""))
         return (
             value
@@ -51,3 +60,11 @@ class NotificationPolicyStore:
 
         self._value = selected
         return selected
+
+    def set_contacts_only(self, enabled: bool) -> bool:
+        if not isinstance(enabled, bool):
+            raise ValueError("contacts-only notifications must be a boolean")
+
+        self._settings.update(contacts_only_notifications=enabled)
+        self._contacts_only = enabled
+        return enabled

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -561,6 +561,17 @@ class BridgeController(QObject):
 
         self._run(lambda: self._backend.set_notification_policy(policy), completed)
 
+    @Slot(bool)
+    def setContactsOnlyNotifications(self, enabled: bool) -> None:
+        def completed(value: object) -> None:
+            self._status["contacts_only_notifications"] = bool(value)
+            self.statusChanged.emit()
+
+        self._run(
+            lambda: self._backend.set_contacts_only_notifications(enabled),
+            completed,
+        )
+
     @Slot(str)
     def setStoragePolicy(self, policy: str) -> None:
         if policy == "encrypted":

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -1382,6 +1382,16 @@ Kirigami.ApplicationWindow {
                         enabled: root.bridge.status.daemon === true && !root.bridge.busy
                         onActivated: root.bridge.setNotificationPolicy(currentValue)
                     }
+                    Controls.CheckBox {
+                        Layout.fillWidth: true
+                        text: qsTr("Only notify for contacts")
+                        checked: root.bridge.status.contacts_only_notifications === true
+                        enabled: root.bridge.status.daemon === true
+                            && root.bridge.status.notification_policy !== "none"
+                            && !root.bridge.busy
+                        onClicked: root.bridge.setContactsOnlyNotifications(checked)
+                        Accessible.description: qsTr("Unknown senders remain available in message history.")
+                    }
                 }
 
                 Kirigami.Heading { text: qsTr("Local Data"); level: 2 }

--- a/src/blueferry/quickshell_bridge.py
+++ b/src/blueferry/quickshell_bridge.py
@@ -46,6 +46,13 @@ def _texts(args: Mapping[str, Any], name: str) -> list[str]:
     return value
 
 
+def _boolean(args: Mapping[str, Any], name: str) -> bool:
+    value = args.get(name)
+    if not isinstance(value, bool):
+        raise RequestError(f"{name} must be a boolean")
+    return value
+
+
 class QuickshellBridge:
     """Decode local requests and dispatch them through ``BackendClient``."""
 
@@ -100,6 +107,10 @@ class QuickshellBridge:
             return self.client.delete_threads(_texts(args, "thread_keys"))
         if method == "set_notification_policy":
             return self.client.set_notification_policy(_text(args, "policy"))
+        if method == "set_contacts_only_notifications":
+            return self.client.set_contacts_only_notifications(
+                _boolean(args, "enabled")
+            )
         if method == "set_storage_policy":
             return self.client.set_storage_policy(_text(args, "policy"))
         if method == "unlock_storage":

--- a/src/blueferry/sinks/libnotify.py
+++ b/src/blueferry/sinks/libnotify.py
@@ -78,10 +78,12 @@ class LibnotifySink:
         *,
         submit_obex,
         notification_policy=None,
+        contacts_only_notifications=None,
         on_open_message=None,
     ) -> None:
         self._submit_obex = submit_obex
         self._notification_policy = notification_policy
+        self._contacts_only_notifications = contacts_only_notifications
         self._on_open_message = on_open_message
         self._notif = dbus.Interface(
             get_session_bus().get_object(
@@ -136,11 +138,17 @@ class LibnotifySink:
             else DEFAULT_NOTIFICATION_POLICY
         )
 
+    def _contacts_only(self) -> bool:
+        provider = getattr(self, "_contacts_only_notifications", None)
+        return bool(provider()) if provider is not None else False
+
     def handle(self, event: SmsEvent) -> None:
         # Don't pop a desktop notification for a message we ourselves sent.
         if event.kind == "sms_sent":
             return
         if self._policy() == NO_NOTIFICATIONS:
+            return
+        if self._contacts_only() and not getattr(event, "contact_name", None):
             return
         title = f"\U0001f4ac {event.display_sender}"
         body = (event.body or "").strip()

--- a/src/blueferry/ui/client.py
+++ b/src/blueferry/ui/client.py
@@ -352,6 +352,20 @@ class DaemonClient(GObject.Object):
             mutation=True,
         )
 
+    def set_contacts_only_notifications_async(
+        self, enabled: bool, on_ok, on_err
+    ) -> None:
+        self._submit(
+            lambda: self._call_backend(
+                lambda backend: backend.set_contacts_only_notifications(
+                    enabled
+                )
+            ),
+            on_ok,
+            on_err,
+            mutation=True,
+        )
+
     def set_storage_policy_async(self, policy: str, on_ok, on_err) -> None:
         self._submit(
             lambda: self._call_backend(

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -44,6 +44,7 @@ class IPhonePage(Gtk.Box):
         self._setup_loaded = False
         self._onboarding = OnboardingState()
         self._applying_notification_policy = False
+        self._applying_contacts_only_notifications = False
         self._applying_storage_policy = False
         self._storage_unlock_attempted = False
         self._pairing_issue_report = ""
@@ -315,6 +316,21 @@ class IPhonePage(Gtk.Box):
         self._notification_policy_row.set_selected(1)
         self._notification_policy_row.connect("notify::selected", self._notification_policy_changed)
         notification_group.add(self._notification_policy_row)
+        self._contacts_only_row = Adw.ActionRow(
+            title=_("Only Notify for Contacts"),
+            subtitle=_(
+                "Unknown senders remain available in message history"
+            ),
+        )
+        self._contacts_only_switch = Gtk.Switch(valign=Gtk.Align.CENTER)
+        self._contacts_only_switch.connect(
+            "notify::active", self._contacts_only_notifications_changed
+        )
+        self._contacts_only_row.add_suffix(self._contacts_only_switch)
+        self._contacts_only_row.set_activatable_widget(
+            self._contacts_only_switch
+        )
+        notification_group.add(self._contacts_only_row)
         page.add(notification_group)
 
         data_group = Adw.PreferencesGroup(title=_("Local Data"))
@@ -922,6 +938,14 @@ class IPhonePage(Gtk.Box):
         self._notification_policy_row.set_selected(selected)
         self._notification_policy_row.set_sensitive(reachable)
         self._applying_notification_policy = False
+        self._applying_contacts_only_notifications = True
+        self._contacts_only_switch.set_active(
+            status.contacts_only_notifications
+        )
+        self._contacts_only_row.set_sensitive(
+            reachable and policy != "none"
+        )
+        self._applying_contacts_only_notifications = False
         self._applying_storage_policy = True
         selected_storage = {
             "encrypted": 0,
@@ -958,6 +982,30 @@ class IPhonePage(Gtk.Box):
             self._apply_status(self._last_status)
 
         self._client.set_notification_policy_async(policy, saved, failed)
+
+    def _contacts_only_notifications_changed(
+        self, _switch, _property
+    ) -> None:
+        if self._applying_contacts_only_notifications:
+            return
+        enabled = self._contacts_only_switch.get_active()
+        self._contacts_only_row.set_sensitive(False)
+
+        def saved(_value: bool) -> None:
+            self._toast(_("Message notification preference saved"))
+            self._refresh()
+
+        def failed(error: str) -> None:
+            self._toast(
+                _("Could not save notification preference: {error}").format(
+                    error=error
+                )
+            )
+            self._apply_status(self._last_status)
+
+        self._client.set_contacts_only_notifications_async(
+            enabled, saved, failed
+        )
 
     def _storage_policy_changed(self, _row, _property) -> None:
         if self._applying_storage_policy:

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -168,10 +168,15 @@ def test_failed_group_reply_is_not_marked_confirmed(monkeypatch):
 def test_notification_policy_is_backend_owned_and_notifies_status() -> None:
     class Policy:
         value = "messages"
+        contacts_only = False
 
         def set(self, value):
             self.value = value
             return value
+
+        def set_contacts_only(self, enabled):
+            self.contacts_only = enabled
+            return enabled
 
     changes = []
     operations = _operations(
@@ -182,7 +187,11 @@ def test_notification_policy_is_backend_owned_and_notifies_status() -> None:
     assert operations.get_notification_policy() == "messages"
     assert operations.set_notification_policy("all") == "all"
     assert operations.get_notification_policy() == "all"
-    assert changes == [True]
+    assert operations.get_contacts_only_notifications() is False
+    assert operations.set_contacts_only_notifications(True) is True
+    assert operations.get_contacts_only_notifications() is True
+    assert operations.status()["contacts_only_notifications"] is True
+    assert changes == [True, True]
 
 
 def test_invalid_notification_policy_has_public_invalid_args_error() -> None:

--- a/tests/test_client_models.py
+++ b/tests/test_client_models.py
@@ -42,6 +42,12 @@ class _Messages:
     def SetNotificationPolicy(self, policy, **_kwargs):
         return policy
 
+    def GetContactsOnlyNotifications(self, **_kwargs):
+        return False
+
+    def SetContactsOnlyNotifications(self, enabled, **_kwargs):
+        return enabled
+
     def SetGroupParticipants(self, key, recipients, **_kwargs):
         return json.dumps({
             "key": key,
@@ -73,6 +79,8 @@ def test_backend_client_returns_shared_models(monkeypatch):
     ]
     assert client.notification_policy() == "messages"
     assert client.set_notification_policy("none") == "none"
+    assert client.contacts_only_notifications() is False
+    assert client.set_contacts_only_notifications(True) is True
     group = client.set_group_participants(
         "group:named:test", ["+15551111111", "+15552222222"]
     )

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -20,7 +20,9 @@ def _bare_daemon():
     instance.obex_worker = SimpleNamespace(submit=lambda *_args, **_kwargs: None)
     instance.contacts = object()
     instance.connectivity = Connectivity()
-    instance.notification_policy = SimpleNamespace(value="messages")
+    instance.notification_policy = SimpleNamespace(
+        value="messages", contacts_only=False
+    )
     storage_status = SimpleNamespace(
         policy="encrypted", state="ready", detail="", can_read=True
     )
@@ -150,6 +152,7 @@ def test_status_exposes_split_ancs_and_last_le_error(monkeypatch):
     assert status["ancs"] is False
     assert status["ancs_subscribed"] is True
     assert status["ancs_authorized"] is False
+    assert status["contacts_only_notifications"] is False
     assert status["bredr"] is True
     assert status["le"] is False
     assert status["last_le_error"] == "org.bluez.Error.Failed"

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -80,7 +80,9 @@ def _daemon(calls):
     value.profiles = _Profiles(calls)
     value.adapter_class = _AdapterClass(calls)
     value.solicitation = _Solicitation(calls)
-    value.notification_policy = type("Policy", (), {"value": "messages"})()
+    value.notification_policy = type(
+        "Policy", (), {"value": "messages", "contacts_only": False}
+    )()
     value.setup_verification = type("Verification", (), {"verified": ()})()
     value.ancs = None
     value._dbus_service = None

--- a/tests/test_dbus_integration.py
+++ b/tests/test_dbus_integration.py
@@ -32,10 +32,15 @@ class _Sessions:
 
 class _Policy:
     value = "messages"
+    contacts_only = False
 
     def set(self, value: str) -> str:
         self.value = value
         return value
+
+    def set_contacts_only(self, enabled: bool) -> bool:
+        self.contacts_only = enabled
+        return enabled
 
 
 @pytest.fixture
@@ -161,6 +166,12 @@ def test_notification_policy_round_trips_without_profile_io(public_service) -> N
             outcome["after"] = str(
                 interface.SetNotificationPolicy("none", timeout=5)
             )
+            outcome["contacts_before"] = bool(
+                interface.GetContactsOnlyNotifications(timeout=5)
+            )
+            outcome["contacts_after"] = bool(
+                interface.SetContactsOnlyNotifications(True, timeout=5)
+            )
         except Exception as error:
             outcome["error"] = error
         finally:
@@ -171,9 +182,15 @@ def test_notification_policy_round_trips_without_profile_io(public_service) -> N
     _dispatch_until(lambda: not client_thread.is_alive())
     client_thread.join(timeout=1)
 
-    assert outcome == {"before": "messages", "after": "none"}
+    assert outcome == {
+        "before": "messages",
+        "after": "none",
+        "contacts_before": False,
+        "contacts_after": True,
+    }
     assert policy.value == "none"
-    assert policy_changes == [True]
+    assert policy.contacts_only is True
+    assert policy_changes == [True, True]
 
 
 def test_live_signal_contains_only_an_opaque_revision(public_service) -> None:

--- a/tests/test_event_dispatcher.py
+++ b/tests/test_event_dispatcher.py
@@ -223,6 +223,7 @@ def test_libnotify_is_added_when_notification_server_appears(monkeypatch):
         # Install the owner watch before the fallible construction so the
         # server cannot appear in an unobserved gap.
         assert bus.callback is not None
+        assert _kwargs["contacts_only_notifications"]() is True
         attempts.append(bus.owner)
         if not bus.owner:
             raise RuntimeError("notification server is not ready")
@@ -231,6 +232,7 @@ def test_libnotify_is_added_when_notification_server_appears(monkeypatch):
     dispatcher = EventDispatcher(
         object(),
         submit_obex=lambda *_args, **_kwargs: None,
+        contacts_only_notifications=lambda: True,
         notification_sink_factory=create_sink,
         session_bus=bus,
     )

--- a/tests/test_libnotify.py
+++ b/tests/test_libnotify.py
@@ -200,6 +200,44 @@ def test_none_suppresses_message_popup() -> None:
     assert sink._notif.calls == []
 
 
+def test_contacts_only_suppresses_unknown_sender_popup() -> None:
+    sink = LibnotifySink.__new__(LibnotifySink)
+    sink._notification_policy = lambda: "messages"
+    sink._contacts_only_notifications = lambda: True
+    sink._notif = _FakeNotifications()
+    event = SimpleNamespace(
+        kind="sms_received",
+        contact_name=None,
+        display_sender="+15551234567",
+        body="Hello",
+        message_path=None,
+    )
+
+    sink.handle(event)
+
+    assert sink._notif.calls == []
+
+
+def test_contacts_only_allows_resolved_contact_popup() -> None:
+    sink = LibnotifySink.__new__(LibnotifySink)
+    sink._notification_policy = lambda: "messages"
+    sink._contacts_only_notifications = lambda: True
+    sink._notif = _FakeNotifications()
+    sink._pending = {}
+    sink._msg_subs = {}
+    event = SimpleNamespace(
+        kind="sms_received",
+        contact_name="Alice",
+        display_sender="Alice",
+        body="Hello",
+        message_path=None,
+    )
+
+    sink.handle(event)
+
+    assert len(sink._notif.calls) == 1
+
+
 def test_read_state_trackers_are_bounded(monkeypatch) -> None:
     removed = []
     subscription = SimpleNamespace(remove=lambda: removed.append(True))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ def test_status_defaults_missing_fields_and_preserves_new_fields():
             "daemon": True,
             "contacts": "12",
             "notification_policy": "all",
+            "contacts_only_notifications": True,
             "storage_policy": "none",
             "storage_state": "disabled",
             "verified_iphone_setup": ["contacts"],
@@ -24,6 +25,7 @@ def test_status_defaults_missing_fields_and_preserves_new_fields():
     assert status.map is False
     assert status.contacts == 12
     assert status.notification_policy == "all"
+    assert status.contacts_only_notifications is True
     assert status.storage_policy == "none"
     assert status.storage_state == "disabled"
     assert status.connectivity_state == "map-connection-refused"
@@ -31,6 +33,7 @@ def test_status_defaults_missing_fields_and_preserves_new_fields():
     assert status.retry_delay_seconds == 15
     assert status.verified_iphone_setup == ("contacts",)
     assert status.to_dict()["verified_iphone_setup"] == ["contacts"]
+    assert status.to_dict()["contacts_only_notifications"] is True
     assert status.extra["future_capability"] == "supported"
     assert status.to_dict()["future_capability"] == "supported"
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -429,6 +429,19 @@ def test_qt_connection_health_stays_compact_and_centered() -> None:
     assert "Kirigami.InlineMessage" in health
 
 
+def test_all_gui_clients_offer_contacts_only_message_notifications() -> None:
+    clients = [
+        (ROOT / "src/blueferry/ui/status.py").read_text(),
+        (ROOT / "src/blueferry/qt/qml/Main.qml").read_text(),
+        (ROOT / "data/quickshell/shell.qml").read_text(),
+    ]
+
+    for client in clients:
+        lowered = client.casefold()
+        assert "only notify for contacts" in lowered
+        assert "unknown senders remain available in message history" in lowered
+
+
 def test_qt_sends_group_replies_without_a_confirmation_dialog() -> None:
     qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
 

--- a/tests/test_notification_policy.py
+++ b/tests/test_notification_policy.py
@@ -13,6 +13,7 @@ def test_default_is_messages_only(tmp_path) -> None:
     store = NotificationPolicyStore(tmp_path / "blueferry" / "settings.json")
 
     assert store.value == "messages"
+    assert store.contacts_only is False
 
 
 def test_policy_persists_and_preserves_future_settings(tmp_path) -> None:
@@ -22,11 +23,14 @@ def test_policy_persists_and_preserves_future_settings(tmp_path) -> None:
     store = NotificationPolicyStore(path)
 
     assert store.set("ALL") == "all"
+    assert store.set_contacts_only(True) is True
 
     assert NotificationPolicyStore(path).value == "all"
+    assert NotificationPolicyStore(path).contacts_only is True
     assert json.loads(path.read_text()) == {
         "future_setting": 7,
         "desktop_notifications": "all",
+        "contacts_only_notifications": True,
     }
     assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
@@ -42,3 +46,12 @@ def test_invalid_policy_does_not_replace_existing_value(tmp_path) -> None:
 
     assert store.value == "none"
     assert NotificationPolicyStore(path).value == "none"
+
+
+def test_contacts_only_requires_a_real_boolean(tmp_path) -> None:
+    store = NotificationPolicyStore(tmp_path / "settings.json")
+
+    with pytest.raises(ValueError, match="must be a boolean"):
+        store.set_contacts_only(1)  # type: ignore[arg-type]
+
+    assert store.contacts_only is False

--- a/tests/test_quickshell_bridge.py
+++ b/tests/test_quickshell_bridge.py
@@ -35,6 +35,10 @@ class FakeClient:
         self.calls.append(("delete_threads", thread_keys))
         return len(thread_keys)
 
+    def set_contacts_only_notifications(self, enabled):
+        self.calls.append(("set_contacts_only_notifications", enabled))
+        return enabled
+
 
 def test_bridge_dispatches_private_values_without_command_arguments() -> None:
     client = FakeClient()
@@ -58,6 +62,9 @@ def test_bridge_dispatches_private_values_without_command_arguments() -> None:
     assert bridge.dispatch("delete_threads", {
         "thread_keys": ["thread-one", "thread-two"],
     }) == 2
+    assert bridge.dispatch("set_contacts_only_notifications", {
+        "enabled": True,
+    }) is True
 
     assert client.calls == [
         ("contacts", "private search"),
@@ -69,7 +76,19 @@ def test_bridge_dispatches_private_values_without_command_arguments() -> None:
             ["+15550000001", "+15550000002"],
         ),
         ("delete_threads", ["thread-one", "thread-two"]),
+        ("set_contacts_only_notifications", True),
     ]
+
+
+def test_bridge_rejects_non_boolean_contacts_only_value() -> None:
+    bridge = QuickshellBridge(FakeClient())  # type: ignore[arg-type]
+
+    try:
+        bridge.dispatch("set_contacts_only_notifications", {"enabled": 1})
+    except ValueError as error:
+        assert str(error) == "enabled must be a boolean"
+    else:
+        raise AssertionError("non-boolean preference was accepted")
 
 
 def test_bridge_returns_structured_success_and_errors() -> None:


### PR DESCRIPTION
## Summary

- add an opt-in “Only notify for contacts” preference to GTK, Qt/Kirigami, and Quickshell
- persist and expose the preference through the daemon-owned settings and D-Bus API
- suppress unknown-sender libnotify popups while retaining every message in local history
- classify senders only through unambiguous PBAP contact resolution, never sender-supplied display names

Closes #84

## Validation

- 767 tests pass in the hermetic private-D-Bus environment
- Ruff, Bandit, mypy, and qmllint pass
- live simulation produced one control popup for a resolved contact and no `Notify` call for the unknown sender