### PR TITLE
Fix Bluetooth bearer reconnect follow-up races

### DIFF
--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -149,9 +149,12 @@ class BearerSupervisor:
         self._running = False
         self._generation = 0
         self._connecting: set[str] = set()
+        self._connect_observation_pending: set[str] = set()
         self._disconnecting: set[str] = set()
         self._le_hold_disconnect_pending = False
+        self._unpublished_le_live = False
         self._le_dial_active = False
+        self._le_preference_restore_pending = False
         # Outbound Bearer.LE1.Connect is only a bootstrap hint.  Real-device
         # traces show the solicitation advertisement to be the reliable
         # reconnect path, while repeating Connect can leave BlueZ in an
@@ -197,19 +200,14 @@ class BearerSupervisor:
         self._le_enabled = True
         self._le_hold_disconnect_pending = False
         log.info("MAP/PBAP attempt completed; enabling iPhone LE bearer")
-        if self._states["le"] is not True and "le" not in self._connecting:
+        if self._states["le"] is not True:
             # Pairing deliberately leaves the untyped Device1.Connect path on
             # BR/EDR while MAP/PBAP get their first turn. Hand inbound control
             # back once here, before either an LE dial or a solicited link is
             # in flight. Bearer.LE1.Connect already names its transport and
             # must not rewrite PreferredBearer underneath itself.
-            try:
-                self._prefer("le")
-            except Exception as error:
-                log.warning(
-                    "could not hand PreferredBearer to inbound LE: %s",
-                    error,
-                )
+            self._le_preference_restore_pending = True
+            self._restore_le_preference()
         if self._running:
             self._tick()
 
@@ -240,11 +238,14 @@ class BearerSupervisor:
         previous = dict(self._states)
         self._generation += 1
         self._connecting.clear()
+        self._connect_observation_pending.clear()
         self._disconnecting.clear()
         self._set_le_dial_active(False)
         # The old owner's live link is gone. While the profile gate is closed,
         # reject any LE link that appears under the replacement owner.
         self._le_hold_disconnect_pending = not self._le_enabled
+        self._unpublished_le_live = False
+        self._le_preference_restore_pending = False
         self._le_dial_spent = False
         self._le_reset_pending = False
         self._le_reset_failures = 0
@@ -283,9 +284,12 @@ class BearerSupervisor:
         self._running = False
         self._generation += 1
         self._connecting.clear()
+        self._connect_observation_pending.clear()
         self._disconnecting.clear()
         self._set_le_dial_active(False)
         self._le_hold_disconnect_pending = False
+        self._unpublished_le_live = False
+        self._le_preference_restore_pending = False
         self._le_dial_spent = False
         self._le_reset_pending = False
         self._cancel_le_settle()
@@ -320,16 +324,26 @@ class BearerSupervisor:
 
         if not self._le_enabled and le is False:
             self._le_hold_disconnect_pending = True
-        if not self._le_enabled and self._le_hold_disconnect_pending and le is True:
+        if (
+            not self._le_enabled
+            and self._le_hold_disconnect_pending
+            and (le is True or (self._unpublished_le_live and le is None))
+        ):
             # Do not publish the transient link to ANCS. It was missing when
             # the profile gate closed, so allowing it to become usable here
             # would put GATT ahead of the MAP/PBAP attempt again.
+            self._settle_in_progress_connect("le", le)
+            if le is True:
+                self._unpublished_le_live = True
             self._request_le_disconnect(force=True)
-            # Wait for the targeted LE teardown before selecting BR/EDR. A
-            # PreferredBearer write here would race the still-live LE link we
-            # just asked BlueZ to remove.
+            if bredr is False:
+                # Bearer.BREDR1.Connect is transport-specific, so Classic may
+                # recover while the unpublished LE teardown is outstanding
+                # without a PreferredBearer write racing either operation.
+                self._request_connect("bredr")
             return True
         else:
+            self._unpublished_le_live = False
             self._update_state("le", le)
 
         if self._le_reset_pending and self._le_enabled:
@@ -351,7 +365,9 @@ class BearerSupervisor:
         if bredr is False:
             self._request_connect("bredr")
         elif bredr is True and le is False and self._le_enabled:
-            self._schedule_le_connect()
+            self._restore_le_preference()
+            if "bredr" not in self._connecting:
+                self._schedule_le_connect()
         elif le is True:
             self._cancel_le_settle()
         return True
@@ -403,6 +419,7 @@ class BearerSupervisor:
             return None
 
     def _update_state(self, kind: str, value: bool | None) -> None:
+        self._settle_in_progress_connect(kind, value)
         previous = self._states[kind]
         self._states[kind] = value
         if previous != value:
@@ -447,6 +464,8 @@ class BearerSupervisor:
             return
         if kind == "bredr" and "le" in self._connecting:
             return
+        if kind == "le" and "bredr" in self._connecting:
+            return
         if (
             kind == "bredr"
             and self._le_enabled
@@ -467,12 +486,16 @@ class BearerSupervisor:
         log.info("connecting iPhone %s bearer", kind.upper())
         try:
             if kind == "bredr":
-                if self._states["le"] is not True:
+                if (
+                    self._states["le"] is not True
+                    and not self._unpublished_le_live
+                ):
                     # Device1.Connect is transport-agnostic, so select Classic
                     # only when no LE link is live. With live LE,
                     # _connect_bluez uses targeted Bearer.BREDR1.Connect and
                     # leaves the preference untouched.
                     self._prefer("bredr")
+                    self._le_preference_restore_pending = True
             else:
                 # Advertising while this asynchronous call is outstanding can
                 # abort the dial locally. The daemon withdraws solicitation
@@ -490,9 +513,12 @@ class BearerSupervisor:
         if generation != self._generation:
             return
         self._connecting.discard(kind)
+        self._connect_observation_pending.discard(kind)
         if kind == "le":
             self._set_le_dial_active(False)
         self._last_errors.pop(kind, None)
+        if kind == "bredr":
+            self._restore_le_preference()
         if kind == "le" and not self._le_enabled:
             self._le_hold_disconnect_pending = True
             self._le_dial_spent = False
@@ -522,21 +548,30 @@ class BearerSupervisor:
     def _connect_failed(self, kind: str, error: Exception, generation: int) -> None:
         if generation != self._generation:
             return
+        name, message = _connect_error_parts(error)
+        if name == "org.bluez.Error.InProgress":
+            # BlueZ still owns a connect attempt. Keep solicitation withdrawn
+            # and keep this bearer in _connecting until a later health read
+            # observes either the resulting link or a settled false state.
+            self._connect_observation_pending.add(kind)
+            if kind == "le":
+                # This call overlapped an existing attempt; it did not consume
+                # this presence generation's one outbound bootstrap.
+                self._le_dial_spent = False
+            log.debug("%s bearer connection is still in progress", kind.upper())
+            return
+        if name == "org.bluez.Error.AlreadyConnected":
+            log.debug("%s bearer connection already active", kind.upper())
+            self._connect_succeeded(kind, generation)
+            return
         self._connecting.discard(kind)
+        self._connect_observation_pending.discard(kind)
         if kind == "le":
             self._set_le_dial_active(False)
         if kind == "le" and not self._le_enabled:
             # Policy closed the gate while the asynchronous request was in
             # flight.  This generation never received its permitted attempt.
             self._le_dial_spent = False
-            return
-        name, message = _connect_error_parts(error)
-        if name in {
-            "org.bluez.Error.AlreadyConnected",
-            "org.bluez.Error.InProgress",
-        }:
-            log.debug("%s bearer connection already active", kind.upper())
-            self._connect_succeeded(kind, generation)
             return
         self._failures[kind] += 1
         delay = min(
@@ -553,6 +588,46 @@ class BearerSupervisor:
                 delay,
             )
             self._last_errors[kind] = (name, message)
+
+    def _settle_in_progress_connect(self, kind: str, value: bool | None) -> None:
+        """Resolve an InProgress reply only from a later concrete state read."""
+        if kind not in self._connect_observation_pending or value is None:
+            return
+        self._connect_observation_pending.discard(kind)
+        self._connecting.discard(kind)
+        if kind == "le":
+            self._set_le_dial_active(False)
+        if value is False:
+            # Do not issue another request in the same health tick that proved
+            # the old attempt settled. The one-shot itself remains available.
+            self._next_attempt[kind] = max(
+                self._next_attempt[kind],
+                self._clock() + POLL_SECONDS,
+            )
+        log.debug(
+            "%s bearer InProgress state settled as %s",
+            kind.upper(),
+            "connected" if value else "disconnected",
+        )
+
+    def _restore_le_preference(self) -> None:
+        """Hand untyped connects back to inbound LE once Classic is settled."""
+        if (
+            not self._le_preference_restore_pending
+            or not self._le_enabled
+            or self._states["le"] is True
+            or self._connecting
+        ):
+            return
+        try:
+            self._prefer("le")
+        except Exception as error:
+            log.warning(
+                "could not hand PreferredBearer to inbound LE: %s",
+                error,
+            )
+            return
+        self._le_preference_restore_pending = False
 
     def _le_dial_exhausted(self) -> bool:
         """Yield to inbound solicitation only when it is actually on air."""
@@ -682,7 +757,7 @@ class BearerSupervisor:
         if kind == "bredr":
             interface = (
                 _INTERFACES["bredr"]
-                if self.le_connected
+                if self.le_connected or self._unpublished_le_live
                 else "org.bluez.Device1"
             )
         else:

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -398,6 +398,12 @@ class BearerSupervisor:
         self._update_state("bredr", bredr)
         self._update_state("le", le)
         if bredr is True and le is False and self._le_enabled:
+            # The handoff may have failed when LE was enabled or when this
+            # timer was armed. Retry at the last safe point before the
+            # targeted dial; a transient Set failure must not suppress the
+            # one outbound bootstrap, and the pending flag remains set so a
+            # later Classic-up/LE-down tick can try again.
+            self._restore_le_preference()
             self._request_connect("le")
         elif bredr is False:
             self._request_connect("bredr")

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -17,6 +17,10 @@ log = logging.getLogger(__name__)
 
 POLL_SECONDS = 5
 CLASSIC_SETTLE_SECONDS = 3
+# org.bluez.Bearer*.Connect uses this same timeout below. An InProgress reply
+# means BlueZ owns an overlapping request, so Connected=false cannot settle it
+# before a full method-timeout-sized quiet window has elapsed.
+CONNECT_TIMEOUT_SECONDS = 45
 # A phone that rejects a connection keeps rejecting it for a while (powered
 # off, out of range, or a broken bond). Repeating Connect every poll turned
 # into a five-second hammer against the iPhone; back off exponentially
@@ -149,7 +153,7 @@ class BearerSupervisor:
         self._running = False
         self._generation = 0
         self._connecting: set[str] = set()
-        self._connect_observation_pending: set[str] = set()
+        self._connect_observation_deadlines: dict[str, float] = {}
         self._disconnecting: set[str] = set()
         self._le_hold_disconnect_pending = False
         self._unpublished_le_live = False
@@ -238,7 +242,7 @@ class BearerSupervisor:
         previous = dict(self._states)
         self._generation += 1
         self._connecting.clear()
-        self._connect_observation_pending.clear()
+        self._connect_observation_deadlines.clear()
         self._disconnecting.clear()
         self._set_le_dial_active(False)
         # The old owner's live link is gone. While the profile gate is closed,
@@ -284,7 +288,7 @@ class BearerSupervisor:
         self._running = False
         self._generation += 1
         self._connecting.clear()
-        self._connect_observation_pending.clear()
+        self._connect_observation_deadlines.clear()
         self._disconnecting.clear()
         self._set_le_dial_active(False)
         self._le_hold_disconnect_pending = False
@@ -333,8 +337,9 @@ class BearerSupervisor:
             # the profile gate closed, so allowing it to become usable here
             # would put GATT ahead of the MAP/PBAP attempt again.
             self._settle_in_progress_connect("le", le)
-            if le is True:
+            if le is True and not self._unpublished_le_live:
                 self._unpublished_le_live = True
+                self._reset_classic_backoff_from_le()
             self._request_le_disconnect(force=True)
             if bredr is False:
                 # Bearer.BREDR1.Connect is transport-specific, so Classic may
@@ -448,9 +453,7 @@ class BearerSupervisor:
         if kind == "le" and value is True and previous is not True:
             # An inbound LE connection is the missing presence event for a
             # Classic backoff accumulated while the phone was out of range.
-            self._last_errors.pop("bredr", None)
-            self._failures["bredr"] = 0
-            self._next_attempt["bredr"] = 0.0
+            self._reset_classic_backoff_from_le()
         # Repeating stale Connected=true after a failed GATT operation can
         # race BlueZ's pending CCC registration with ATT teardown. Consumers
         # therefore receive only genuine bearer lifecycle transitions.
@@ -513,7 +516,7 @@ class BearerSupervisor:
         if generation != self._generation:
             return
         self._connecting.discard(kind)
-        self._connect_observation_pending.discard(kind)
+        self._connect_observation_deadlines.pop(kind, None)
         if kind == "le":
             self._set_le_dial_active(False)
         self._last_errors.pop(kind, None)
@@ -551,13 +554,13 @@ class BearerSupervisor:
         name, message = _connect_error_parts(error)
         if name == "org.bluez.Error.InProgress":
             # BlueZ still owns a connect attempt. Keep solicitation withdrawn
-            # and keep this bearer in _connecting until a later health read
-            # observes either the resulting link or a settled false state.
-            self._connect_observation_pending.add(kind)
-            if kind == "le":
-                # This call overlapped an existing attempt; it did not consume
-                # this presence generation's one outbound bootstrap.
-                self._le_dial_spent = False
+            # and keep this bearer in _connecting until Connected=true or a
+            # full Connect-sized timeout. Connected=false is normal while the
+            # overlapping operation is still running and proves nothing.
+            self._connect_observation_deadlines.setdefault(
+                kind,
+                self._clock() + CONNECT_TIMEOUT_SECONDS,
+            )
             log.debug("%s bearer connection is still in progress", kind.upper())
             return
         if name == "org.bluez.Error.AlreadyConnected":
@@ -565,7 +568,7 @@ class BearerSupervisor:
             self._connect_succeeded(kind, generation)
             return
         self._connecting.discard(kind)
-        self._connect_observation_pending.discard(kind)
+        self._connect_observation_deadlines.pop(kind, None)
         if kind == "le":
             self._set_le_dial_active(False)
         if kind == "le" and not self._le_enabled:
@@ -590,25 +593,41 @@ class BearerSupervisor:
             self._last_errors[kind] = (name, message)
 
     def _settle_in_progress_connect(self, kind: str, value: bool | None) -> None:
-        """Resolve an InProgress reply only from a later concrete state read."""
-        if kind not in self._connect_observation_pending or value is None:
+        """Resolve InProgress on connection or after a method-sized timeout."""
+        deadline = self._connect_observation_deadlines.get(kind)
+        if deadline is None:
             return
-        self._connect_observation_pending.discard(kind)
+        connected = value is True
+        if not connected and self._clock() < deadline:
+            return
+        self._connect_observation_deadlines.pop(kind, None)
         self._connecting.discard(kind)
         if kind == "le":
             self._set_le_dial_active(False)
-        if value is False:
-            # Do not issue another request in the same health tick that proved
-            # the old attempt settled. The one-shot itself remains available.
-            self._next_attempt[kind] = max(
-                self._next_attempt[kind],
-                self._clock() + POLL_SECONDS,
-            )
-        log.debug(
-            "%s bearer InProgress state settled as %s",
-            kind.upper(),
-            "connected" if value else "disconnected",
+        if connected:
+            log.debug("%s bearer InProgress state connected", kind.upper())
+            return
+
+        # The operation remained down for a full BlueZ Connect timeout. Count
+        # that as a failure so Classic observes normal exponential backoff.
+        # LE deliberately keeps its one-shot spent and yields to solicitation.
+        self._failures[kind] += 1
+        delay = min(
+            POLL_SECONDS * (2 ** self._failures[kind]),
+            self._backoff_cap(kind),
         )
+        self._next_attempt[kind] = self._clock() + delay
+        log.debug(
+            "%s bearer InProgress state timed out; next attempt in %ds",
+            kind.upper(),
+            delay,
+        )
+
+    def _reset_classic_backoff_from_le(self) -> None:
+        """Treat any live LE link as proof that the phone is in range."""
+        self._last_errors.pop("bredr", None)
+        self._failures["bredr"] = 0
+        self._next_attempt["bredr"] = 0.0
 
     def _restore_le_preference(self) -> None:
         """Hand untyped connects back to inbound LE once Classic is settled."""
@@ -651,7 +670,7 @@ class BearerSupervisor:
             log.info("re-arming outbound iPhone LE bootstrap: %s", reason)
 
     def _backoff_cap(self, kind: str) -> int:
-        if kind == "bredr" and self.le_connected:
+        if kind == "bredr" and (self.le_connected or self._unpublished_le_live):
             return LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS
         return BACKOFF_CAP_SECONDS
 
@@ -769,7 +788,7 @@ class BearerSupervisor:
         bearer.Connect(
             reply_handler=on_success,
             error_handler=on_error,
-            timeout=45.0,
+            timeout=float(CONNECT_TIMEOUT_SECONDS),
         )
 
     def _disconnect_bluez(

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -823,7 +823,13 @@ def test_le_in_progress_keeps_solicitation_paused_until_connected() -> None:
 
     assert dial_states == [True]
     assert "le" in supervisor._connecting
-    assert supervisor._le_dial_spent is False
+    assert supervisor._le_dial_spent is True
+
+    # Connected=false is expected while BlueZ still owns the operation. The
+    # ordinary five-second health poll must not reopen solicitation.
+    health_check()
+    assert dial_states == [True]
+    assert "le" in supervisor._connecting
 
     state["le"] = True
     health_check()
@@ -832,7 +838,7 @@ def test_le_in_progress_keeps_solicitation_paused_until_connected() -> None:
     assert "le" not in supervisor._connecting
 
 
-def test_le_in_progress_settled_false_refunds_and_retries_dial() -> None:
+def test_le_in_progress_times_out_to_solicitation_without_another_dial() -> None:
     import dbus
 
     state = {"bredr": True, "le": False}
@@ -871,20 +877,75 @@ def test_le_in_progress_settled_false_refunds_and_retries_dial() -> None:
     )
     health_check()
 
+    assert dial_states == [True]
+    assert "le" in supervisor._connecting
+    assert supervisor._le_dial_spent is True
+
+    now = bearer_supervisor.CONNECT_TIMEOUT_SECONDS - 1
+    health_check()
+    assert dial_states == [True]
+    assert "le" in supervisor._connecting
+
+    now = bearer_supervisor.CONNECT_TIMEOUT_SECONDS
+    health_check()
     assert dial_states == [True, False]
     assert "le" not in supervisor._connecting
-    assert supervisor._le_dial_spent is False
+    assert supervisor._le_dial_spent is True
+    assert supervisor._failures["le"] == 1
 
-    now = bearer_supervisor.POLL_SECONDS + 1
-    retry = next(
-        callback
-        for delay, callback in reversed(scheduled)
-        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    now = 600.0
+    health_check()
+    assert [item[0] for item in connect_callbacks] == ["le"]
+    assert dial_states == [True, False]
+
+
+def test_classic_in_progress_times_out_with_exponential_backoff() -> None:
+    import dbus
+
+    state = {"bredr": False, "le": False}
+    connect_callbacks = []
+    scheduled = []
+    now = 0.0
+    supervisor = BearerSupervisor(
+        "/device",
+        le_enabled=False,
+        read_connected=state.get,
+        connect=lambda kind, on_success, on_error: connect_callbacks.append(
+            (kind, on_success, on_error)
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
     )
-    retry()
+    supervisor.start()
+    health_check = next(
+        callback
+        for delay, callback in scheduled
+        if delay == bearer_supervisor.POLL_SECONDS
+    )
+    connect_callbacks[0][2](
+        dbus.exceptions.DBusException(
+            "Operation already in progress",
+            name="org.bluez.Error.InProgress",
+        )
+    )
 
-    assert [item[0] for item in connect_callbacks] == ["le", "le"]
-    assert dial_states == [True, False, True]
+    health_check()
+    assert "bredr" in supervisor._connecting
+
+    now = bearer_supervisor.CONNECT_TIMEOUT_SECONDS
+    health_check()
+    assert "bredr" not in supervisor._connecting
+    assert supervisor._failures["bredr"] == 1
+    assert supervisor._next_attempt["bredr"] == 55.0
+    assert [item[0] for item in connect_callbacks] == ["bredr"]
+
+    now = 54.0
+    health_check()
+    assert [item[0] for item in connect_callbacks] == ["bredr"]
+
+    now = 55.0
+    health_check()
+    assert [item[0] for item in connect_callbacks] == ["bredr", "bredr"]
 
 
 def test_le_already_connected_restores_solicitation_immediately() -> None:
@@ -1224,6 +1285,40 @@ def test_bluez_restart_rejects_new_le_link_while_profile_gate_is_closed() -> Non
     supervisor.poke()
     assert preferences == []
     assert supervisor._unpublished_le_live is True
+
+
+def test_unpublished_live_le_resets_and_caps_classic_backoff() -> None:
+    state = {"bredr": True, "le": False}
+    connect_callbacks = []
+    scheduled = []
+    now = 0.0
+    supervisor = BearerSupervisor(
+        "/device",
+        le_enabled=False,
+        read_connected=state.get,
+        connect=lambda kind, _on_success, on_error: connect_callbacks.append(
+            (kind, on_error)
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    supervisor._failures["bredr"] = 6
+    supervisor._next_attempt["bredr"] = 300.0
+
+    state.update(bredr=False, le=True)
+    scheduled[0][1]()
+
+    assert supervisor._unpublished_le_live is True
+    assert supervisor._failures["bredr"] == 0
+    assert supervisor._next_attempt["bredr"] == 0.0
+    assert [kind for kind, _on_error in connect_callbacks] == ["bredr"]
+
+    supervisor._failures["bredr"] = 9
+    connect_callbacks[0][1](RuntimeError("not now"))
+    assert supervisor._next_attempt["bredr"] == (
+        bearer_supervisor.LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS
+    )
 
 
 def test_bluez_restart_discards_callbacks_from_the_previous_owner() -> None:

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -261,7 +261,7 @@ def test_hold_rejects_an_le_connect_already_in_flight() -> None:
     assert [kind for kind, _callback in connect_callbacks] == ["le", "le"]
 
 
-def test_only_untyped_classic_connect_selects_a_preferred_bearer() -> None:
+def test_untyped_classic_connect_restores_le_preference_before_le_dial() -> None:
     state = {"bredr": False, "le": False}
     calls = []
     scheduled = []
@@ -277,7 +277,11 @@ def test_only_untyped_classic_connect_selects_a_preferred_bearer() -> None:
     )
 
     supervisor.start()
-    assert calls == [("prefer", "bredr"), ("connect", "bredr")]
+    assert calls == [
+        ("prefer", "bredr"),
+        ("connect", "bredr"),
+        ("prefer", "le"),
+    ]
 
     state["bredr"] = True
     scheduled[0][1]()
@@ -285,7 +289,59 @@ def test_only_untyped_classic_connect_selects_a_preferred_bearer() -> None:
     assert calls == [
         ("prefer", "bredr"),
         ("connect", "bredr"),
+        ("prefer", "le"),
         ("connect", "le"),
+    ]
+
+    # A later out-of-range cycle repeats the handoff instead of leaving the
+    # idle preference on BR/EDR after its untyped bootstrap.
+    state["bredr"] = False
+    scheduled[0][1]()
+    assert calls[-3:] == [
+        ("prefer", "bredr"),
+        ("connect", "bredr"),
+        ("prefer", "le"),
+    ]
+
+
+def test_enabling_le_waits_for_an_outstanding_classic_connect() -> None:
+    state = {"bredr": False, "le": False}
+    calls = []
+    connect_callbacks = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        le_enabled=False,
+        read_connected=state.get,
+        prefer=lambda kind: calls.append(("prefer", kind)),
+        connect=lambda kind, on_success, _on_error: (
+            calls.append(("connect", kind)),
+            connect_callbacks.append(on_success),
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+
+    supervisor.start()
+    supervisor.enable_le()
+
+    assert calls == [("prefer", "bredr"), ("connect", "bredr")]
+    state["bredr"] = True
+    supervisor.poke()
+    assert [delay for delay, _callback in scheduled] == [
+        bearer_supervisor.POLL_SECONDS
+    ]
+
+    connect_callbacks[0]()
+    assert calls == [
+        ("prefer", "bredr"),
+        ("connect", "bredr"),
+        ("prefer", "le"),
+    ]
+
+    supervisor.poke()
+    assert [delay for delay, _callback in scheduled] == [
+        bearer_supervisor.POLL_SECONDS,
+        bearer_supervisor.CLASSIC_SETTLE_SECONDS,
     ]
 
 
@@ -390,6 +446,40 @@ def test_bluez_targets_classic_bearer_when_le_is_live(monkeypatch) -> None:
     )
     supervisor = BearerSupervisor("/device")
     supervisor._states["le"] = True
+
+    supervisor._connect_bluez("bredr", lambda: None, lambda _error: None)
+
+    assert calls == [
+        ("org.bluez", "/device"),
+        ("interface", "org.bluez.Bearer.BREDR1"),
+        ("connect", 45.0),
+    ]
+
+
+def test_bluez_targets_classic_bearer_when_live_le_is_unpublished(
+    monkeypatch,
+) -> None:
+    calls = []
+
+    class Bearer:
+        @staticmethod
+        def Connect(**kwargs):
+            calls.append(("connect", kwargs["timeout"]))
+
+    class Bus:
+        @staticmethod
+        def get_object(service, path):
+            calls.append((service, path))
+            return object()
+
+    monkeypatch.setattr(bearer_supervisor, "get_system_bus", Bus)
+    monkeypatch.setattr(
+        bearer_supervisor.dbus,
+        "Interface",
+        lambda _object, interface: calls.append(("interface", interface)) or Bearer(),
+    )
+    supervisor = BearerSupervisor("/device")
+    supervisor._unpublished_le_live = True
 
     supervisor._connect_bluez("bredr", lambda: None, lambda _error: None)
 
@@ -695,6 +785,138 @@ def test_le_dial_restores_solicitation_after_failure() -> None:
     assert dial_states == [True, False]
 
 
+def test_le_in_progress_keeps_solicitation_paused_until_connected() -> None:
+    import dbus
+
+    state = {"bredr": True, "le": False}
+    connect_callbacks = []
+    dial_states = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, on_error: connect_callbacks.append(
+            (kind, on_success, on_error)
+        ),
+        on_le_dial=dial_states.append,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    supervisor.start()
+    settle = next(
+        callback
+        for delay, callback in scheduled
+        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    )
+    health_check = next(
+        callback
+        for delay, callback in scheduled
+        if delay == bearer_supervisor.POLL_SECONDS
+    )
+
+    settle()
+    connect_callbacks[0][2](
+        dbus.exceptions.DBusException(
+            "Operation already in progress",
+            name="org.bluez.Error.InProgress",
+        )
+    )
+
+    assert dial_states == [True]
+    assert "le" in supervisor._connecting
+    assert supervisor._le_dial_spent is False
+
+    state["le"] = True
+    health_check()
+
+    assert dial_states == [True, False]
+    assert "le" not in supervisor._connecting
+
+
+def test_le_in_progress_settled_false_refunds_and_retries_dial() -> None:
+    import dbus
+
+    state = {"bredr": True, "le": False}
+    connect_callbacks = []
+    dial_states = []
+    scheduled = []
+    now = 0.0
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda kind, on_success, on_error: connect_callbacks.append(
+            (kind, on_success, on_error)
+        ),
+        on_le_dial=dial_states.append,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    settle = next(
+        callback
+        for delay, callback in scheduled
+        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    )
+    health_check = next(
+        callback
+        for delay, callback in scheduled
+        if delay == bearer_supervisor.POLL_SECONDS
+    )
+
+    settle()
+    connect_callbacks[0][2](
+        dbus.exceptions.DBusException(
+            "Operation already in progress",
+            name="org.bluez.Error.InProgress",
+        )
+    )
+    health_check()
+
+    assert dial_states == [True, False]
+    assert "le" not in supervisor._connecting
+    assert supervisor._le_dial_spent is False
+
+    now = bearer_supervisor.POLL_SECONDS + 1
+    retry = next(
+        callback
+        for delay, callback in reversed(scheduled)
+        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    )
+    retry()
+
+    assert [item[0] for item in connect_callbacks] == ["le", "le"]
+    assert dial_states == [True, False, True]
+
+
+def test_le_already_connected_restores_solicitation_immediately() -> None:
+    import dbus
+
+    connect_callbacks = []
+    dial_states = []
+    scheduled = []
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=lambda kind: {"bredr": True, "le": False}[kind],
+        connect=lambda kind, on_success, on_error: connect_callbacks.append(
+            (kind, on_success, on_error)
+        ),
+        on_le_dial=dial_states.append,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+    supervisor.start()
+    scheduled[0][1]()
+
+    connect_callbacks[0][2](
+        dbus.exceptions.DBusException(
+            "Already connected",
+            name="org.bluez.Error.AlreadyConnected",
+        )
+    )
+
+    assert dial_states == [True, False]
+    assert "le" not in supervisor._connecting
+    assert supervisor._le_dial_spent is True
+
+
 def test_le_outbound_dial_is_spent_once_then_solicitation_takes_over() -> None:
     state = {"bredr": True, "le": False}
     connections = []
@@ -974,11 +1196,13 @@ def test_bluez_restart_rejects_new_le_link_while_profile_gate_is_closed() -> Non
     connections = []
     disconnects = []
     observed = []
+    preferences = []
     supervisor = BearerSupervisor(
         "/device",
         read_connected=state.get,
         connect=lambda kind, _on_success, _on_error: connections.append(kind),
         disconnect=lambda kind, _on_success, _on_error: disconnects.append(kind),
+        prefer=preferences.append,
         on_le_state=observed.append,
         schedule=lambda _delay, _callback: 7,
     )
@@ -989,8 +1213,17 @@ def test_bluez_restart_rejects_new_le_link_while_profile_gate_is_closed() -> Non
     supervisor.reset_after_bluez_restart()
 
     assert disconnects == ["le"]
-    assert connections == []
+    assert connections == ["bredr"]
+    assert preferences == []
     assert observed == [True, None]
+    assert supervisor._unpublished_le_live is True
+
+    # A transient missing property does not forget that teardown is still in
+    # flight and therefore cannot fall back to an untyped Device1.Connect.
+    state["le"] = None
+    supervisor.poke()
+    assert preferences == []
+    assert supervisor._unpublished_le_live is True
 
 
 def test_bluez_restart_discards_callbacks_from_the_previous_owner() -> None:

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -345,6 +345,44 @@ def test_enabling_le_waits_for_an_outstanding_classic_connect() -> None:
     ]
 
 
+def test_le_settle_retries_failed_preference_handoff_without_blocking_dial() -> None:
+    state = {"bredr": True, "le": False}
+    calls = []
+    scheduled = []
+
+    def prefer(kind):
+        calls.append(("prefer", kind))
+        raise RuntimeError("temporary D-Bus failure")
+
+    supervisor = BearerSupervisor(
+        "/device",
+        le_enabled=False,
+        read_connected=state.get,
+        prefer=prefer,
+        connect=lambda kind, _on_success, _on_error: calls.append(
+            ("connect", kind)
+        ),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+    )
+
+    supervisor.start()
+    supervisor.enable_le()
+    settle = next(
+        callback
+        for delay, callback in scheduled
+        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
+    )
+    settle()
+
+    assert calls == [
+        ("prefer", "le"),
+        ("prefer", "le"),
+        ("prefer", "le"),
+        ("connect", "le"),
+    ]
+    assert supervisor._le_preference_restore_pending is True
+
+
 def test_live_le_dials_classic_without_rewriting_preference() -> None:
     calls = []
     scheduled = []


### PR DESCRIPTION
## Summary

- keep the LE dial gate closed after BlueZ reports InProgress until the bearer connects or a Connect-sized timeout expires
- preserve the LE one-shot for solicitation after timeout and apply exponential backoff to Classic retries
- restore PreferredBearer=le after untyped Classic bootstrap, retrying the handoff before the LE hint without making it a dial prerequisite
- recover Classic through Bearer.BREDR1 while an unpublished LE link is being torn down, with the normal in-range backoff reset and cap

## Validation

- pytest -q (793 passed, 3 skipped)
- ruff check .
- mypy src/blueferry