### PR TITLE
Prevent Bluetooth bearer reconnect races

### DIFF
--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -97,6 +97,7 @@ Connect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
 Disconnect = Callable[[str, Callable[[], None], Callable[[Exception], None]], None]
 Prefer = Callable[[str], None]
 ObserveLeState = Callable[[bool | None], None]
+ObserveLeDial = Callable[[bool], None]
 InboundLePrimed = Callable[[], bool]
 Schedule = Callable[[int, Callable[[], bool]], int]
 Cancel = Callable[[int], object]
@@ -118,6 +119,7 @@ class BearerSupervisor:
         le_enabled: bool = True,
         on_status: Callable[[], None] | None = None,
         on_le_state: ObserveLeState | None = None,
+        on_le_dial: ObserveLeDial | None = None,
         read_connected: ReadConnected | None = None,
         connect: Connect | None = None,
         disconnect: Disconnect | None = None,
@@ -130,6 +132,7 @@ class BearerSupervisor:
         self.device_path = device_path
         self._on_status = on_status
         self._on_le_state = on_le_state
+        self._on_le_dial = on_le_dial
         self._read_connected = read_connected or self._read_bluez_connected
         self._connect = connect or self._connect_bluez
         self._disconnect = disconnect or self._disconnect_bluez
@@ -148,6 +151,7 @@ class BearerSupervisor:
         self._connecting: set[str] = set()
         self._disconnecting: set[str] = set()
         self._le_hold_disconnect_pending = False
+        self._le_dial_active = False
         # Outbound Bearer.LE1.Connect is only a bootstrap hint.  Real-device
         # traces show the solicitation advertisement to be the reliable
         # reconnect path, while repeating Connect can leave BlueZ in an
@@ -193,6 +197,19 @@ class BearerSupervisor:
         self._le_enabled = True
         self._le_hold_disconnect_pending = False
         log.info("MAP/PBAP attempt completed; enabling iPhone LE bearer")
+        if self._states["le"] is not True and "le" not in self._connecting:
+            # Pairing deliberately leaves the untyped Device1.Connect path on
+            # BR/EDR while MAP/PBAP get their first turn. Hand inbound control
+            # back once here, before either an LE dial or a solicited link is
+            # in flight. Bearer.LE1.Connect already names its transport and
+            # must not rewrite PreferredBearer underneath itself.
+            try:
+                self._prefer("le")
+            except Exception as error:
+                log.warning(
+                    "could not hand PreferredBearer to inbound LE: %s",
+                    error,
+                )
         if self._running:
             self._tick()
 
@@ -224,6 +241,7 @@ class BearerSupervisor:
         self._generation += 1
         self._connecting.clear()
         self._disconnecting.clear()
+        self._set_le_dial_active(False)
         # The old owner's live link is gone. While the profile gate is closed,
         # reject any LE link that appears under the replacement owner.
         self._le_hold_disconnect_pending = not self._le_enabled
@@ -266,6 +284,7 @@ class BearerSupervisor:
         self._generation += 1
         self._connecting.clear()
         self._disconnecting.clear()
+        self._set_le_dial_active(False)
         self._le_hold_disconnect_pending = False
         self._le_dial_spent = False
         self._le_reset_pending = False
@@ -306,6 +325,10 @@ class BearerSupervisor:
             # the profile gate closed, so allowing it to become usable here
             # would put GATT ahead of the MAP/PBAP attempt again.
             self._request_le_disconnect(force=True)
+            # Wait for the targeted LE teardown before selecting BR/EDR. A
+            # PreferredBearer write here would race the still-live LE link we
+            # just asked BlueZ to remove.
+            return True
         else:
             self._update_state("le", le)
 
@@ -422,6 +445,17 @@ class BearerSupervisor:
     def _request_connect(self, kind: str) -> None:
         if kind in self._connecting:
             return
+        if kind == "bredr" and "le" in self._connecting:
+            return
+        if (
+            kind == "bredr"
+            and self._le_enabled
+            and self._states["le"] is None
+        ):
+            # Do not guess that LE is down and rewrite PreferredBearer during
+            # a transient read failure. During the initial MAP-first gate, a
+            # missing LE interface must not strand Classic-only controllers.
+            return
         if kind == "le" and self._le_dial_exhausted():
             return
         if self._clock() < self._next_attempt[kind]:
@@ -432,10 +466,18 @@ class BearerSupervisor:
         generation = self._generation
         log.info("connecting iPhone %s bearer", kind.upper())
         try:
-            # Pairing pins the device to BR/EDR so iOS sees MAP/PBAP first.
-            # Switch that preference explicitly for the deferred LE handoff;
-            # restore it just as explicitly before a later Classic reconnect.
-            self._prefer(kind)
+            if kind == "bredr":
+                if self._states["le"] is not True:
+                    # Device1.Connect is transport-agnostic, so select Classic
+                    # only when no LE link is live. With live LE,
+                    # _connect_bluez uses targeted Bearer.BREDR1.Connect and
+                    # leaves the preference untouched.
+                    self._prefer("bredr")
+            else:
+                # Advertising while this asynchronous call is outstanding can
+                # abort the dial locally. The daemon withdraws solicitation
+                # synchronously here and restores it on reply or timeout.
+                self._set_le_dial_active(True)
             self._connect(
                 kind,
                 lambda: self._connect_succeeded(kind, generation),
@@ -448,6 +490,8 @@ class BearerSupervisor:
         if generation != self._generation:
             return
         self._connecting.discard(kind)
+        if kind == "le":
+            self._set_le_dial_active(False)
         self._last_errors.pop(kind, None)
         if kind == "le" and not self._le_enabled:
             self._le_hold_disconnect_pending = True
@@ -479,6 +523,8 @@ class BearerSupervisor:
         if generation != self._generation:
             return
         self._connecting.discard(kind)
+        if kind == "le":
+            self._set_le_dial_active(False)
         if kind == "le" and not self._le_enabled:
             # Policy closed the gate while the asynchronous request was in
             # flight.  This generation never received its permitted attempt.
@@ -511,6 +557,14 @@ class BearerSupervisor:
     def _le_dial_exhausted(self) -> bool:
         """Yield to inbound solicitation only when it is actually on air."""
         return self._le_dial_spent and self._inbound_le_primed()
+
+    def _set_le_dial_active(self, active: bool) -> None:
+        """Publish one LE dial's lifetime so solicitation cannot overlap it."""
+        if active == self._le_dial_active:
+            return
+        self._le_dial_active = active
+        if self._on_le_dial is not None:
+            self._on_le_dial(active)
 
     def _rearm_le_dial(self, reason: str) -> None:
         """Grant one outbound LE bootstrap for a new presence generation."""
@@ -620,9 +674,19 @@ class BearerSupervisor:
         on_success: Callable[[], None],
         on_error: Callable[[Exception], None],
     ) -> None:
-        # Device1.Connect drives the Classic bearer (Bearer.BREDR1 can be
-        # marker-only); the LE bearer interface is driven directly.
-        interface = "org.bluez.Device1" if kind == "bredr" else _INTERFACES[kind]
+        # With no live link, Device1.Connect is the broadly compatible Classic
+        # bootstrap (Bearer.BREDR1 can be marker-only). Under live LE, using
+        # the targeted Classic method avoids rewriting PreferredBearer and
+        # disturbing ANCS. If that method is marker-only, profile reconnects
+        # still establish their own OBEX transports.
+        if kind == "bredr":
+            interface = (
+                _INTERFACES["bredr"]
+                if self.le_connected
+                else "org.bluez.Device1"
+            )
+        else:
+            interface = _INTERFACES[kind]
         bearer = dbus.Interface(
             get_system_bus().get_object("org.bluez", self.device_path),
             interface,

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -105,6 +105,7 @@ class Daemon:
             le_enabled=False,
             on_status=self._emit_status,
             on_le_state=self._observe_le_state,
+            on_le_dial=self.solicitation.set_dialing,
             inbound_le_primed=self.solicitation.active,
         )
         self._contacts_refresh_id: int | None = None

--- a/src/blueferry/solicitation_supervisor.py
+++ b/src/blueferry/solicitation_supervisor.py
@@ -63,6 +63,7 @@ class SolicitationSupervisor:
         self._cancel = cancel
         self._clock = clock
         self._running = False
+        self._dialing = False
         self._timer_id: int | None = None
         self._hold_until = 0.0
 
@@ -89,6 +90,13 @@ class SolicitationSupervisor:
         if needed and changed:
             self._begin_hold()
         if self._running and (changed or needed != self._is_registered()):
+            self._reconcile()
+
+    def set_dialing(self, dialing: bool) -> None:
+        """Keep solicitation off while an outbound LE connect is in flight."""
+        changed = dialing != self._dialing
+        self._dialing = dialing
+        if self._running and changed:
             self._reconcile()
 
     def reset_after_bluez_restart(self) -> None:
@@ -118,6 +126,13 @@ class SolicitationSupervisor:
 
     def _reconcile(self) -> None:
         registered = self._is_registered()
+        if self._dialing:
+            # This safety override deliberately ignores the post-pair minimum
+            # hold. Advertising and initiating an LE connection concurrently
+            # can make BlueZ abort its own outstanding dial.
+            if registered:
+                self._unregister(self.adapter)
+            return
         if self._needed and not registered:
             if not self._register(self.adapter):
                 log.warning(

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -150,6 +150,30 @@ def test_le_can_be_held_until_classic_profile_attempt_finishes() -> None:
     assert connections == ["le"]
 
 
+def test_enabling_le_hands_preference_back_before_any_le_dial() -> None:
+    state = {"bredr": True, "le": False}
+    calls = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        le_enabled=False,
+        read_connected=state.get,
+        prefer=lambda kind: calls.append(("prefer", kind)),
+        connect=lambda kind, on_success, _on_error: (
+            calls.append(("connect", kind)),
+            on_success(),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+
+    supervisor.start()
+    supervisor.enable_le()
+
+    assert calls == [("prefer", "le")]
+    scheduled[-1][1]()
+    assert calls == [("prefer", "le"), ("connect", "le")]
+
+
 def test_le_can_be_held_again_during_a_later_profile_reconnect() -> None:
     state = {"bredr": True, "le": False}
     connections = []
@@ -237,7 +261,7 @@ def test_hold_rejects_an_le_connect_already_in_flight() -> None:
     assert [kind for kind, _callback in connect_callbacks] == ["le", "le"]
 
 
-def test_selects_each_bearer_before_requesting_its_connection() -> None:
+def test_only_untyped_classic_connect_selects_a_preferred_bearer() -> None:
     state = {"bredr": False, "le": False}
     calls = []
     scheduled = []
@@ -258,7 +282,59 @@ def test_selects_each_bearer_before_requesting_its_connection() -> None:
     state["bredr"] = True
     scheduled[0][1]()
     scheduled[1][1]()
-    assert calls[-2:] == [("prefer", "le"), ("connect", "le")]
+    assert calls == [
+        ("prefer", "bredr"),
+        ("connect", "bredr"),
+        ("connect", "le"),
+    ]
+
+
+def test_live_le_dials_classic_without_rewriting_preference() -> None:
+    calls = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=lambda kind: {"bredr": False, "le": True}[kind],
+        prefer=lambda kind: calls.append(("prefer", kind)),
+        connect=lambda kind, *_args: calls.append(("connect", kind)),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+
+    supervisor.start()
+    scheduled[0][1]()
+
+    assert calls == [("connect", "bredr")]
+
+
+def test_unknown_le_state_delays_classic_fallback_after_le_is_enabled() -> None:
+    calls = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=lambda kind: {"bredr": False, "le": None}[kind],
+        prefer=lambda kind: calls.append(("prefer", kind)),
+        connect=lambda kind, *_args: calls.append(("connect", kind)),
+        schedule=lambda _delay, _callback: 7,
+    )
+
+    supervisor.start()
+
+    assert calls == []
+
+
+def test_initial_profile_gate_allows_classic_with_no_le_interface() -> None:
+    calls = []
+    supervisor = BearerSupervisor(
+        "/device",
+        le_enabled=False,
+        read_connected=lambda kind: {"bredr": False, "le": None}[kind],
+        prefer=lambda kind: calls.append(("prefer", kind)),
+        connect=lambda kind, *_args: calls.append(("connect", kind)),
+        schedule=lambda _delay, _callback: 7,
+    )
+
+    supervisor.start()
+
+    assert calls == [("prefer", "bredr"), ("connect", "bredr")]
 
 
 def test_bluez_preference_selects_requested_bearer(monkeypatch) -> None:
@@ -289,6 +365,38 @@ def test_bluez_preference_selects_requested_bearer(monkeypatch) -> None:
         ("org.bluez", "/device"),
         ("interface", "org.freedesktop.DBus.Properties"),
         ("org.bluez.Device1", "PreferredBearer", "le", 5.0),
+    ]
+
+
+def test_bluez_targets_classic_bearer_when_le_is_live(monkeypatch) -> None:
+    calls = []
+
+    class Bearer:
+        @staticmethod
+        def Connect(**kwargs):
+            calls.append(("connect", kwargs["timeout"]))
+
+    class Bus:
+        @staticmethod
+        def get_object(service, path):
+            calls.append((service, path))
+            return object()
+
+    monkeypatch.setattr(bearer_supervisor, "get_system_bus", Bus)
+    monkeypatch.setattr(
+        bearer_supervisor.dbus,
+        "Interface",
+        lambda _object, interface: calls.append(("interface", interface)) or Bearer(),
+    )
+    supervisor = BearerSupervisor("/device")
+    supervisor._states["le"] = True
+
+    supervisor._connect_bluez("bredr", lambda: None, lambda _error: None)
+
+    assert calls == [
+        ("org.bluez", "/device"),
+        ("interface", "org.bluez.Bearer.BREDR1"),
+        ("connect", 45.0),
     ]
 
 
@@ -482,9 +590,10 @@ def test_backoff_resets_once_the_bearer_connects() -> None:
     assert attempts == ["bredr", "bredr"]
 
 
-def test_returning_le_link_clears_classic_absence_backoff() -> None:
+def test_returning_le_link_retries_classic_without_rewriting_preference() -> None:
     state = {"bredr": False, "le": False}
     attempts = []
+    preferences = []
     scheduled = []
     now = 0.0
 
@@ -496,21 +605,24 @@ def test_returning_le_link_clears_classic_absence_backoff() -> None:
         "/device",
         read_connected=state.get,
         connect=connect,
+        prefer=preferences.append,
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
         clock=lambda: now,
     )
     supervisor.start()
     assert attempts == ["bredr"]
 
-    # The old retry is ten seconds away, but an inbound LE link proves that
-    # the phone has returned and makes Classic retry on this health tick.
+    # The old retry is ten seconds away. Live LE clears that penalty and the
+    # targeted Classic retry may run, but it must not change PreferredBearer
+    # underneath the working ANCS link.
     state["le"] = True
     scheduled[0][1]()
 
     assert attempts == ["bredr", "bredr"]
+    assert preferences == ["bredr"]
 
 
-def test_live_le_bounds_classic_backoff() -> None:
+def test_live_le_keeps_targeted_classic_fallback_bounded() -> None:
     state = {"bredr": False, "le": True}
     attempts = []
     scheduled = []
@@ -535,6 +647,52 @@ def test_live_le_bounds_classic_backoff() -> None:
 
     assert attempts == ["bredr"] * 5
     assert supervisor._next_attempt["bredr"] == 120.0
+
+
+def test_le_dial_pauses_solicitation_until_async_reply() -> None:
+    state = {"bredr": True, "le": False}
+    connect_callbacks = []
+    dial_states = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, on_error: connect_callbacks.append(
+            (kind, on_success, on_error)
+        ),
+        on_le_dial=dial_states.append,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    supervisor.start()
+
+    scheduled[0][1]()
+    assert [item[0] for item in connect_callbacks] == ["le"]
+    assert dial_states == [True]
+
+    connect_callbacks[0][1]()
+    assert dial_states == [True, False]
+
+
+def test_le_dial_restores_solicitation_after_failure() -> None:
+    state = {"bredr": True, "le": False}
+    connect_callbacks = []
+    dial_states = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, on_error: connect_callbacks.append(
+            (kind, on_success, on_error)
+        ),
+        on_le_dial=dial_states.append,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    supervisor.start()
+
+    scheduled[0][1]()
+    connect_callbacks[0][2](RuntimeError("no route"))
+
+    assert dial_states == [True, False]
 
 
 def test_le_outbound_dial_is_spent_once_then_solicitation_takes_over() -> None:
@@ -831,7 +989,7 @@ def test_bluez_restart_rejects_new_le_link_while_profile_gate_is_closed() -> Non
     supervisor.reset_after_bluez_restart()
 
     assert disconnects == ["le"]
-    assert connections == ["bredr"]
+    assert connections == []
     assert observed == [True, None]
 
 

--- a/tests/test_solicitation_supervisor.py
+++ b/tests/test_solicitation_supervisor.py
@@ -90,6 +90,43 @@ def test_healthy_ancs_keeps_post_pair_solicitation_for_permission_window() -> No
     assert calls[-1] == ("unregister", "hci7")
 
 
+def test_outbound_dial_withdraws_and_then_restores_solicitation() -> None:
+    calls = []
+    state = {"registered": False}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+    supervisor.start()
+
+    supervisor.set_dialing(True)
+    assert calls[-1] == ("unregister", "hci7")
+    assert supervisor.active() is False
+
+    supervisor.set_dialing(False)
+    assert calls[-1] == ("register", "hci7")
+    assert supervisor.active() is True
+
+
+def test_solicitation_stays_withdrawn_when_need_changes_during_dial() -> None:
+    calls = []
+    state = {"registered": False}
+    scheduled = []
+    supervisor = _supervisor(calls, state, scheduled)
+    supervisor.start()
+    supervisor.set_dialing(True)
+
+    supervisor.set_needed(False)
+    supervisor.set_needed(True)
+
+    assert state["registered"] is False
+    assert calls == [
+        ("register", "hci7"),
+        ("unregister", "hci7"),
+    ]
+
+    supervisor.set_dialing(False)
+    assert calls[-1] == ("register", "hci7")
+
+
 def test_bluez_restart_forgets_registration_and_primes_inbound_le() -> None:
     calls = []
     state = {"registered": False}


### PR DESCRIPTION
## Summary

- avoid rewriting `PreferredBearer` underneath live or in-flight LE connections
- use targeted `Bearer.BREDR1.Connect` for Classic recovery while LE is live, preserving ANCS
- hand bearer preference back to LE after the MAP/PBAP-first window
- withdraw ANCS solicitation while an outbound LE dial is outstanding, then restore it on completion or failure
- retain the existing Classic-only and one-shot LE fallback behavior

## Why

Changing `PreferredBearer` during a live LE link can tear down ANCS, while advertising ANCS solicitation during an asynchronous LE dial can make BlueZ abort its own connection attempt. The two reconnect mechanisms now have explicit ownership instead of racing each other.

## Testing

- `785 passed` in the hermetic D-Bus test suite
- `ruff check .`
- `mypy src/blueferry`
- `bandit -r src/blueferry -q`

A synthetic merge with #98 completes cleanly and the PRs have no overlapping files.