### PR TITLE
Add config-based ANCS app filtering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -202,10 +202,11 @@ managers; distro systemd hooks reload changed user-unit metadata.
   a wrong or replaced key fail closed without deleting the stored records.
 - ANCS is app-identified before content is requested. Under the default
   policy, unrelated app/system content is never fetched. Under the opt-in
-  `all` policy it is delivered only to an explicitly ephemeral popup sink,
-  never retained or broadcast on D-Bus. Apple Messages retains only the fields
-  required for group correlation, and those raw records are not exposed by the
-  public event-query method.
+  `all` policy, optional exact bundle-ID allow/block rules are applied before
+  notification attributes are fetched. Included content is delivered only to
+  an explicitly ephemeral popup sink, never retained or broadcast on D-Bus.
+  Apple Messages retains only the fields required for group correlation, and
+  those raw records are not exposed by the public event-query method.
 - Logs exclude message bodies, notification text, and recipient identities at
   every level. UI markup and terminal output are escaped at their respective
   display boundaries.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -364,8 +364,11 @@ message and read-state synchronization. Other ANCS application notifications
 are transient display-only events; ANCS provides no general reply mechanism.
 BlueFerry first requests only the owning app identifier. Unless live mirroring
 of all notifications is enabled, it does not request unrelated notification
-content at all. Even when mirroring is enabled, non-Messages content is never
-written to history or placed on BlueFerry's D-Bus event feed.
+content at all. When mirroring is enabled, the optional local allow/block rules
+are evaluated against that exact identifier before title, subtitle, message,
+or app display-name attributes are requested. Even when mirroring is enabled,
+included non-Messages content is never written to history or placed on
+BlueFerry's D-Bus event feed.
 
 ## Historical HFP result
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,31 @@ BLUEFERRY_HISTORY_MAX_EVENTS=10000
 BLUEFERRY_HISTORY_MAX_PAYLOAD_BYTES=268435456
 ```
 
-Restart the user service after editing those settings.
+When **All iPhone Notifications** is selected, optional exact bundle-ID rules
+can limit which non-Messages ANCS apps create desktop popups:
+
+```bash
+# Keep all iPhone app notifications except these apps:
+BLUEFERRY_ANCS_APP_BLOCKLIST=com.example.Chat,com.example.Mail
+
+# Or allow only these apps (omit this setting to allow every unblocked app):
+# BLUEFERRY_ANCS_APP_ALLOWLIST=com.example.Calendar,com.example.Reminders
+```
+
+If both are configured, the blocklist wins. An explicitly empty allowlist
+blocks every non-Messages app. Apple Messages is always processed for group
+conversation metadata, but its duplicate ANCS popup remains suppressed in
+favor of the MAP message popup.
+
+Bundle IDs are case-sensitive. To discover them, follow the user-service log
+while causing the app to send a notification; BlueFerry logs each app once per
+daemon run without logging its notification content:
+
+```bash
+journalctl --user -u blueferry -f | grep "ANCS app observed"
+```
+
+Restart the user service after editing `local.env` settings.
 
 ## Command line
 

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -13,10 +13,9 @@ Protocol behavior established by the pairing experiments:
 - StartNotify is called on Notification Source and Data Source as soon as
   they're present + we're paired. Control Point is write-only.
 
-- For each NotificationAdded/Modified event we get on NS, we synthesize a
-  GetNotificationAttributes packet asking for AppIdentifier+Title+Subtitle+
-  Message (plus positive/negative action labels if the iPhone declared
-  them) and write it to CP. The response comes back on DS.
+- For each NotificationAdded/Modified event we get on NS, we first request
+  only AppIdentifier. Policy and per-app configuration are evaluated before
+  requesting Title+Subtitle+Message, and the response comes back on DS.
 
 - App display names are looked up lazily via GetAppAttributes and cached.
 """
@@ -134,6 +133,7 @@ class AncsClient:
         on_event: Callable[[AncsEvent], None],
         on_status: Callable[[], None] | None = None,
         include_non_message_notifications: Callable[[], bool] | None = None,
+        include_app_notification: Callable[[str], bool] | None = None,
         on_bluez_restart: Callable[[], None] | None = None,
         on_transport_failure: Callable[[], None] | None = None,
         *,
@@ -148,6 +148,9 @@ class AncsClient:
         self._on_transport_failure = on_transport_failure
         self._include_non_message_notifications = (
             include_non_message_notifications or (lambda: False)
+        )
+        self._include_app_notification = (
+            include_app_notification or (lambda _app_id: True)
         )
         self._schedule = schedule
         self._cancel = cancel
@@ -171,6 +174,7 @@ class AncsClient:
 
         # In-flight per-notification attribute requests + app-name cache
         self._app_name_cache: OrderedDict[str, str] = OrderedDict()
+        self._observed_app_ids: OrderedDict[str, None] = OrderedDict()
         self._pending_app_lookups: dict[str, list[NotificationAttributes]] = {}
         self._app_lookup_requested: set[str] = set()
         self._request_queue: RequestBacklog[_PendingRequest] = RequestBacklog(
@@ -1047,7 +1051,23 @@ class AncsClient:
                     _APP_ID_RE.fullmatch(app_id)
                     and self._include_non_message_notifications()
                 ):
-                    self._request_full_attrs(request.notification, app_id)
+                    included = self._include_app_notification(app_id)
+                    if app_id not in self._observed_app_ids:
+                        log.info(
+                            "ANCS app observed: %s (%s)",
+                            app_id,
+                            "included" if included else "blocked",
+                        )
+                    self._observed_app_ids[app_id] = None
+                    self._observed_app_ids.move_to_end(app_id)
+                    while len(self._observed_app_ids) > MAX_ANCS_APP_CACHE:
+                        self._observed_app_ids.popitem(last=False)
+                    if included:
+                        self._request_full_attrs(request.notification, app_id)
+                    else:
+                        log.debug(
+                            "discarding ANCS notification blocked by app filter"
+                        )
                 else:
                     # The default policy never asks the iPhone for unrelated
                     # notification title, subtitle, message, or action text.

--- a/src/blueferry/config.py
+++ b/src/blueferry/config.py
@@ -13,6 +13,8 @@ LOCAL_ENV_KEYS = frozenset({
     "BLUEFERRY_MAC",
     "BLUEFERRY_ADAPTER",
     "BLUEFERRY_ANCS_ENABLED",
+    "BLUEFERRY_ANCS_APP_ALLOWLIST",
+    "BLUEFERRY_ANCS_APP_BLOCKLIST",
     "BLUEFERRY_SHOW_NOTIFICATION_CONTENT",
     "BLUEFERRY_NOTIFICATION_TIMEOUT_MS",
     "BLUEFERRY_HISTORY_RETENTION_DAYS",
@@ -144,12 +146,52 @@ def _env_int(name: str, default: int, minimum: int, maximum: int) -> int:
     return max(minimum, min(value, maximum))
 
 
+_ANCS_APP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
+
+
+def _env_ancs_app_ids(name: str) -> frozenset[str] | None:
+    """Parse one optional comma-separated set of exact ANCS bundle IDs."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    return frozenset(
+        app_id
+        for value in raw.split(",")
+        if (app_id := value.strip()) and _ANCS_APP_ID_RE.fullmatch(app_id)
+    )
+
+
 ANCS_ENABLED: bool = _env_bool("BLUEFERRY_ANCS_ENABLED", True)
 """Whether the daemon should connect and subscribe to ANCS over LE.
 
 The pairing solicitation advertisement is deliberately independent: even
 compatibility mode broadcasts it so iOS exposes MAP/PBAP permissions.
 """
+
+ANCS_APP_ALLOWLIST: frozenset[str] | None = _env_ancs_app_ids(
+    "BLUEFERRY_ANCS_APP_ALLOWLIST"
+)
+"""Exact bundle IDs allowed to create non-Messages ANCS popups.
+
+``None`` means no allowlist was configured. An explicitly empty value allows
+no non-Messages apps. Apple Messages bypasses this popup filter because its
+ANCS metadata is required for group-message correlation.
+"""
+
+ANCS_APP_BLOCKLIST: frozenset[str] = (
+    _env_ancs_app_ids("BLUEFERRY_ANCS_APP_BLOCKLIST") or frozenset()
+)
+"""Exact bundle IDs denied after the allowlist; block rules take precedence."""
+
+
+def include_ancs_app(app_id: str) -> bool:
+    """Return whether one validated non-Messages app passes local rules."""
+    selected = str(app_id).strip()
+    if not _ANCS_APP_ID_RE.fullmatch(selected):
+        return False
+    if selected in ANCS_APP_BLOCKLIST:
+        return False
+    return ANCS_APP_ALLOWLIST is None or selected in ANCS_APP_ALLOWLIST
 
 SHOW_NOTIFICATION_CONTENT: bool = _env_bool(
     "BLUEFERRY_SHOW_NOTIFICATION_CONTENT", True

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -320,6 +320,7 @@ class Daemon:
                 include_non_message_notifications=lambda: (
                     self.notification_policy.value == ALL_NOTIFICATIONS
                 ),
+                include_app_notification=config.include_ancs_app,
                 previously_authorized=(
                     NOTIFICATION_ACCESS in self.setup_verification.verified
                 ),

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -158,6 +158,59 @@ def test_all_policy_reads_future_well_formed_system_notifications() -> None:
     assert len(client._request_queue) == 1
 
 
+def test_app_filter_discards_before_notification_content_is_requested() -> None:
+    considered = []
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        include_non_message_notifications=lambda: True,
+        include_app_notification=lambda app_id: (
+            considered.append(app_id) or False
+        ),
+    )
+    notification = Notification.parse(_notification(42))
+    client._request_attrs(notification)
+
+    _complete_app_probe(client, 42, "com.example.Blocked")
+
+    assert considered == ["com.example.Blocked"]
+    assert len(client._request_queue) == 0
+
+
+def test_app_filter_allows_matching_notification_content_request() -> None:
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        include_non_message_notifications=lambda: True,
+        include_app_notification=lambda app_id: app_id == "com.example.Allowed",
+    )
+    notification = Notification.parse(_notification(42))
+    client._request_attrs(notification)
+
+    _complete_app_probe(client, 42, "com.example.Allowed")
+
+    assert len(client._request_queue) == 1
+    assert client._request_queue.popleft().expected_app_id == "com.example.Allowed"
+
+
+def test_messages_bypasses_non_message_app_filter_for_grouping() -> None:
+    client = AncsClient(
+        "/device",
+        lambda _event: None,
+        include_non_message_notifications=lambda: True,
+        include_app_notification=lambda _app_id: False,
+    )
+    notification = Notification.parse(_notification(42))
+    client._request_attrs(notification)
+
+    _complete_app_probe(client, 42, "com.apple.MobileSMS")
+
+    assert len(client._request_queue) == 1
+    assert client._request_queue.popleft().expected_app_id == (
+        "com.apple.MobileSMS"
+    )
+
+
 def test_malformed_app_identifier_is_discarded_even_under_all_policy() -> None:
     client = AncsClient(
         "/device",

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -126,14 +126,20 @@ def test_compatibility_daemon_solicits_but_never_starts_ancs(monkeypatch):
 
 def test_full_daemon_starts_ancs_client(monkeypatch):
     calls = []
+
+    def app_filter(app_id):
+        return app_id == "com.example.Allowed"
+
     value = _daemon(calls)
     _ready_bluetooth(monkeypatch, calls)
     monkeypatch.setattr(daemon.config, "ANCS_ENABLED", True)
+    monkeypatch.setattr(daemon.config, "include_ancs_app", app_filter)
 
     class Ancs:
         def __init__(self, *_args, **kwargs):
             calls.append("ancs-client")
             calls.append(("previously-authorized", kwargs["previously_authorized"]))
+            calls.append(("app-filter", kwargs["include_app_notification"]))
 
         def observe_bearer_state(self, connected):
             calls.append(("ancs-bearer", connected))
@@ -150,6 +156,7 @@ def test_full_daemon_starts_ancs_client(monkeypatch):
 
     assert "ancs-client" in calls
     assert ("previously-authorized", False) in calls
+    assert ("app-filter", app_filter) in calls
     assert ("ancs-bearer", False) in calls
     assert "ancs-start" in calls
     assert value.ancs is not None

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -95,6 +95,14 @@ def test_backend_unit_does_not_source_user_controlled_process_environment() -> N
     assert "RestrictAddressFamilies=AF_UNIX" in unit
 
 
+def test_readme_documents_manual_ancs_app_filter() -> None:
+    readme = (ROOT / "README.md").read_text()
+
+    assert "BLUEFERRY_ANCS_APP_ALLOWLIST" in readme
+    assert "BLUEFERRY_ANCS_APP_BLOCKLIST" in readme
+    assert "ANCS app observed" in readme
+
+
 def test_backend_user_unit_does_not_set_a_capability_bounding_set() -> None:
     unit = (ROOT / "systemd" / "blueferry.service").read_text()
 

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -210,6 +210,7 @@ def test_write_local_env_preserves_settings_and_is_private(tmp_path, monkeypatch
     destination.parent.mkdir()
     destination.write_text(
         "BLUEFERRY_MAC=00:00:00:00:00:00\n"
+        "BLUEFERRY_ANCS_APP_BLOCKLIST=com.example.Chat\n"
         "BLUEFERRY_SHOW_NOTIFICATION_CONTENT=false\n"
         "LD_PRELOAD=/tmp/not-allowed.so\n"
     )
@@ -221,6 +222,7 @@ def test_write_local_env_preserves_settings_and_is_private(tmp_path, monkeypatch
         "BLUEFERRY_MAC=02:00:00:00:00:01\n"
         "BLUEFERRY_ADAPTER=hci7\n"
         "BLUEFERRY_ANCS_ENABLED=true\n"
+        "BLUEFERRY_ANCS_APP_BLOCKLIST=com.example.Chat\n"
         "BLUEFERRY_SHOW_NOTIFICATION_CONTENT=false\n"
     )
     assert stat.S_IMODE(destination.stat().st_mode) == 0o600

--- a/tests/test_private_files.py
+++ b/tests/test_private_files.py
@@ -14,13 +14,19 @@ def test_local_env_repairs_modes_and_ignores_unrelated_variables(tmp_path) -> No
     path = directory / "local.env"
     path.write_text(
         "BLUEFERRY_MAC=02:00:00:00:00:01\n"
+        "BLUEFERRY_ANCS_APP_BLOCKLIST=com.example.Chat,com.example.Mail\n"
         "LD_PRELOAD=/tmp/hostile.so\n"
     )
     path.chmod(0o644)
 
     values = config.read_local_env(path)
 
-    assert values == {"BLUEFERRY_MAC": "02:00:00:00:00:01"}
+    assert values == {
+        "BLUEFERRY_MAC": "02:00:00:00:00:01",
+        "BLUEFERRY_ANCS_APP_BLOCKLIST": (
+            "com.example.Chat,com.example.Mail"
+        ),
+    }
     assert stat.S_IMODE(directory.stat().st_mode) == 0o700
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
@@ -69,3 +75,42 @@ def test_bluetooth_identifiers_from_the_environment_are_validated(
 
     assert config._configured_mac() == "AA:BB:CC:DD:EE:FF"
     assert config._configured_adapter() == "hci0"
+
+
+def test_ancs_app_lists_accept_only_exact_bundle_ids(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "BLUEFERRY_ANCS_APP_ALLOWLIST",
+        " com.example.Allowed,invalid app,,com.example.Second ",
+    )
+
+    assert config._env_ancs_app_ids("BLUEFERRY_ANCS_APP_ALLOWLIST") == {
+        "com.example.Allowed",
+        "com.example.Second",
+    }
+
+
+def test_ancs_app_blocklist_wins_over_allowlist(monkeypatch) -> None:
+    monkeypatch.setattr(
+        config,
+        "ANCS_APP_ALLOWLIST",
+        frozenset({"com.example.Allowed", "com.example.Blocked"}),
+    )
+    monkeypatch.setattr(
+        config,
+        "ANCS_APP_BLOCKLIST",
+        frozenset({"com.example.Blocked"}),
+    )
+
+    assert config.include_ancs_app("com.example.Allowed") is True
+    assert config.include_ancs_app("com.example.Blocked") is False
+    assert config.include_ancs_app("com.example.Unlisted") is False
+    assert config.include_ancs_app("invalid app") is False
+
+
+def test_explicitly_empty_ancs_allowlist_blocks_every_app(monkeypatch) -> None:
+    monkeypatch.setenv("BLUEFERRY_ANCS_APP_ALLOWLIST", "")
+    monkeypatch.setattr(config, "ANCS_APP_ALLOWLIST", frozenset())
+    monkeypatch.setattr(config, "ANCS_APP_BLOCKLIST", frozenset())
+
+    assert config._env_ancs_app_ids("BLUEFERRY_ANCS_APP_ALLOWLIST") == set()
+    assert config.include_ancs_app("com.example.Anything") is False


### PR DESCRIPTION
## Summary

- add optional comma-separated ANCS bundle-ID allowlists and blocklists to `~/.config/blueferry/local.env`
- apply app rules immediately after the ANCS app-ID probe, before requesting title, subtitle, body, or display-name attributes
- keep Apple Messages available for group correlation while continuing to suppress its duplicate ANCS popup
- log each observed non-Messages bundle ID once per daemon run for configuration discovery
- preserve app-filter settings across pairing/config rewrites and document precedence and empty-allowlist behavior

Addresses #74

## Configuration

```bash
BLUEFERRY_ANCS_APP_BLOCKLIST=com.example.Chat,com.example.Mail
# or
BLUEFERRY_ANCS_APP_ALLOWLIST=com.example.Calendar,com.example.Reminders
```

The blocklist wins when both are present. Existing behavior is unchanged when neither setting is configured.

## Validation

- 774 tests pass in the hermetic private-D-Bus environment
- Ruff, Bandit, mypy, and qmllint pass
- live installed-package test: allowed control requested content and produced one popup; blocked synthetic app requested no content, emitted no event, and made no desktop `Notify` call