### PR TITLE
Compact pairing reports for GitHub issues

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -390,7 +390,14 @@ Each pairing attempt records the resolved delivery mode, authentication
 strategy, controller capability, phone/bearer observations, daemon transport
 state, and an ordered monotonic timeline. Reports redact device addresses,
 object paths, and user directories before they are retained or embedded in a
-GitHub issue URL.
+GitHub issue URL. The first `bluez_trace` entry contains a complete device
+snapshot; later entries contain only recursive `changes` from the previous
+entry, with JSON `null` removing a field. Unchanged snapshots are represented
+by the ordered timeline instead of taking another trace entry. GitHub issue
+prefill also omits the redundant root/child interface inventories and limits
+the adapter UUID inventory to messaging/phonebook services, while the local
+report retains them; if necessary, it drops the timeline only as a final
+size-reduction step.
 
 Native packages also bake a SHA-256 of their deterministic source snapshot.
 The report's `blueferry_build` uses the same package-release plus short-SHA

--- a/src/blueferry/quirks_report.py
+++ b/src/blueferry/quirks_report.py
@@ -156,6 +156,102 @@ def mark(attempt: PairingAttempt | None, event: str, **fields: Any) -> None:
     attempt.setdefault("timeline", []).append(entry)
 
 
+def _mapping_changes(
+    previous: Mapping[str, Any],
+    current: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return a recursive merge patch from one diagnostic state to another."""
+    changes: dict[str, Any] = {
+        str(key): None for key in previous.keys() - current.keys()
+    }
+    for key, value in current.items():
+        old = previous.get(key)
+        if key in previous and isinstance(old, Mapping) and isinstance(value, Mapping):
+            nested = _mapping_changes(old, value)
+            if nested:
+                changes[str(key)] = nested
+        elif key not in previous or old != value:
+            changes[str(key)] = value
+    return changes
+
+
+def _compact_bluez_trace(value: Any) -> Any:
+    """Store one full BlueZ state followed by lossless recursive changes."""
+    if not isinstance(value, list) or not value:
+        return value
+    if not all(
+        isinstance(entry, dict) and isinstance(entry.get("state"), dict)
+        for entry in value
+    ):
+        # Reports already written in the compact format have only one full
+        # state. Leave them untouched when pairing-issue reads them later.
+        return value
+
+    compacted: list[dict[str, Any]] = []
+    previous: Mapping[str, Any] | None = None
+    for entry in value:
+        state = entry["state"]
+        compact = {key: item for key, item in entry.items() if key != "state"}
+        if previous is None:
+            compact["state"] = state
+        else:
+            changes = _mapping_changes(previous, state)
+            if not changes:
+                previous = state
+                continue
+            compact["changes"] = changes
+        compacted.append(compact)
+        previous = state
+    return compacted
+
+
+def _compact_report(report: Mapping[str, Any]) -> dict[str, Any]:
+    compacted = dict(report)
+    if "bluez_trace" in compacted:
+        compacted["bluez_trace"] = _compact_bluez_trace(compacted["bluez_trace"])
+    return compacted
+
+
+def _issue_compact_report(report: Mapping[str, Any]) -> dict[str, Any]:
+    """Remove trace inventories duplicated by explicit bearer/GATT fields."""
+    compacted = _compact_report(report)
+    raw_controller = compacted.get("controller")
+    if isinstance(raw_controller, dict):
+        controller = dict(raw_controller)
+        raw_uuids = controller.pop("uuids", None)
+        if isinstance(raw_uuids, list):
+            controller["messaging_uuids"] = [
+                uuid
+                for uuid in raw_uuids
+                if "message" in str(uuid) or "phonebook" in str(uuid)
+            ]
+        controller.pop("summary", None)
+        compacted["controller"] = controller
+    trace = compacted.get("bluez_trace")
+    if not isinstance(trace, list):
+        return compacted
+    issue_trace: list[Any] = []
+    for raw_entry in trace:
+        if not isinstance(raw_entry, dict):
+            issue_trace.append(raw_entry)
+            continue
+        entry = dict(raw_entry)
+        for field in ("state", "changes"):
+            raw_snapshot = entry.get(field)
+            if not isinstance(raw_snapshot, dict):
+                continue
+            snapshot = dict(raw_snapshot)
+            snapshot.pop("root_interfaces", None)
+            snapshot.pop("child_interfaces", None)
+            if snapshot:
+                entry[field] = snapshot
+            else:
+                entry.pop(field)
+        issue_trace.append(entry)
+    compacted["bluez_trace"] = issue_trace
+    return compacted
+
+
 def save_report(report: Mapping[str, Any], *, directory: Path | None = None) -> Path | None:
     """Write one scrubbed report beside the history database and keep ten."""
     try:
@@ -170,7 +266,7 @@ def save_report(report: Mapping[str, Any], *, directory: Path | None = None) -> 
         while path.exists():
             sequence += 1
             path = target_dir / f"{REPORT_PREFIX}{stamp}-{sequence:04d}{REPORT_SUFFIX}"
-        prepared = dict(report)
+        prepared = _compact_report(report)
         origin = prepared.pop("_t0", None)
         timeline = prepared.get("timeline")
         if isinstance(origin, (int, float)):
@@ -346,15 +442,28 @@ def issue_url(report: dict[str, Any] | Path | str | None = None) -> str:
     """GitHub new-issue URL with label, chipset title, and report JSON body."""
     payload = report if isinstance(report, dict) else _read_report(report)
     title = issue_title(payload)
+    issue_compacted = _issue_compact_report(payload)
     candidates = [
         json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
-        json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True),
     ]
-    slim = dict(payload)
-    slim.pop("timeline", None)
-    candidates.append(
-        json.dumps(slim, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    issue_json = json.dumps(
+        issue_compacted,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
     )
+    if issue_json not in candidates:
+        candidates.append(issue_json)
+    slim = dict(issue_compacted)
+    slim.pop("timeline", None)
+    slim_json = json.dumps(
+        slim,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if slim_json not in candidates:
+        candidates.append(slim_json)
     for report_json in candidates:
         url = (
             f"{GITHUB_ISSUE_NEW}?"

--- a/tests/test_quirks_report.py
+++ b/tests/test_quirks_report.py
@@ -93,6 +93,138 @@ def test_issue_url_labels_a_pairing_issue_with_adapter_and_outcome() -> None:
     ) == "Pairing issue: MediaTek MT7921 — MAP/PBAP success, ANCS fail"
 
 
+def test_save_report_delta_compacts_repeated_bluez_snapshots(tmp_path) -> None:
+    initial = {
+        "device": {"paired": False, "trusted": False},
+        "bearers": {"bredr": {"present": True}, "le": {"present": False}},
+    }
+    paired = {
+        "device": {"paired": True, "trusted": False},
+        "bearers": {
+            "bredr": {"present": True, "connected": True},
+            "le": {"present": True, "connected": False},
+        },
+    }
+    disconnected = {
+        "device": {"paired": True, "trusted": True},
+        "bearers": {"bredr": {"present": True}, "le": {"present": False}},
+    }
+
+    path = quirks_report.save_report(
+        {
+            "bluez_trace": [
+                {"t": 0.1, "phase": "device_loaded", "state": initial},
+                {"t": 1.2, "phase": "paired", "state": paired},
+                {"t": 2.3, "phase": "advert_ready", "state": paired},
+                {"t": 3.4, "phase": "finished", "state": disconnected},
+            ],
+        },
+        directory=tmp_path,
+    )
+
+    assert path is not None
+    trace = json.loads(path.read_text())["bluez_trace"]
+    assert trace[0]["state"] == initial
+    assert trace[1]["changes"] == {
+        "bearers": {
+            "bredr": {"connected": True},
+            "le": {"connected": False, "present": True},
+        },
+        "device": {"paired": True},
+    }
+    assert [entry["phase"] for entry in trace] == [
+        "device_loaded", "paired", "finished",
+    ]
+    assert trace[2]["changes"] == {
+        "bearers": {
+            "bredr": {"connected": None},
+            "le": {"connected": None, "present": False},
+        },
+        "device": {"trusted": True},
+    }
+
+
+def test_issue_url_compacts_full_snapshot_reports_before_embedding(monkeypatch) -> None:
+    interfaces = {
+        f"org.example.Interface{index}": index
+        for index in range(18)
+    }
+    state = {
+        "object_present": True,
+        "device_present": True,
+        "child_objects": 18,
+        "root_interfaces": list(interfaces),
+        "child_interfaces": interfaces,
+        "device": {
+            "paired": True,
+            "trusted": True,
+            "connected": True,
+            "services_resolved": True,
+            "ancs_uuid": False,
+            "uuid_count": 14,
+        },
+        "bearers": {
+            "bredr": {"present": True, "connected": True},
+            "le": {"present": True, "connected": False},
+        },
+        "gatt": {
+            "services": 0,
+            "characteristics": 0,
+            "ancs_service": False,
+            "ancs_characteristics": [],
+        },
+        "battery_objects": 1,
+    }
+    payload = {
+        "blueferry": "0.7.7",
+        "blueferry_sha": "a" * 64,
+        "controller": {
+            "name": "hci0",
+            "vendor": "Realtek",
+            "product": "RTL8852CE",
+            "supported_settings": list(interfaces),
+            "current_settings": list(interfaces)[:10],
+            "summary": "Realtek RTL8852CE (usb 0bda:c852, btusb)",
+            "uuids": [
+                *list(interfaces),
+                "message-access-server",
+                "phonebook-access-server",
+            ],
+        },
+        "outcome": {"map": False, "pbap": False, "ancs": False},
+        "timeline": [
+            {"t": index * 1.5, "event": f"pairing_phase_{index}"}
+            for index in range(30)
+        ],
+        "bluez_trace": [
+            {"t": index * 5.0, "phase": f"phase_{index}", "state": state}
+            for index in range(8)
+        ],
+    }
+    monkeypatch.setattr(quirks_report, "MAX_ISSUE_URL_CHARS", 6_000)
+
+    url = quirks_report.issue_url(payload)
+
+    assert len(url) <= quirks_report.MAX_ISSUE_URL_CHARS
+    body = parse_qs(urlparse(url).query)["body"][0]
+    assert "too large to embed" not in body
+    report_json = body.partition("```json\n")[2].rpartition("\n```")[0]
+    embedded = json.loads(report_json)
+    assert len(embedded["timeline"]) == 30
+    assert len(embedded["bluez_trace"]) == 1
+    issue_state = embedded["bluez_trace"][0]["state"]
+    assert issue_state["device"] == state["device"]
+    assert issue_state["bearers"] == state["bearers"]
+    assert issue_state["gatt"] == state["gatt"]
+    assert "root_interfaces" not in issue_state
+    assert "child_interfaces" not in issue_state
+    assert "summary" not in embedded["controller"]
+    assert embedded["controller"]["messaging_uuids"] == [
+        "message-access-server",
+        "phonebook-access-server",
+    ]
+
+
 def test_issue_report_keeps_a_successful_ancs_setup(tmp_path) -> None:
     failed = quirks_report.save_report(
         {"outcome": {"setup_complete": True, "ancs": False}},


### PR DESCRIPTION
## Summary

- delta-compress repeated BlueZ device snapshots in saved pairing reports
- omit unchanged snapshots while retaining their phases in the pairing timeline
- trim redundant interface inventories and unrelated adapter UUIDs from GitHub issue-prefill copies
- compact older full-snapshot reports when `blueferry pairing-issue` reads them

## Real report validation

- issue #82: 5,121-character issue URL
- issue #89: 6,476-character issue URL
- configured ceiling: 8,000 characters
- both embedded reports retain their complete timelines

## Validation

- `ruff check .`
- `bandit -r src/blueferry -q`
- `mypy src/blueferry`
- `pytest -q` (776 passed)
- `qmllint src/blueferry/qt/qml/*.qml data/quickshell/*.qml`