### PR TITLE
Accept inbound ANCS links during Classic recovery

### DIFF
--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -155,8 +155,6 @@ class BearerSupervisor:
         self._connecting: set[str] = set()
         self._connect_observation_deadlines: dict[str, float] = {}
         self._disconnecting: set[str] = set()
-        self._le_hold_disconnect_pending = False
-        self._unpublished_le_live = False
         self._le_dial_active = False
         self._le_preference_restore_pending = False
         # Outbound Bearer.LE1.Connect is only a bootstrap hint.  Real-device
@@ -194,16 +192,17 @@ class BearerSupervisor:
         self._timer_id = self._schedule(POLL_SECONDS, self._tick)
 
     def enable_le(self) -> None:
-        """Allow the LE bearer after the current Classic profile attempt.
+        """Allow outbound LE bootstrap after the current Classic profile attempt.
 
-        Callers hold LE during every whole-device reconnect so MAP/PBAP can be
-        the first profile transaction. Calling this more than once is harmless.
+        Callers hold outbound LE work during every whole-device reconnect so
+        MAP/PBAP can get the first host-initiated transaction. Phone-initiated
+        LE links remain usable throughout. Calling this more than once is
+        harmless.
         """
         if self._le_enabled:
             return
         self._le_enabled = True
-        self._le_hold_disconnect_pending = False
-        log.info("MAP/PBAP attempt completed; enabling iPhone LE bearer")
+        log.info("MAP/PBAP attempt completed; enabling outbound iPhone LE bootstrap")
         if self._states["le"] is not True:
             # Pairing deliberately leaves the untyped Device1.Connect path on
             # BR/EDR while MAP/PBAP get their first turn. Hand inbound control
@@ -216,21 +215,24 @@ class BearerSupervisor:
             self._tick()
 
     def hold_le(self) -> None:
-        """Prevent a missing LE bearer from connecting during a MAP/PBAP attempt.
+        """Prevent outbound LE dialing during a MAP/PBAP attempt.
 
-        An LE link that is already established is left alone. If LE is missing,
-        the gate also rejects a Connect that was already in flight, avoiding a
-        race with the MAP/PBAP attempt without churning a healthy LE link.
+        An LE link that is already established or arrives inbound is left alone.
+        If BlueFerry already has an outbound LE request in flight, ask BlueZ to
+        cancel it once. If that request wins the race and establishes a link
+        anyway, keep the link rather than churning a connection iOS initiated
+        or accepted.
         """
         was_enabled = self._le_enabled
         self._le_enabled = False
-        if self._states["le"] is False:
-            self._le_hold_disconnect_pending = True
         self._cancel_le_settle()
         if "le" in self._connecting:
             self._request_le_disconnect(force=True)
         if was_enabled:
-            log.info("holding iPhone LE bearer until the MAP/PBAP attempt completes")
+            log.info(
+                "holding outbound iPhone LE bootstrap until the MAP/PBAP "
+                "attempt completes"
+            )
 
     def poke(self) -> None:
         """Run a health check now, for example after system resume."""
@@ -245,10 +247,6 @@ class BearerSupervisor:
         self._connect_observation_deadlines.clear()
         self._disconnecting.clear()
         self._set_le_dial_active(False)
-        # The old owner's live link is gone. While the profile gate is closed,
-        # reject any LE link that appears under the replacement owner.
-        self._le_hold_disconnect_pending = not self._le_enabled
-        self._unpublished_le_live = False
         self._le_preference_restore_pending = False
         self._le_dial_spent = False
         self._le_reset_pending = False
@@ -291,8 +289,6 @@ class BearerSupervisor:
         self._connect_observation_deadlines.clear()
         self._disconnecting.clear()
         self._set_le_dial_active(False)
-        self._le_hold_disconnect_pending = False
-        self._unpublished_le_live = False
         self._le_preference_restore_pending = False
         self._le_dial_spent = False
         self._le_reset_pending = False
@@ -325,31 +321,10 @@ class BearerSupervisor:
         bredr = self._read("bredr")
         le = self._read("le")
         self._update_state("bredr", bredr)
-
-        if not self._le_enabled and le is False:
-            self._le_hold_disconnect_pending = True
-        if (
-            not self._le_enabled
-            and self._le_hold_disconnect_pending
-            and (le is True or (self._unpublished_le_live and le is None))
-        ):
-            # Do not publish the transient link to ANCS. It was missing when
-            # the profile gate closed, so allowing it to become usable here
-            # would put GATT ahead of the MAP/PBAP attempt again.
-            self._settle_in_progress_connect("le", le)
-            if le is True and not self._unpublished_le_live:
-                self._unpublished_le_live = True
-                self._reset_classic_backoff_from_le()
-            self._request_le_disconnect(force=True)
-            if bredr is False:
-                # Bearer.BREDR1.Connect is transport-specific, so Classic may
-                # recover while the unpublished LE teardown is outstanding
-                # without a PreferredBearer write racing either operation.
-                self._request_connect("bredr")
-            return True
-        else:
-            self._unpublished_le_live = False
-            self._update_state("le", le)
+        # The profile gate controls BlueFerry's outbound LE requests, not links
+        # initiated by the phone. Publishing an inbound link lets ANCS perform
+        # its authorization handshake while Classic recovers independently.
+        self._update_state("le", le)
 
         if self._le_reset_pending and self._le_enabled:
             if le is False:
@@ -495,10 +470,7 @@ class BearerSupervisor:
         log.info("connecting iPhone %s bearer", kind.upper())
         try:
             if kind == "bredr":
-                if (
-                    self._states["le"] is not True
-                    and not self._unpublished_le_live
-                ):
+                if self._states["le"] is not True:
                     # Device1.Connect is transport-agnostic, so select Classic
                     # only when no LE link is live. With live LE,
                     # _connect_bluez uses targeted Bearer.BREDR1.Connect and
@@ -528,16 +500,6 @@ class BearerSupervisor:
         self._last_errors.pop(kind, None)
         if kind == "bredr":
             self._restore_le_preference()
-        if kind == "le" and not self._le_enabled:
-            self._le_hold_disconnect_pending = True
-            self._le_dial_spent = False
-            self._request_le_disconnect(force=True)
-            # The request completed only after policy closed the gate. Treat
-            # rejecting it as cancellation, not as a failed connection that
-            # should delay the next permitted LE attempt.
-            self._failures[kind] = 0
-            self._next_attempt[kind] = 0.0
-            return
         # A successful method reply only means BlueZ accepted the request; it
         # does not mean the bearer connected. Keep widening the quiet window
         # until an observed Connected=true resets it.
@@ -676,7 +638,7 @@ class BearerSupervisor:
             log.info("re-arming outbound iPhone LE bootstrap: %s", reason)
 
     def _backoff_cap(self, kind: str) -> int:
-        if kind == "bredr" and (self.le_connected or self._unpublished_le_live):
+        if kind == "bredr" and self.le_connected:
             return LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS
         return BACKOFF_CAP_SECONDS
 
@@ -782,7 +744,7 @@ class BearerSupervisor:
         if kind == "bredr":
             interface = (
                 _INTERFACES["bredr"]
-                if self.le_connected or self._unpublished_le_live
+                if self.le_connected
                 else "org.bluez.Device1"
             )
         else:

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -153,8 +153,15 @@ class BearerSupervisor:
         self._running = False
         self._generation = 0
         self._connecting: set[str] = set()
+        self._connect_request_serial = 0
+        self._connect_request_ids: dict[str, int] = {}
+        self._connect_targeted: dict[str, bool] = {}
         self._connect_observation_deadlines: dict[str, float] = {}
         self._disconnecting: set[str] = set()
+        # A concrete False clears this hint; a transient unavailable read does
+        # not. It affects only Classic targeting/backoff, while _states["le"]
+        # remains the exact value published to ANCS consumers.
+        self._le_targeting_hint = False
         self._le_dial_active = False
         self._le_preference_restore_pending = False
         # Outbound Bearer.LE1.Connect is only a bootstrap hint.  Real-device
@@ -244,9 +251,12 @@ class BearerSupervisor:
         previous = dict(self._states)
         self._generation += 1
         self._connecting.clear()
+        self._connect_request_ids.clear()
+        self._connect_targeted.clear()
         self._connect_observation_deadlines.clear()
         self._disconnecting.clear()
         self._set_le_dial_active(False)
+        self._le_targeting_hint = False
         self._le_preference_restore_pending = False
         self._le_dial_spent = False
         self._le_reset_pending = False
@@ -286,9 +296,12 @@ class BearerSupervisor:
         self._running = False
         self._generation += 1
         self._connecting.clear()
+        self._connect_request_ids.clear()
+        self._connect_targeted.clear()
         self._connect_observation_deadlines.clear()
         self._disconnecting.clear()
         self._set_le_dial_active(False)
+        self._le_targeting_hint = False
         self._le_preference_restore_pending = False
         self._le_dial_spent = False
         self._le_reset_pending = False
@@ -408,6 +421,11 @@ class BearerSupervisor:
         self._settle_in_progress_connect(kind, value)
         previous = self._states[kind]
         self._states[kind] = value
+        if kind == "le":
+            if value is True:
+                self._le_targeting_hint = True
+            elif value is False:
+                self._le_targeting_hint = False
         if previous != value:
             label = "unknown" if value is None else ("connected" if value else "disconnected")
             log.debug("iPhone %s bearer state: %s", kind.upper(), label)
@@ -442,6 +460,26 @@ class BearerSupervisor:
             self._on_le_state(value)
         if previous != value and self._on_status is not None:
             self._on_status()
+        if kind == "le" and value is True:
+            self._retarget_pending_classic_connect()
+
+    def _classic_connect_should_be_targeted(self) -> bool:
+        """Keep Classic transport-specific across transient LE read failures."""
+        return self._le_targeting_hint or self._states["le"] is True
+
+    def _retarget_pending_classic_connect(self) -> None:
+        """Supersede an untyped Classic request after an inbound LE arrival."""
+        if "bredr" not in self._connecting or self._connect_targeted.get("bredr"):
+            return
+        log.info(
+            "iPhone LE connected during untyped Classic bootstrap; "
+            "retargeting Classic bearer"
+        )
+        self._clear_connect_request("bredr")
+        # The live LE link is current reachability evidence, so the replacement
+        # request must not inherit a quiet window from the obsolete request.
+        self._reset_classic_backoff_from_le()
+        self._request_connect("bredr")
 
     def _request_connect(self, kind: str) -> None:
         if kind in self._connecting:
@@ -454,6 +492,7 @@ class BearerSupervisor:
             kind == "bredr"
             and self._le_enabled
             and self._states["le"] is None
+            and not self._classic_connect_should_be_targeted()
         ):
             # Do not guess that LE is down and rewrite PreferredBearer during
             # a transient read failure. During the initial MAP-first gate, a
@@ -465,12 +504,17 @@ class BearerSupervisor:
             return
         if kind == "le":
             self._le_dial_spent = True
+        targeted = kind == "bredr" and self._classic_connect_should_be_targeted()
         self._connecting.add(kind)
+        self._connect_request_serial += 1
+        request_id = self._connect_request_serial
+        self._connect_request_ids[kind] = request_id
+        self._connect_targeted[kind] = targeted
         generation = self._generation
         log.info("connecting iPhone %s bearer", kind.upper())
         try:
             if kind == "bredr":
-                if self._states["le"] is not True:
+                if not targeted:
                     # Device1.Connect is transport-agnostic, so select Classic
                     # only when no LE link is live. With live LE,
                     # _connect_bluez uses targeted Bearer.BREDR1.Connect and
@@ -484,17 +528,26 @@ class BearerSupervisor:
                 self._set_le_dial_active(True)
             self._connect(
                 kind,
-                lambda: self._connect_succeeded(kind, generation),
-                lambda error: self._connect_failed(kind, error, generation),
+                lambda: self._connect_succeeded(kind, generation, request_id),
+                lambda error: self._connect_failed(
+                    kind,
+                    error,
+                    generation,
+                    request_id,
+                ),
             )
         except Exception as error:
-            self._connect_failed(kind, error, generation)
+            self._connect_failed(kind, error, generation, request_id)
 
-    def _connect_succeeded(self, kind: str, generation: int) -> None:
-        if generation != self._generation:
+    def _connect_succeeded(
+        self,
+        kind: str,
+        generation: int,
+        request_id: int,
+    ) -> None:
+        if not self._connect_request_is_current(kind, generation, request_id):
             return
-        self._connecting.discard(kind)
-        self._connect_observation_deadlines.pop(kind, None)
+        self._clear_connect_request(kind)
         if kind == "le":
             self._set_le_dial_active(False)
         self._last_errors.pop(kind, None)
@@ -516,8 +569,14 @@ class BearerSupervisor:
             delay,
         )
 
-    def _connect_failed(self, kind: str, error: Exception, generation: int) -> None:
-        if generation != self._generation:
+    def _connect_failed(
+        self,
+        kind: str,
+        error: Exception,
+        generation: int,
+        request_id: int,
+    ) -> None:
+        if not self._connect_request_is_current(kind, generation, request_id):
             return
         name, message = _connect_error_parts(error)
         if name == "org.bluez.Error.InProgress":
@@ -532,11 +591,30 @@ class BearerSupervisor:
             log.debug("%s bearer connection is still in progress", kind.upper())
             return
         if name == "org.bluez.Error.AlreadyConnected":
-            log.debug("%s bearer connection already active", kind.upper())
-            self._connect_succeeded(kind, generation)
-            return
-        self._connecting.discard(kind)
-        self._connect_observation_deadlines.pop(kind, None)
+            if kind == "bredr" and not self._connect_targeted.get(kind, False):
+                bredr = self._read("bredr")
+                self._update_state("bredr", bredr)
+                if bredr is not True:
+                    # Device1.Connected can mean only LE is up. Refresh that
+                    # state so an inbound link supersedes this untyped request
+                    # with Bearer.BREDR1.Connect instead of creating a false
+                    # Classic success and quiet window.
+                    self._update_state("le", self._read("le"))
+                    if not self._connect_request_is_current(
+                        kind,
+                        generation,
+                        request_id,
+                    ):
+                        return
+                else:
+                    log.debug("%s bearer connection already active", kind.upper())
+                    self._connect_succeeded(kind, generation, request_id)
+                    return
+            else:
+                log.debug("%s bearer connection already active", kind.upper())
+                self._connect_succeeded(kind, generation, request_id)
+                return
+        self._clear_connect_request(kind)
         if kind == "le":
             self._set_le_dial_active(False)
         if kind == "le" and not self._le_enabled:
@@ -560,6 +638,23 @@ class BearerSupervisor:
             )
             self._last_errors[kind] = (name, message)
 
+    def _connect_request_is_current(
+        self,
+        kind: str,
+        generation: int,
+        request_id: int,
+    ) -> bool:
+        return (
+            generation == self._generation
+            and self._connect_request_ids.get(kind) == request_id
+        )
+
+    def _clear_connect_request(self, kind: str) -> None:
+        self._connecting.discard(kind)
+        self._connect_request_ids.pop(kind, None)
+        self._connect_targeted.pop(kind, None)
+        self._connect_observation_deadlines.pop(kind, None)
+
     def _settle_in_progress_connect(self, kind: str, value: bool | None) -> None:
         """Resolve InProgress on connection or after a method-sized timeout."""
         deadline = self._connect_observation_deadlines.get(kind)
@@ -568,8 +663,7 @@ class BearerSupervisor:
         connected = value is True
         if not connected and self._clock() < deadline:
             return
-        self._connect_observation_deadlines.pop(kind, None)
-        self._connecting.discard(kind)
+        self._clear_connect_request(kind)
         if kind == "le":
             self._set_le_dial_active(False)
         if connected:
@@ -602,7 +696,7 @@ class BearerSupervisor:
         if (
             not self._le_preference_restore_pending
             or not self._le_enabled
-            or self._states["le"] is True
+            or self._classic_connect_should_be_targeted()
             or self._connecting
         ):
             return
@@ -638,7 +732,7 @@ class BearerSupervisor:
             log.info("re-arming outbound iPhone LE bootstrap: %s", reason)
 
     def _backoff_cap(self, kind: str) -> int:
-        if kind == "bredr" and self.le_connected:
+        if kind == "bredr" and self._classic_connect_should_be_targeted():
             return LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS
         return BACKOFF_CAP_SECONDS
 
@@ -744,7 +838,10 @@ class BearerSupervisor:
         if kind == "bredr":
             interface = (
                 _INTERFACES["bredr"]
-                if self.le_connected
+                if self._connect_targeted.get(
+                    "bredr",
+                    self._classic_connect_should_be_targeted(),
+                )
                 else "org.bluez.Device1"
             )
         else:

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -302,9 +302,10 @@ class Daemon:
             )
         self.solicitation.start()
 
-        # A bond records trust but does not guarantee a live connection.
-        # The bearer supervisor establishes BR/EDR but deliberately holds LE
-        # until ProfileSupervisor completes its first MAP/PBAP attempt.
+        # A bond records trust but does not guarantee a live connection. The
+        # bearer supervisor establishes BR/EDR but deliberately holds its own
+        # outbound LE bootstrap until ProfileSupervisor completes its first
+        # MAP/PBAP attempt. Phone-initiated LE remains usable for ANCS.
         self.bearers.start()
 
         # ANCS — per-app notifications via BLE GATT. Independent of MAP/PBAP.

--- a/src/blueferry/profile_supervisor.py
+++ b/src/blueferry/profile_supervisor.py
@@ -234,7 +234,7 @@ class ProfileSupervisor:
         if not force and not self._attempt_ready():
             log.debug(
                 "MAP/PBAP attempt completed while BR/EDR was unavailable; "
-                "keeping LE held for the next attempt"
+                "keeping outbound LE bootstrap held for the next attempt"
             )
             return
         self._first_attempt_completed = True

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -342,6 +342,108 @@ def test_enabling_le_waits_for_an_outstanding_classic_connect() -> None:
     ]
 
 
+def test_inbound_le_retargets_an_outstanding_untyped_classic_connect() -> None:
+    state = {"bredr": False, "le": False}
+    calls = []
+    preferences = []
+    observed = []
+    supervisor = None
+
+    def connect(kind, on_success, on_error):
+        assert supervisor is not None
+        calls.append(
+            (
+                kind,
+                supervisor._connect_targeted[kind],
+                on_success,
+                on_error,
+            )
+        )
+
+    supervisor = BearerSupervisor(
+        "/device",
+        le_enabled=False,
+        read_connected=state.get,
+        connect=connect,
+        prefer=preferences.append,
+        on_le_state=observed.append,
+        schedule=lambda _delay, _callback: 7,
+    )
+    supervisor.start()
+
+    assert [(kind, targeted) for kind, targeted, *_callbacks in calls] == [
+        ("bredr", False)
+    ]
+    assert preferences == ["bredr"]
+
+    state["le"] = True
+    supervisor.poke()
+
+    assert observed == [False, True]
+    assert [(kind, targeted) for kind, targeted, *_callbacks in calls] == [
+        ("bredr", False),
+        ("bredr", True),
+    ]
+    assert preferences == ["bredr"]
+    assert supervisor._failures["bredr"] == 0
+    assert supervisor._next_attempt["bredr"] == 0.0
+
+    # The obsolete Device1.Connect callback cannot settle or delay the new
+    # Bearer.BREDR1.Connect request.
+    calls[0][2]()
+    assert "bredr" in supervisor._connecting
+    assert supervisor._failures["bredr"] == 0
+    assert supervisor._next_attempt["bredr"] == 0.0
+
+
+def test_untyped_classic_already_connected_rechecks_bearers_before_success() -> None:
+    import dbus
+
+    state = {"bredr": False, "le": False}
+    calls = []
+    preferences = []
+    supervisor = None
+
+    def connect(kind, on_success, on_error):
+        assert supervisor is not None
+        calls.append(
+            (
+                kind,
+                supervisor._connect_targeted[kind],
+                on_success,
+                on_error,
+            )
+        )
+
+    supervisor = BearerSupervisor(
+        "/device",
+        le_enabled=False,
+        read_connected=state.get,
+        connect=connect,
+        prefer=preferences.append,
+        schedule=lambda _delay, _callback: 7,
+    )
+    supervisor.start()
+
+    state["le"] = True
+    calls[0][3](
+        dbus.exceptions.DBusException(
+            "Already connected",
+            name="org.bluez.Error.AlreadyConnected",
+        )
+    )
+
+    assert [(kind, targeted) for kind, targeted, *_callbacks in calls] == [
+        ("bredr", False),
+        ("bredr", True),
+    ]
+    assert preferences == ["bredr"]
+    assert supervisor.bredr_connected is False
+    assert supervisor.le_connected is True
+    assert supervisor._failures["bredr"] == 0
+    assert supervisor._next_attempt["bredr"] == 0.0
+
+
 def test_le_settle_retries_failed_preference_handoff_without_blocking_dial() -> None:
     state = {"bredr": True, "le": False}
     calls = []
@@ -1259,14 +1361,22 @@ def test_bluez_restart_accepts_new_le_link_while_profile_gate_is_closed() -> Non
     disconnects = []
     observed = []
     preferences = []
+    now = 0.0
+    supervisor = None
+
+    def connect(kind, _on_success, on_error):
+        assert supervisor is not None
+        connections.append((kind, supervisor._connect_targeted[kind], on_error))
+
     supervisor = BearerSupervisor(
         "/device",
         read_connected=state.get,
-        connect=lambda kind, _on_success, _on_error: connections.append(kind),
+        connect=connect,
         disconnect=lambda kind, _on_success, _on_error: disconnects.append(kind),
         prefer=preferences.append,
         on_le_state=observed.append,
         schedule=lambda _delay, _callback: 7,
+        clock=lambda: now,
     )
     supervisor.start()
     supervisor.hold_le()
@@ -1275,7 +1385,9 @@ def test_bluez_restart_accepts_new_le_link_while_profile_gate_is_closed() -> Non
     supervisor.reset_after_bluez_restart()
 
     assert disconnects == []
-    assert connections == ["bredr"]
+    assert [(kind, targeted) for kind, targeted, _error in connections] == [
+        ("bredr", True)
+    ]
     assert preferences == []
     assert observed == [True, None, True]
     assert supervisor.le_connected is True
@@ -1287,6 +1399,20 @@ def test_bluez_restart_accepts_new_le_link_while_profile_gate_is_closed() -> Non
     assert preferences == []
     assert disconnects == []
     assert observed == [True, None, True, None]
+
+    supervisor._failures["bredr"] = 9
+    connections[0][2](RuntimeError("not now"))
+    assert supervisor._next_attempt["bredr"] == (
+        bearer_supervisor.LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS
+    )
+
+    now = bearer_supervisor.LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS
+    supervisor.poke()
+    assert [(kind, targeted) for kind, targeted, _error in connections] == [
+        ("bredr", True),
+        ("bredr", True),
+    ]
+    assert preferences == []
 
 
 def test_inbound_le_during_hold_resets_and_caps_classic_backoff() -> None:

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -204,11 +204,12 @@ def test_le_can_be_held_again_during_a_later_profile_reconnect() -> None:
     assert connections == ["le"]
 
 
-def test_hold_rejects_an_le_connect_already_in_flight() -> None:
+def test_hold_cancels_in_flight_le_once_but_keeps_a_late_connection() -> None:
     state = {"bredr": True, "le": False}
     connect_callbacks = []
     disconnect_callbacks = []
     observed = []
+    preferences = []
     scheduled = []
 
     supervisor = BearerSupervisor(
@@ -217,9 +218,10 @@ def test_hold_rejects_an_le_connect_already_in_flight() -> None:
         connect=lambda kind, on_success, _on_error: connect_callbacks.append(
             (kind, on_success)
         ),
-        disconnect=lambda kind, on_success, _on_error: disconnect_callbacks.append(
-            (kind, on_success)
+        disconnect=lambda kind, on_success, on_error: disconnect_callbacks.append(
+            (kind, on_success, on_error)
         ),
+        prefer=preferences.append,
         on_le_state=observed.append,
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
     )
@@ -238,27 +240,22 @@ def test_hold_rejects_an_le_connect_already_in_flight() -> None:
     assert [kind for kind, _callback in connect_callbacks] == ["le"]
 
     supervisor.hold_le()
+    assert [kind for kind, _success, _error in disconnect_callbacks] == ["le"]
+
+    # BlueZ reports that the best-effort cancellation found no live link, but
+    # the original asynchronous Connect subsequently wins the race. Keep and
+    # publish that observed link instead of issuing a second Disconnect.
+    disconnect_callbacks[0][2](RuntimeError("not connected"))
     connect_callbacks[0][1]()
     state["le"] = True
     health_check()
 
-    # The pending Connect is countered immediately, and its transient True
-    # state is not published to ANCS while the profile gate is closed.
-    assert [kind for kind, _callback in disconnect_callbacks] == ["le"]
-    assert observed == [False]
+    assert [kind for kind, _success, _error in disconnect_callbacks] == ["le"]
+    assert observed == [False, True]
 
-    disconnect_callbacks[0][1]()
-    state["le"] = False
-    health_check()
     supervisor.enable_le()
-    assert observed == [False]
-    next_settle = next(
-        callback
-        for delay, callback in reversed(scheduled)
-        if delay == bearer_supervisor.CLASSIC_SETTLE_SECONDS
-    )
-    next_settle()
-    assert [kind for kind, _callback in connect_callbacks] == ["le", "le"]
+    assert preferences == []
+    assert [kind for kind, _callback in connect_callbacks] == ["le"]
 
 
 def test_untyped_classic_connect_restores_le_preference_before_le_dial() -> None:
@@ -484,40 +481,6 @@ def test_bluez_targets_classic_bearer_when_le_is_live(monkeypatch) -> None:
     )
     supervisor = BearerSupervisor("/device")
     supervisor._states["le"] = True
-
-    supervisor._connect_bluez("bredr", lambda: None, lambda _error: None)
-
-    assert calls == [
-        ("org.bluez", "/device"),
-        ("interface", "org.bluez.Bearer.BREDR1"),
-        ("connect", 45.0),
-    ]
-
-
-def test_bluez_targets_classic_bearer_when_live_le_is_unpublished(
-    monkeypatch,
-) -> None:
-    calls = []
-
-    class Bearer:
-        @staticmethod
-        def Connect(**kwargs):
-            calls.append(("connect", kwargs["timeout"]))
-
-    class Bus:
-        @staticmethod
-        def get_object(service, path):
-            calls.append((service, path))
-            return object()
-
-    monkeypatch.setattr(bearer_supervisor, "get_system_bus", Bus)
-    monkeypatch.setattr(
-        bearer_supervisor.dbus,
-        "Interface",
-        lambda _object, interface: calls.append(("interface", interface)) or Bearer(),
-    )
-    supervisor = BearerSupervisor("/device")
-    supervisor._unpublished_le_live = True
 
     supervisor._connect_bluez("bredr", lambda: None, lambda _error: None)
 
@@ -1290,7 +1253,7 @@ def test_gatt_transport_recovery_waits_for_profile_gate_to_reopen() -> None:
     assert disconnects == ["le"]
 
 
-def test_bluez_restart_rejects_new_le_link_while_profile_gate_is_closed() -> None:
+def test_bluez_restart_accepts_new_le_link_while_profile_gate_is_closed() -> None:
     state = {"bredr": True, "le": True}
     connections = []
     disconnects = []
@@ -1311,21 +1274,22 @@ def test_bluez_restart_rejects_new_le_link_while_profile_gate_is_closed() -> Non
 
     supervisor.reset_after_bluez_restart()
 
-    assert disconnects == ["le"]
+    assert disconnects == []
     assert connections == ["bredr"]
     assert preferences == []
-    assert observed == [True, None]
-    assert supervisor._unpublished_le_live is True
+    assert observed == [True, None, True]
+    assert supervisor.le_connected is True
 
-    # A transient missing property does not forget that teardown is still in
-    # flight and therefore cannot fall back to an untyped Device1.Connect.
+    # A transient read failure is published normally; no teardown or untyped
+    # Classic fallback is introduced while the targeted request is in flight.
     state["le"] = None
     supervisor.poke()
     assert preferences == []
-    assert supervisor._unpublished_le_live is True
+    assert disconnects == []
+    assert observed == [True, None, True, None]
 
 
-def test_unpublished_live_le_resets_and_caps_classic_backoff() -> None:
+def test_inbound_le_during_hold_resets_and_caps_classic_backoff() -> None:
     state = {"bredr": True, "le": False}
     connect_callbacks = []
     scheduled = []
@@ -1347,7 +1311,7 @@ def test_unpublished_live_le_resets_and_caps_classic_backoff() -> None:
     state.update(bredr=False, le=True)
     scheduled[0][1]()
 
-    assert supervisor._unpublished_le_live is True
+    assert supervisor.le_connected is True
     assert supervisor._failures["bredr"] == 0
     assert supervisor._next_attempt["bredr"] == 0.0
     assert [kind for kind, _on_error in connect_callbacks] == ["bredr"]


### PR DESCRIPTION
## Summary

- keep phone-initiated LE links usable and publish them to ANCS while the MAP/PBAP-first gate suppresses BlueFerry's outbound LE bootstrap
- make cancellation of an already in-flight outbound LE dial best-effort, retaining the connection if the dial wins the race
- supersede an outstanding untyped Device1.Connect with Bearer.BREDR1.Connect when inbound LE appears, while ignoring callbacks from the obsolete request
- retain last-known-live LE as a Classic-targeting hint across transient state-read failures and verify bearer-specific Classic state before accepting Device1.AlreadyConnected

## Why

On the RTL8852CE path reported in #58, iOS can initiate LE while Classic is still down after pairing. The reconnect gate introduced after 0.7.7 treated that healthy inbound link as a race, withheld it from ANCS, and forcibly disconnected it. That prevents the initial ANCS authorization prompt and can make later iOS attempts progressively quieter.

The gate now controls only host-initiated LE work. Classic recovery remains independent and transport-specific once LE is live.


## Validation

- uv run ruff check .
- uv run mypy src
- uv run pytest -q — 794 passed, 3 skipped
