### PR TITLE
Retry pairing when BlueZ drops the selected device

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -65,6 +65,13 @@ authentication. BlueZ exposes neither its registered-agent list nor the
 identity of its default agent, so automatic desktop-agent heuristics proved too
 indirect to choose a reliable transaction.
 
+An unpaired `Device1` discovery record can expire while BlueFerry prepares the
+adapter, including while setup waits for interactive system authorization. If
+the Connect-first call reports `UnknownObject`, BlueFerry scans the selected
+adapter for that exact address and retries `Connect()` once. Other devices and
+adapters are not eligible, and ordinary runtime connections continue to fail
+on `UnknownObject`.
+
 Some controllers instead cancel the Connect-first transaction before pairing
 finishes. For those systems the independent **Use explicit Bluetooth pairing**
 override registers the same device-scoped agent but calls `Device1.Pair()`

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import json
 import logging
 import time
-from collections.abc import Callable
-from contextlib import ExitStack
+from collections.abc import Callable, Iterator
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
@@ -59,6 +59,10 @@ class _TransportStatus(Protocol):
 
     @property
     def ancs(self) -> bool: ...
+
+
+class _ConnectDeviceMissing(PairingError):
+    """BlueZ removed the Device1 object before Connect was dispatched."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -425,6 +429,83 @@ def _device(mac: str, *, adapter: str | None = None) -> PairedDevice:
     raise PairingError(f"Bluetooth device {normalized} is no longer available; scan again")
 
 
+@contextmanager
+def _rediscover_pairing_device(
+    mac: str,
+    *,
+    adapter: str,
+    timeout: float = DISCOVERY_SECONDS,
+    attempt: PairingAttempt | None = None,
+) -> Iterator[PairedDevice]:
+    """Recreate one vanished Device1 on its selected adapter.
+
+    This is deliberately narrower than the setup client's general scan: it
+    waits for the exact address, never switches adapters, and leaves a scan
+    that another Bluetooth client already owned running.
+    """
+    normalized = mac.strip().upper()
+    device = _find_device(normalized, adapter=adapter)
+    if device is not None:
+        yield device
+        return
+
+    adapter_path = f"/org/bluez/{adapter}"
+    log.info(
+        "BlueZ removed %s before pairing; rediscovering it on %s",
+        normalized,
+        adapter,
+    )
+    quirks_report.mark(attempt, "pairing_device_rediscovery_started")
+    radio = dbus.Interface(
+        get_system_bus().get_object("org.bluez", adapter_path),
+        "org.bluez.Adapter1",
+    )
+    started_discovery = False
+    try:
+        try:
+            radio.StartDiscovery()
+            started_discovery = True
+        except dbus.exceptions.DBusException as error:
+            if error.get_dbus_name() != "org.bluez.Error.InProgress":
+                raise
+
+        deadline = time.monotonic() + max(1.0, timeout)
+        while True:
+            device = _find_device(normalized, adapter=adapter)
+            if device is not None:
+                log.info(
+                    "rediscovered pairing device %s on %s",
+                    normalized,
+                    adapter,
+                )
+                quirks_report.mark(attempt, "pairing_device_rediscovered")
+                # Keep our discovery session alive until the caller has sent
+                # Connect, so BlueZ cannot age this new unpaired object out
+                # at the same boundary a second time.
+                yield device
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(0.25, remaining))
+    except dbus.exceptions.DBusException as error:
+        detail = error.get_dbus_message() or error.get_dbus_name() or str(error)
+        raise PairingError(
+            f"Could not rediscover the iPhone on {adapter}: {detail}"
+        ) from error
+    finally:
+        if started_discovery:
+            try:
+                radio.StopDiscovery()
+            except dbus.exceptions.DBusException:
+                pass
+
+    raise PairingError(
+        f"The iPhone disappeared from {adapter} before pairing. Keep its "
+        "Bluetooth settings open and retry."
+    )
+
+
 def _wait_for_paired_device(
     mac: str, *, adapter: str | None = None, timeout: float = 120,
 ) -> PairedDevice:
@@ -540,25 +621,30 @@ def _connect_classic(
     )
     _dispatching_wait(time.monotonic() + timeout + 5.0, lambda: bool(results))
     error = results[0] if results else None
-    if error is not None and error.get_dbus_name() not in {
+    error_name = error.get_dbus_name() if error is not None else ""
+    if error is not None and error_name not in {
         "org.bluez.Error.AlreadyConnected",
         "org.bluez.Error.InProgress",
     }:
         quirks_report.mark(
             attempt, "classic_connect_failed",
-            error=error.get_dbus_name() or "failed",
+            error=error_name or "failed",
         )
+        if error_name == "org.freedesktop.DBus.Error.UnknownObject":
+            raise _ConnectDeviceMissing(
+                error.get_dbus_message() or error_name or str(error)
+            ) from error
         raise PairingError(
-            error.get_dbus_message() or error.get_dbus_name() or str(error)
+            error.get_dbus_message() or error_name or str(error)
         ) from error
     if error is None:
         log.debug("Device1.Connect completed successfully")
         quirks_report.mark(attempt, "classic_connect_replied")
     else:
-        log.debug("Device1.Connect reports %s", error.get_dbus_name())
+        log.debug("Device1.Connect reports %s", error_name)
         quirks_report.mark(
             attempt, "classic_connect_replied",
-            result=error.get_dbus_name() or "error",
+            result=error_name or "error",
         )
     if settle:
         _wait_for_classic_settled(device_path, timeout=timeout, attempt=attempt)
@@ -1118,12 +1204,28 @@ def _run_pairing_transaction(
             resources.agent_registered = True
             quirks_report.mark(attempt, "agent_registered")
             if policy.iphone_initiated:
-                _connect_classic(
-                    device.device_path,
-                    timeout=60.0,
-                    settle=False,
-                    attempt=attempt,
-                )
+                try:
+                    _connect_classic(
+                        device.device_path,
+                        timeout=60.0,
+                        settle=False,
+                        attempt=attempt,
+                    )
+                except _ConnectDeviceMissing:
+                    # An unpaired discovery record can expire while adapter
+                    # preparation is waiting for authorization. Recreate only
+                    # that exact object, then retry once.
+                    with _rediscover_pairing_device(
+                        mac,
+                        adapter=adapter,
+                        attempt=attempt,
+                    ) as device:
+                        _connect_classic(
+                            device.device_path,
+                            timeout=60.0,
+                            settle=False,
+                            attempt=attempt,
+                        )
                 registered.wait_for_pair(timeout=120.0)
                 attempt["pairing_transaction"] = "iphone-initiated-connect"
             else:

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import stat
+from contextlib import contextmanager
 
 import pytest
 
@@ -1449,6 +1450,153 @@ def test_classic_connect_requires_observable_settled_connection(monkeypatch):
     ]
 
 
+def test_classic_connect_distinguishes_a_missing_bluez_device(monkeypatch):
+    class Interface:
+        @staticmethod
+        def Connect(*, error_handler, **_kwargs):
+            error_handler(
+                pair_setup.dbus.exceptions.DBusException(
+                    'Method "Connect" does not exist',
+                    name="org.freedesktop.DBus.Error.UnknownObject",
+                )
+            )
+
+    class Bus:
+        @staticmethod
+        def get_object(*_args):
+            return object()
+
+    attempt = {"timeline": []}
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Interface())
+    monkeypatch.setattr(
+        pair_setup,
+        "_wait_for_classic_settled",
+        lambda *_args, **_kwargs: pytest.fail("non-settling connect settled"),
+    )
+
+    with pytest.raises(pair_setup._ConnectDeviceMissing, match="does not exist"):
+        pair_setup._connect_classic(
+            "/org/bluez/hci0/dev_02_00_00_00_00_01",
+            settle=False,
+            timeout=1.0,
+            attempt=attempt,
+        )
+
+    assert [event["event"] for event in attempt["timeline"]] == [
+        "classic_connect_sent",
+        "classic_connect_failed",
+    ]
+    assert attempt["timeline"][-1]["error"] == (
+        "org.freedesktop.DBus.Error.UnknownObject"
+    )
+
+
+def test_pairing_rediscovery_waits_for_exact_device_on_selected_adapter(
+    monkeypatch,
+):
+    same_phone_other_adapter = _device(paired=False)
+    other_phone = _device(paired=False)
+    other_phone.mac = "02:00:00:00:00:02"
+    other_phone.adapter_path = "/org/bluez/hci1"
+    other_phone.device_path = "/org/bluez/hci1/dev_02_00_00_00_00_02"
+    target = _device(paired=False)
+    target.adapter_path = "/org/bluez/hci1"
+    target.device_path = "/org/bluez/hci1/dev_02_00_00_00_00_01"
+    snapshots = [
+        [same_phone_other_adapter, other_phone],
+        [same_phone_other_adapter, other_phone],
+        [same_phone_other_adapter, other_phone, target],
+    ]
+    calls = []
+    elapsed = 0.0
+
+    class Adapter:
+        @staticmethod
+        def StartDiscovery():
+            calls.append("start")
+
+        @staticmethod
+        def StopDiscovery():
+            calls.append("stop")
+
+    class Bus:
+        @staticmethod
+        def get_object(service, path):
+            calls.append((service, path))
+            return Adapter()
+
+    def sleep(seconds):
+        nonlocal elapsed
+        elapsed += seconds
+
+    attempt = {"timeline": []}
+    monkeypatch.setattr(pair_setup, "list_devices", lambda: snapshots.pop(0))
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(pair_setup.time, "monotonic", lambda: elapsed)
+    monkeypatch.setattr(pair_setup.time, "sleep", sleep)
+
+    with pair_setup._rediscover_pairing_device(
+        target.mac,
+        adapter="hci1",
+        timeout=1.0,
+        attempt=attempt,
+    ) as result:
+        assert calls == [
+            ("org.bluez", "/org/bluez/hci1"),
+            "start",
+        ]
+
+    assert result == target
+    assert calls == [
+        ("org.bluez", "/org/bluez/hci1"),
+        "start",
+        "stop",
+    ]
+    assert [event["event"] for event in attempt["timeline"]] == [
+        "pairing_device_rediscovery_started",
+        "pairing_device_rediscovered",
+    ]
+
+
+def test_pairing_rediscovery_leaves_an_existing_scan_running(monkeypatch):
+    target = _device(paired=False)
+    devices = iter([None, target])
+
+    class Adapter:
+        @staticmethod
+        def StartDiscovery():
+            raise pair_setup.dbus.exceptions.DBusException(
+                "Discovery already in progress",
+                name="org.bluez.Error.InProgress",
+            )
+
+        @staticmethod
+        def StopDiscovery():
+            pytest.fail("BlueFerry did not start this discovery session")
+
+    class Bus:
+        @staticmethod
+        def get_object(_service, _path):
+            return Adapter()
+
+    monkeypatch.setattr(
+        pair_setup,
+        "_find_device",
+        lambda _mac, **_kwargs: next(devices),
+    )
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda value, _iface: value)
+
+    with pair_setup._rediscover_pairing_device(
+        target.mac,
+        adapter="hci0",
+        timeout=1.0,
+    ) as result:
+        assert result == target
+
+
 def test_post_pair_bearer_preference_is_forced_to_bredr(monkeypatch):
     calls = []
 
@@ -1692,7 +1840,7 @@ def test_compatibility_pairing_connects_and_lets_the_iphone_initiate(monkeypatch
     ]
 
 
-def test_default_interactive_pairing_lets_the_iphone_initiate(monkeypatch):
+def test_default_pairing_rediscovers_a_device_lost_before_connect(monkeypatch):
     from blueferry import pairing_agent
 
     unpaired = _device(paired=False)
@@ -1731,10 +1879,31 @@ def test_default_interactive_pairing_lets_the_iphone_initiate(monkeypatch):
         lambda _adapter: calls.append("advert-exit"),
     )
     monkeypatch.setattr(pairing_agent, "RegisteredPairingAgent", Agent)
+
+    connect_attempts = 0
+
+    def connect_classic(path, **kwargs):
+        nonlocal connect_attempts
+        connect_attempts += 1
+        calls.append(("connect", path, kwargs["timeout"]))
+        if connect_attempts == 1:
+            raise pair_setup._ConnectDeviceMissing("Device1 disappeared")
+
     monkeypatch.setattr(
         pair_setup,
         "_connect_classic",
-        lambda path, **kwargs: calls.append(("connect", path, kwargs["timeout"])),
+        connect_classic,
+    )
+
+    @contextmanager
+    def rediscover_pairing_device(mac, **kwargs):
+        calls.append(("rediscover", mac, kwargs["adapter"]))
+        yield unpaired
+
+    monkeypatch.setattr(
+        pair_setup,
+        "_rediscover_pairing_device",
+        rediscover_pairing_device,
     )
     monkeypatch.setattr(
         pair_setup,
@@ -1758,6 +1927,8 @@ def test_default_interactive_pairing_lets_the_iphone_initiate(monkeypatch):
     assert calls == [
         ("agent", unpaired.device_path, True),
         "agent-enter",
+        ("connect", unpaired.device_path, 60.0),
+        ("rediscover", unpaired.mac, "hci0"),
         ("connect", unpaired.device_path, 60.0),
         ("wait", 120.0),
         "settled",

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -410,6 +410,10 @@ def test_textual_warns_about_bluez_restart_when_only_ancs_is_missing(
                 "sudo systemctl restart bluetooth.service",
             )
             assert notice.has_class("warn")
+            for _attempt in range(30):
+                if notice.region.height >= 3:
+                    break
+                await pilot.pause(0.05)
             assert notice.region.height >= 3
 
     monkeypatch.setattr(tui_module.config, "ANCS_ENABLED", True)


### PR DESCRIPTION
## Summary

- distinguish a vanished BlueZ Device1 from other Connect failures
- rediscover only the selected iPhone MAC on the selected adapter, then retry Connect once
- keep the owned discovery session alive through the retry without stopping discovery owned by another client
- document the recovery behavior and cover normal, explicit-pairing, adapter-selection, and discovery-ownership boundaries

Fixes #95

## Validation

- ruff check .
- bandit -r src/blueferry -q
- mypy src/blueferry
- 779 tests passed under the hermetic D-Bus session
- qmllint passed