### PR TITLE
Build Python 3.15 RPMs for Fedora 45

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -243,9 +243,19 @@ jobs:
           smoke_tui blueferry tui
 
   build-rpm:
-    name: Build Fedora RPMs
+    name: Build ${{ matrix.name }} RPMs
     runs-on: ubuntu-latest
-    container: fedora:43
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Fedora 43
+            image: fedora:43
+            artifact: packages-rpm-fc43
+          - name: Fedora 45
+            image: fedora:45
+            artifact: packages-rpm-fc45
     steps:
       - name: Install package tools
         run: dnf install -y dnf-plugins-core git rpm-build
@@ -279,12 +289,12 @@ jobs:
           smoke_tui blueferry tui
       - uses: actions/upload-artifact@v4
         with:
-          name: packages-rpm
+          name: ${{ matrix.artifact }}
           path: dist/rpm/*.rpm
           if-no-files-found: error
 
   test-rpm:
-    name: Install Fedora 43 artifacts on ${{ matrix.name }}
+    name: Install matching RPMs on ${{ matrix.name }}
     needs: build-rpm
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
@@ -294,12 +304,17 @@ jobs:
         include:
           - name: Fedora 43
             image: fedora:43
+            artifact: packages-rpm-fc43
           - name: Fedora 44
             image: fedora:44
+            artifact: packages-rpm-fc43
+          - name: Fedora 45
+            image: fedora:45
+            artifact: packages-rpm-fc45
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: packages-rpm
+          name: ${{ matrix.artifact }}
           path: packages
       - name: Install and smoke-test the exact Fedora artifacts
         run: |

--- a/README.md
+++ b/README.md
@@ -58,17 +58,20 @@ install them with apt:
 sudo apt install ./blueferry-backend_*.deb ./blueferry-gtk_*.deb
 ```
 
-For Fedora, download the `.noarch.rpm` files and install them with dnf:
+For Fedora, download the `.noarch.rpm` files whose `.fcNN` tag matches your
+Fedora release, then install them with dnf:
 
 ```bash
-sudo dnf install ./blueferry-backend-*.noarch.rpm ./blueferry-gtk-*.noarch.rpm
+fedora_release=$(rpm -E %fedora)
+sudo dnf install ./blueferry-backend-*.fc${fedora_release}.noarch.rpm \
+  ./blueferry-gtk-*.fc${fedora_release}.noarch.rpm
 ```
 
 Replace the GTK package with `blueferry-qt` for KDE Plasma. Arch and CachyOS
 also provide `blueferry-quickshell`. The tested matrix currently covers Arch
 Linux, CachyOS, Debian 13, Ubuntu 24.04 and 26.04, Linux Mint 22.3, Pop!_OS
-24.04, PikaOS IV, and Fedora 43 and 44. Ubuntu 24.04, Mint, and Pop!_OS do not
-provide necessary Qt dependencies, so use the GTK or terminal client there.
+24.04, PikaOS IV, and Fedora 43, 44, and 45. Ubuntu 24.04, Mint, and Pop!_OS do
+not provide necessary Qt dependencies, so use the GTK or terminal client there.
 
 Arch and Fedora packages set up the newer Bluetooth support needed for iPhone
 system notifications. Debian-family packages do not change or restart

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -10,7 +10,7 @@ described below.
 | `arch/PKGBUILD` | Arch Linux, CachyOS | backend with TUI, GTK, Qt, Quickshell |
 | `deb/` | Debian 13, Ubuntu 26.04, PikaOS IV | MAP/PBAP backend with TUI, GTK, Qt |
 | `deb/` | Ubuntu 24.04, Linux Mint 22.3, Pop!_OS 24.04 | MAP/PBAP backend with TUI, GTK |
-| `rpm/blueferry.spec` | Fedora 43, Fedora 44 | backend with TUI, GTK, Qt |
+| `rpm/blueferry.spec` | Fedora 43, Fedora 44, Fedora 45 | backend with TUI, GTK, Qt |
 
 The matrix tests current package ecosystems rather than claiming that one
 artifact works forever. Arch and CachyOS are rolling releases, and PikaOS IV
@@ -31,8 +31,12 @@ system Bluetooth service.
 openSUSE is the next sensible RPM target. Rocky Linux and AlmaLinux are popular
 RPM server distributions, but they are less relevant to a Bluetooth desktop
 application and their conservative stacks are a poor initial compatibility
-target. Fedora derivatives may accept the Fedora RPM, but they are not claimed
-as tested until they are present in the matrix.
+target. Fedora RPMs remain tied to the Python ABI they were built with even
+though they are CPU-independent `noarch` packages. CI therefore builds an
+`.fc43` set for Fedora 43 and 44, which share Python 3.14, and a separate
+`.fc45` set for Fedora 45 and Python 3.15. Fedora derivatives may accept the
+matching Fedora RPM, but they are not claimed as tested until they are present
+in the matrix.
 
 Arch uses its native `python-textual` package. DEB and RPM repositories do not
 provide a sufficiently recent Textual, so those backend packages contain a

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -1,9 +1,10 @@
 # Fedora RPM packages
 
 This spec builds `blueferry-backend`, `blueferry-gtk`, and `blueferry-qt`
-using only Fedora repository dependencies. Package CI builds it on the current
-older supported Fedora release, then installs those exact RPMs on both current
-Fedora releases.
+using only Fedora repository dependencies. Package CI builds one artifact set
+for each Python ABI in the supported Fedora releases, then installs each exact
+set on the compatible releases. The `.fc43` packages cover Fedora 43 and 44;
+Fedora 45 gets separate `.fc45` packages because it uses Python 3.15.
 The backend requires BlueZ 5.86 or newer because that is the first upstream
 release with working per-bearer connection methods.
 
@@ -22,6 +23,10 @@ preferred graphical client, for example:
 sudo dnf install dist/rpm/blueferry-backend-*.noarch.rpm \
   dist/rpm/blueferry-gtk-*.noarch.rpm
 ```
+
+`noarch` means the package contains no CPU-specific machine code; it does not
+make Python installation paths or dependencies ABI-independent. Release RPMs
+must therefore have the `.fcNN` tag matching the installed Fedora release.
 
 `blueferry-backend` includes the `blueferry-tui` command and a pinned private
 Textual 8 runtime under `/usr/lib/blueferry/vendor`. The package build is offline: its

--- a/tests/test_native_packaging.py
+++ b/tests/test_native_packaging.py
@@ -264,6 +264,7 @@ def test_package_workflow_installs_identical_artifacts_on_targets() -> None:
         "Pop!_OS 24.04",
         "Fedora 43",
         "Fedora 44",
+        "Fedora 45",
     ):
         assert target in workflow
     assert "cachyos/cachyos:latest" in workflow
@@ -271,7 +272,9 @@ def test_package_workflow_installs_identical_artifacts_on_targets() -> None:
     assert "http://apt.pop-os.org/release noble main" in workflow
     assert "name: packages-arch" in workflow
     assert "name: packages-deb" in workflow
-    assert "name: packages-rpm" in workflow
+    assert "artifact: packages-rpm-fc43" in workflow
+    assert "artifact: packages-rpm-fc45" in workflow
+    assert "name: ${{ matrix.artifact }}" in workflow
     assert "Smoke-test the Arch backend and bundled TUI" in workflow
     assert "install the blueferry-tui package" not in workflow
     assert workflow.count("smoke_tui blueferry-tui") == 6


### PR DESCRIPTION
## Summary

- build RPM artifacts independently on Fedora 43 and Fedora 45
- use the `.fc43` packages for Fedora 43/44 and `.fc45` packages for Fedora 45
- test each Fedora release against only its Python-ABI-compatible artifact set
- publish both RPM sets on tagged releases
- document why `noarch` RPMs still require a matching Fedora/Python ABI

## Why

Fedora 45 uses Python 3.15, so the existing Fedora 43 package carries incompatible `python(abi) = 3.14` and `python3.14dist(...)` requirements. Rebuilding the same spec in Fedora 45 naturally produces the correct Python 3.15 paths and dependencies.

Closes #99.

## Testing

- `776 passed` in the hermetic D-Bus test suite
- `pytest -q tests/test_native_packaging.py`
- workflow YAML parsed successfully
- `ruff check .`
- `mypy src/blueferry`
- `bandit -r src/blueferry -q`
- confirmed the published `fedora:45` multi-architecture image manifest