### PR TITLE
Adopt captured pairing reconnect fixes

### DIFF
--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -878,6 +878,24 @@ class BearerSupervisor:
             "org.freedesktop.DBus.Properties",
         )
         try:
+            current = str(
+                properties.Get(
+                    "org.bluez.Device1",
+                    "PreferredBearer",
+                    timeout=5.0,
+                )
+            )
+        except dbus.exceptions.DBusException as error:
+            if preferred_bearer_unavailable(error):
+                # Older or partial experimental BlueZ builds can still accept
+                # inbound ANCS without exposing PreferredBearer.
+                log.debug("PreferredBearer is unavailable on this BlueZ build")
+                return
+            current = ""
+        else:
+            if current == kind:
+                return
+        try:
             properties.Set(
                 "org.bluez.Device1",
                 "PreferredBearer",
@@ -887,8 +905,6 @@ class BearerSupervisor:
             log.debug("set iPhone PreferredBearer=%s", kind)
         except dbus.exceptions.DBusException as error:
             if preferred_bearer_unavailable(error):
-                # Older or partial experimental BlueZ builds can still accept
-                # inbound ANCS without exposing PreferredBearer.
                 log.debug("PreferredBearer is unavailable on this BlueZ build")
                 return
             raise

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -40,7 +40,7 @@ from blueferry.obex.map_events import MapEventListener
 from blueferry.obex.sessions import SessionManager
 from blueferry.obex.worker import ObexWorker
 from blueferry.pair_setup import bond_status
-from blueferry.profile_supervisor import ProfileSupervisor
+from blueferry.profile_supervisor import ProfileSessions, ProfileSupervisor
 from blueferry.protocol import BUS_NAME
 from blueferry.setup_verification import (
     CONTACTS,
@@ -52,6 +52,16 @@ from blueferry.solicitation_supervisor import SolicitationSupervisor
 from blueferry.storage_security import NO_STORAGE, StorageSecurity
 
 log = logging.getLogger(__name__)
+
+
+def classic_reachable(bearers: BearerSupervisor, sessions: ProfileSessions) -> bool:
+    """True when Classic is up or an OBEX session already proves it."""
+    return (
+        bearers.bredr_connected
+        or sessions.map is not None
+        or sessions.pbap is not None
+    )
+
 
 # How often to re-pull the iPhone's phonebook (so the cache picks up new contacts)
 CONTACTS_REFRESH_SEC = 24 * 60 * 60  # 24h
@@ -144,7 +154,7 @@ class Daemon:
             on_first_attempt_complete=(
                 self.bearers.enable_le if config.ANCS_ENABLED else None
             ),
-            attempt_ready=lambda: self.bearers.bredr_connected,
+            attempt_ready=lambda: classic_reachable(self.bearers, self.sessions),
         )
 
     def _emit_status(self) -> None:

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -41,6 +41,10 @@ _SESSION_BLUETOOTH_NAMES = (
 CLASSIC_SETTLE_SECONDS = 3.0
 # Device1.Connect can refuse a profile while iOS still completes pairing.
 CONNECT_REFUSED_GRACE_SECONDS = 5.0
+_CONNECT_PROFILE_REFUSALS = frozenset({
+    "org.bluez.Error.Failed",
+    "org.bluez.Error.NotReady",
+})
 BLUEZ_SNAPSHOT_TIMEOUT_SECONDS = pairing_diagnostics.BLUEZ_SNAPSHOT_TIMEOUT_SECONDS
 BLUEZ_TRACE_POLL_SECONDS = 2.0
 # One BR/EDR inquiry is 10.24s. USB dongles also need a moment to start
@@ -624,31 +628,40 @@ def _connect_classic(
     _dispatching_wait(time.monotonic() + timeout + 5.0, lambda: bool(results))
     error = results[0] if results else None
     error_name = error.get_dbus_name() if error is not None else ""
+    error_message = (
+        error.get_dbus_message() or "" if error is not None else ""
+    )
     if error is not None and error_name not in {
         "org.bluez.Error.AlreadyConnected",
         "org.bluez.Error.InProgress",
     }:
-        quirks_report.mark(
-            attempt, "classic_connect_failed",
-            error=error_name or "failed",
-        )
+        failed_fields: dict[str, str] = {"error": error_name or "failed"}
+        if error_message:
+            failed_fields["message"] = error_message[:256]
+        quirks_report.mark(attempt, "classic_connect_failed", **failed_fields)
         if error_name == "org.freedesktop.DBus.Error.UnknownObject":
             raise _ConnectDeviceMissing(
-                error.get_dbus_message() or error_name or str(error)
+                error_message or error_name or str(error)
             ) from error
-        if _wait_for_paired_after_connect_error(device_path):
+        if (
+            error_name in _CONNECT_PROFILE_REFUSALS
+            and _wait_for_paired_after_connect_error(device_path)
+        ):
             log.info(
                 "Device1.Paired became true after Connect reported %s",
                 error_name or "error",
             )
+            paired_fields: dict[str, str] = {"error": error_name or "error"}
+            if error_message:
+                paired_fields["message"] = error_message[:256]
             quirks_report.mark(
                 attempt,
                 "classic_connect_paired_after_error",
-                error=error_name or "error",
+                **paired_fields,
             )
         else:
             raise PairingError(
-                error.get_dbus_message() or error_name or str(error)
+                error_message or error_name or str(error)
             ) from error
     if error is None:
         log.debug("Device1.Connect completed successfully")
@@ -669,7 +682,7 @@ def _device_is_paired(device_path: str) -> bool:
             get_system_bus().get_object("org.bluez", device_path),
             "org.freedesktop.DBus.Properties",
         )
-        return bool(props.Get("org.bluez.Device1", "Paired", timeout=5.0))
+        return bool(props.Get("org.bluez.Device1", "Paired", timeout=1.0))
     except dbus.exceptions.DBusException:
         return False
 

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -39,6 +39,8 @@ _SESSION_BLUETOOTH_NAMES = (
     "org.gnome.SettingsDaemon.Rfkill",
 )
 CLASSIC_SETTLE_SECONDS = 3.0
+# Device1.Connect can refuse a profile while iOS still completes pairing.
+CONNECT_REFUSED_GRACE_SECONDS = 5.0
 BLUEZ_SNAPSHOT_TIMEOUT_SECONDS = pairing_diagnostics.BLUEZ_SNAPSHOT_TIMEOUT_SECONDS
 BLUEZ_TRACE_POLL_SECONDS = 2.0
 # One BR/EDR inquiry is 10.24s. USB dongles also need a moment to start
@@ -634,9 +636,20 @@ def _connect_classic(
             raise _ConnectDeviceMissing(
                 error.get_dbus_message() or error_name or str(error)
             ) from error
-        raise PairingError(
-            error.get_dbus_message() or error_name or str(error)
-        ) from error
+        if _wait_for_paired_after_connect_error(device_path):
+            log.info(
+                "Device1.Paired became true after Connect reported %s",
+                error_name or "error",
+            )
+            quirks_report.mark(
+                attempt,
+                "classic_connect_paired_after_error",
+                error=error_name or "error",
+            )
+        else:
+            raise PairingError(
+                error.get_dbus_message() or error_name or str(error)
+            ) from error
     if error is None:
         log.debug("Device1.Connect completed successfully")
         quirks_report.mark(attempt, "classic_connect_replied")
@@ -650,18 +663,35 @@ def _connect_classic(
         _wait_for_classic_settled(device_path, timeout=timeout, attempt=attempt)
 
 
-def _prefer_bredr(device_path: str) -> None:
-    """Prefer BR/EDR after pairing when BlueZ exposes PreferredBearer."""
-    log.info(
-        "setting Device1.PreferredBearer=bredr before post-pair connection"
+def _device_is_paired(device_path: str) -> bool:
+    try:
+        props = dbus.Interface(
+            get_system_bus().get_object("org.bluez", device_path),
+            "org.freedesktop.DBus.Properties",
+        )
+        return bool(props.Get("org.bluez.Device1", "Paired", timeout=5.0))
+    except dbus.exceptions.DBusException:
+        return False
+
+
+def _wait_for_paired_after_connect_error(device_path: str) -> bool:
+    """True when pairing finished even though Connect refused a profile."""
+    return _dispatching_wait(
+        time.monotonic() + CONNECT_REFUSED_GRACE_SECONDS,
+        lambda: _device_is_paired(device_path),
     )
+
+
+def _prefer_bearer(device_path: str, kind: str) -> None:
+    """Set Device1.PreferredBearer when BlueZ exposes the property."""
+    log.info("setting Device1.PreferredBearer=%s", kind)
     obj = get_system_bus().get_object("org.bluez", device_path)
     props = dbus.Interface(obj, "org.freedesktop.DBus.Properties")
     try:
         props.Set(
             "org.bluez.Device1",
             "PreferredBearer",
-            dbus.String("bredr"),
+            dbus.String(kind),
         )
     except dbus.exceptions.DBusException as error:
         if preferred_bearer_unavailable(error):
@@ -672,9 +702,14 @@ def _prefer_bredr(device_path: str) -> None:
             return
         detail = error.get_dbus_message() or error.get_dbus_name() or str(error)
         raise PairingError(
-            f"Could not select the BR/EDR bearer for the post-pair "
+            f"Could not select the {kind} bearer for the post-pair "
             f"connection: {detail}"
         ) from error
+
+
+def _prefer_bredr(device_path: str) -> None:
+    """Prefer BR/EDR after pairing when BlueZ exposes PreferredBearer."""
+    _prefer_bearer(device_path, "bredr")
 
 
 def _activate_obex_mns() -> None:
@@ -1260,9 +1295,12 @@ def _trust_and_settle(device: PairedDevice, attempt: PairingAttempt) -> None:
     log.debug("setting Device1.Trusted=true for %s", device.device_path)
     trust_device(device.mac, device.adapter_path)
     quirks_report.mark(attempt, "trusted")
-    _prefer_bredr(device.device_path)
+    _prefer_bearer(device.device_path, "bredr")
     quirks_report.mark(attempt, "preferred_bearer_bredr")
     _wait_for_classic_settled(device.device_path, attempt=attempt)
+    # A bond left on bredr does not accept the phone's inbound LE link.
+    _prefer_bearer(device.device_path, "le")
+    quirks_report.mark(attempt, "preferred_bearer_le")
     _record_bluez_state(
         attempt,
         device.device_path,

--- a/src/blueferry/pairing_diagnostics.py
+++ b/src/blueferry/pairing_diagnostics.py
@@ -114,8 +114,8 @@ def bluez_device_snapshot(
         ("le", "org.bluez.Bearer.LE1"),
     ):
         bearer = root_ifaces.get(interface)
-        state: dict[str, object] = {"present": bearer is not None}
-        if bearer is not None:
+        state: dict[str, object] = {"present": bool(bearer)}
+        if bearer:
             for field in ("Paired", "Bonded", "Connected"):
                 if field in bearer:
                     state[field.casefold()] = bool(bearer[field])
@@ -181,7 +181,8 @@ def le_bearer_snapshot(
             {},
         )
         bearer = interfaces.get("org.bluez.Bearer.LE1") if interfaces else None
-        if bearer is None:
+        # Without -E, bluetoothd still registers an empty Bearer.LE1.
+        if not bearer:
             return state
         state["present"] = True
         state["paired"] = bool(bearer.get("Paired", False))
@@ -253,6 +254,11 @@ def snapshot_phone(
 ) -> None:
     phone = quirks_report.public_device(device)
     phone["le_bearer"] = bearer_snapshot(device.device_path)
+    name = str(getattr(device, "name", "") or "").strip()
+    if name:
+        aliases = attempt.setdefault("_aliases", [])
+        if isinstance(aliases, list) and name not in aliases:
+            aliases.append(name)
     previous = attempt.get("phone")
     if isinstance(previous, dict):
         previous_bearer = previous.get("le_bearer")
@@ -330,7 +336,7 @@ def record_pairing_report(
 ) -> Path | None:
     if transports is not None:
         map_ready, pbap_ready, ancs_ready = transports.as_tuple()
-        attempt["preferred_bearer"] = "bredr"
+        attempt["preferred_bearer"] = "le"
         seen = {
             item.get("event")
             for item in attempt.get("timeline", ())

--- a/src/blueferry/pairing_types.py
+++ b/src/blueferry/pairing_types.py
@@ -18,6 +18,7 @@ class PairingAttempt(TypedDict, total=False):
     pairing_path: str
     session: dict[str, Any]
     _t0: float
+    _aliases: list[str]
     timeline: list[dict[str, Any]]
     bluez_trace: list[dict[str, Any]]
     previous_teardown: dict[str, object]

--- a/src/blueferry/quirks_report.py
+++ b/src/blueferry/quirks_report.py
@@ -107,7 +107,14 @@ def scrub_text(value: str, *, aliases: Sequence[str] = ()) -> str:
     """Remove Bluetooth addresses, aliases, and home/XDG path prefixes."""
     text = str(value)
     for alias, token in _alias_replacements(aliases):
-        text = re.sub(re.escape(alias), token, text, flags=re.IGNORECASE)
+        # Do not match inside kebab/snake tokens: the default iOS alias
+        # "iPhone" is a substring of "iphone-initiated-connect".
+        text = re.sub(
+            r"(?<![A-Za-z0-9_-])" + re.escape(alias) + r"(?![A-Za-z0-9_-])",
+            token,
+            text,
+            flags=re.IGNORECASE,
+        )
     for prefix, token in _redaction_prefixes():
         text = _replace_path_prefix(text, prefix, token)
     text = _MAC_COLON.sub("xx:xx:xx:xx:xx:xx", text)

--- a/src/blueferry/quirks_report.py
+++ b/src/blueferry/quirks_report.py
@@ -7,7 +7,7 @@ import os
 import re
 import stat
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -84,23 +84,47 @@ def _replace_path_prefix(text: str, prefix: str, token: str) -> str:
     return pattern.sub(token, text)
 
 
-def scrub_text(value: str) -> str:
-    """Remove Bluetooth addresses and home/XDG path prefixes from text."""
+def _alias_replacements(aliases: Sequence[str]) -> list[tuple[str, str]]:
+    """Longest-first alias substitutions with numbered placeholders."""
+    replacements: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    index = 1
+    for alias in sorted(
+        (str(item).strip() for item in aliases),
+        key=len,
+        reverse=True,
+    ):
+        key = alias.casefold()
+        if len(alias) < 2 or key in seen:
+            continue
+        seen.add(key)
+        replacements.append((alias, f"<alias-{index}>"))
+        index += 1
+    return replacements
+
+
+def scrub_text(value: str, *, aliases: Sequence[str] = ()) -> str:
+    """Remove Bluetooth addresses, aliases, and home/XDG path prefixes."""
     text = str(value)
+    for alias, token in _alias_replacements(aliases):
+        text = re.sub(re.escape(alias), token, text, flags=re.IGNORECASE)
     for prefix, token in _redaction_prefixes():
         text = _replace_path_prefix(text, prefix, token)
     text = _MAC_COLON.sub("xx:xx:xx:xx:xx:xx", text)
     return _MAC_PATH.sub("dev_REDACTED", text)
 
 
-def scrub_value(value: Any) -> Any:
-    """Recursively redact Bluetooth addresses from a JSON-compatible value."""
+def scrub_value(value: Any, *, aliases: Sequence[str] = ()) -> Any:
+    """Recursively redact Bluetooth addresses and device aliases."""
     if isinstance(value, str):
-        return scrub_text(value)
+        return scrub_text(value, aliases=aliases)
     if isinstance(value, list):
-        return [scrub_value(item) for item in value]
+        return [scrub_value(item, aliases=aliases) for item in value]
     if isinstance(value, dict):
-        return {str(key): scrub_value(item) for key, item in value.items()}
+        return {
+            str(key): scrub_value(item, aliases=aliases)
+            for key, item in value.items()
+        }
     return value
 
 
@@ -267,6 +291,9 @@ def save_report(report: Mapping[str, Any], *, directory: Path | None = None) -> 
             sequence += 1
             path = target_dir / f"{REPORT_PREFIX}{stamp}-{sequence:04d}{REPORT_SUFFIX}"
         prepared = _compact_report(report)
+        aliases = prepared.pop("_aliases", [])
+        if not isinstance(aliases, list):
+            aliases = []
         origin = prepared.pop("_t0", None)
         timeline = prepared.get("timeline")
         if isinstance(origin, (int, float)):
@@ -276,7 +303,7 @@ def save_report(report: Mapping[str, Any], *, directory: Path | None = None) -> 
             if isinstance(last, dict) and isinstance(last.get("t"), (int, float)):
                 prepared["duration_s"] = last["t"]
         payload = json.dumps(
-            scrub_value(prepared),
+            scrub_value(prepared, aliases=aliases),
             ensure_ascii=False,
             indent=2,
             sort_keys=True,

--- a/src/blueferry/solicitation_supervisor.py
+++ b/src/blueferry/solicitation_supervisor.py
@@ -126,10 +126,10 @@ class SolicitationSupervisor:
 
     def _reconcile(self) -> None:
         registered = self._is_registered()
-        if self._dialing:
-            # This safety override deliberately ignores the post-pair minimum
-            # hold. Advertising and initiating an LE connection concurrently
-            # can make BlueZ abort its own outstanding dial.
+        if self._dialing and self._clock() >= self._hold_until:
+            # After the post-pair hold, advertising during an outbound dial
+            # can make BlueZ abort its own Connect. During the hold, keep
+            # the advert: that is the inbound door iOS uses.
             if registered:
                 self._unregister(self.adapter)
             return

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -535,6 +535,11 @@ def test_bluez_preference_selects_requested_bearer(monkeypatch) -> None:
 
     class Properties:
         @staticmethod
+        def Get(interface, name, *, timeout):
+            calls.append(("get", interface, name, timeout))
+            return "bredr"
+
+        @staticmethod
         def Set(interface, name, value, *, timeout):
             calls.append((interface, name, str(value), timeout))
 
@@ -557,6 +562,7 @@ def test_bluez_preference_selects_requested_bearer(monkeypatch) -> None:
     assert calls == [
         ("org.bluez", "/device"),
         ("interface", "org.freedesktop.DBus.Properties"),
+        ("get", "org.bluez.Device1", "PreferredBearer", 5.0),
         ("org.bluez.Device1", "PreferredBearer", "le", 5.0),
     ]
 
@@ -666,6 +672,13 @@ def test_bluez_falls_back_when_classic_bearer_is_marker_only(monkeypatch) -> Non
 def test_bluez_preference_ignores_a_missing_preferred_bearer_property(monkeypatch) -> None:
     class Properties:
         @staticmethod
+        def Get(_interface, _name, *, timeout):
+            raise bearer_supervisor.dbus.exceptions.DBusException(
+                "No such property 'PreferredBearer'",
+                name="org.bluez.Error.InvalidArguments",
+            )
+
+        @staticmethod
         def Set(_interface, _name, _value, *, timeout):
             raise bearer_supervisor.dbus.exceptions.DBusException(
                 "No such property 'PreferredBearer'",
@@ -685,6 +698,36 @@ def test_bluez_preference_ignores_a_missing_preferred_bearer_property(monkeypatc
     )
 
     BearerSupervisor("/device")._prefer_bluez("bredr")
+
+
+def test_bluez_preference_skips_set_when_already_selected(monkeypatch) -> None:
+    calls = []
+
+    class Properties:
+        @staticmethod
+        def Get(_interface, _name, *, timeout):
+            calls.append("get")
+            return "le"
+
+        @staticmethod
+        def Set(_interface, _name, _value, *, timeout):
+            calls.append("set")
+
+    class Bus:
+        @staticmethod
+        def get_object(_service, _path):
+            return object()
+
+    monkeypatch.setattr(bearer_supervisor, "get_system_bus", Bus)
+    monkeypatch.setattr(
+        bearer_supervisor.dbus,
+        "Interface",
+        lambda _object, _interface: Properties(),
+    )
+
+    BearerSupervisor("/device")._prefer_bluez("le")
+
+    assert calls == ["get"]
 
 
 def test_failed_connection_is_retried_after_backoff() -> None:

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -299,3 +299,13 @@ def test_changing_saved_target_requests_restart(monkeypatch):
     assert instance._check_target_config() is False
     assert instance._restart_after_upgrade is True
     assert stopped == [True]
+
+
+def test_classic_reachable_accepts_an_open_obex_session() -> None:
+    bearers = SimpleNamespace(bredr_connected=False)
+    sessions = SimpleNamespace(map=object(), pbap=None)
+    assert daemon_mod.classic_reachable(bearers, sessions) is True
+    sessions = SimpleNamespace(map=None, pbap=None)
+    assert daemon_mod.classic_reachable(bearers, sessions) is False
+    bearers = SimpleNamespace(bredr_connected=True)
+    assert daemon_mod.classic_reachable(bearers, sessions) is True

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -430,6 +430,34 @@ def test_bluez_device_snapshot_captures_bearers_battery_and_ancs(monkeypatch):
     ]
 
 
+def test_empty_le_bearer_interface_is_treated_as_absent() -> None:
+    from blueferry import pairing_diagnostics
+
+    objects = {
+        "/org/bluez/hci0/dev_02_00_00_00_00_01": {
+            "org.bluez.Device1": {"Paired": True},
+            "org.bluez.Bearer.LE1": {},
+        },
+    }
+
+    snapshot = pairing_diagnostics.bluez_device_snapshot(
+        "/org/bluez/hci0/dev_02_00_00_00_00_01",
+        load_objects=lambda _timeout: objects,
+    )
+    assert snapshot["bearers"]["le"] == {"present": False}
+
+    le = pairing_diagnostics.le_bearer_snapshot(
+        "/org/bluez/hci0/dev_02_00_00_00_00_01",
+        load_objects=lambda: objects,
+    )
+    assert le == {
+        "present": False,
+        "paired": False,
+        "bonded": False,
+        "connected": False,
+    }
+
+
 def test_forget_records_bluez_state_before_and_after_remove(monkeypatch):
     device = _device(paired=True)
     snapshots = iter([
@@ -1275,6 +1303,7 @@ def _compatible(
             "issue": issue,
         },
     )
+    monkeypatch.setattr(pair_setup, "_prefer_bearer", lambda *_args: None)
     monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
     monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
     monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path, **_kwargs: None)
@@ -1308,8 +1337,8 @@ def test_complete_pairing_starts_profiles_while_pairing_advert_is_active(monkeyp
     monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: calls.append("trust"))
     monkeypatch.setattr(
         pair_setup,
-        "_prefer_bredr",
-        lambda path: calls.append(("prefer-bredr", path)),
+        "_prefer_bearer",
+        lambda path, kind: calls.append((f"prefer-{kind}", path)),
     )
     monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: calls.append("config"))
     monkeypatch.setattr(
@@ -1329,6 +1358,7 @@ def test_complete_pairing_starts_profiles_while_pairing_advert_is_active(monkeyp
         "trust",
         ("prefer-bredr", device.device_path),
         ("classic-settled", device.device_path),
+        ("prefer-le", device.device_path),
         ("advert", "hci0"),
         "config",
         "restart",
@@ -1492,6 +1522,90 @@ def test_classic_connect_distinguishes_a_missing_bluez_device(monkeypatch):
     )
 
 
+def test_classic_connect_treats_late_paired_as_success(monkeypatch):
+    calls = []
+
+    class Interface:
+        @staticmethod
+        def Connect(*, error_handler, **_kwargs):
+            error_handler(
+                pair_setup.dbus.exceptions.DBusException(
+                    "br-connection-unknown",
+                    name="org.bluez.Error.Failed",
+                )
+            )
+
+        @staticmethod
+        def Get(_interface, name, *, timeout):
+            calls.append(("get", name, timeout))
+            return name == "Paired"
+
+    class Bus:
+        @staticmethod
+        def get_object(*_args):
+            return object()
+
+    attempt = {"timeline": []}
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Interface())
+    monkeypatch.setattr(
+        pair_setup,
+        "_wait_for_classic_settled",
+        lambda path, **kwargs: calls.append(("settled", path)),
+    )
+
+    pair_setup._connect_classic(
+        "/org/bluez/hci0/dev_02_00_00_00_00_01",
+        settle=True,
+        timeout=1.0,
+        attempt=attempt,
+    )
+
+    assert ("get", "Paired", 5.0) in calls
+    assert calls[-1] == (
+        "settled",
+        "/org/bluez/hci0/dev_02_00_00_00_00_01",
+    )
+    assert [event["event"] for event in attempt["timeline"]] == [
+        "classic_connect_sent",
+        "classic_connect_failed",
+        "classic_connect_paired_after_error",
+        "classic_connect_replied",
+    ]
+
+
+def test_classic_connect_still_fails_when_pairing_does_not_finish(monkeypatch):
+    class Interface:
+        @staticmethod
+        def Connect(*, error_handler, **_kwargs):
+            error_handler(
+                pair_setup.dbus.exceptions.DBusException(
+                    "br-connection-unknown",
+                    name="org.bluez.Error.Failed",
+                )
+            )
+
+        @staticmethod
+        def Get(_interface, _name, *, timeout):
+            return False
+
+    class Bus:
+        @staticmethod
+        def get_object(*_args):
+            return object()
+
+    monkeypatch.setattr(pair_setup, "CONNECT_REFUSED_GRACE_SECONDS", 0.0)
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Interface())
+
+    with pytest.raises(pair_setup.PairingError, match="br-connection-unknown"):
+        pair_setup._connect_classic(
+            "/org/bluez/hci0/dev_02_00_00_00_00_01",
+            settle=False,
+            timeout=1.0,
+        )
+
+
 def test_pairing_rediscovery_waits_for_exact_device_on_selected_adapter(
     monkeypatch,
 ):
@@ -1627,6 +1741,34 @@ def test_post_pair_bearer_preference_is_forced_to_bredr(monkeypatch):
         ("interface", "org.freedesktop.DBus.Properties"),
         ("org.bluez.Device1", "PreferredBearer", "bredr"),
     ]
+
+
+def test_post_pair_bearer_preference_can_select_le(monkeypatch):
+    calls = []
+
+    class Properties:
+        @staticmethod
+        def Set(interface, name, value):
+            calls.append((interface, name, str(value)))
+
+    class Bus:
+        @staticmethod
+        def get_object(service, path):
+            calls.append((service, path))
+            return object()
+
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(
+        pair_setup.dbus,
+        "Interface",
+        lambda _obj, interface: (
+            calls.append(("interface", interface)) or Properties()
+        ),
+    )
+
+    pair_setup._prefer_bearer("/org/bluez/hci0/dev_02_00_00_00_00_01", "le")
+
+    assert calls[-1] == ("org.bluez.Device1", "PreferredBearer", "le")
 
 
 def test_post_pair_bearer_preference_is_optional_when_bluez_omits_it(monkeypatch):
@@ -1795,8 +1937,8 @@ def test_compatibility_pairing_connects_and_lets_the_iphone_initiate(monkeypatch
     )
     monkeypatch.setattr(
         pair_setup,
-        "_prefer_bredr",
-        lambda path: calls.append(("prefer-bredr", path)),
+        "_prefer_bearer",
+        lambda path, kind: calls.append((f"prefer-{kind}", path)),
     )
     monkeypatch.setattr(
         pair_setup,
@@ -1833,6 +1975,7 @@ def test_compatibility_pairing_connects_and_lets_the_iphone_initiate(monkeypatch
         "trust",
         ("prefer-bredr", paired.device_path),
         ("classic-settled", paired.device_path),
+        ("prefer-le", paired.device_path),
         "persist",
         "daemon",
         "advert-exit",
@@ -1913,8 +2056,8 @@ def test_default_pairing_rediscovers_a_device_lost_before_connect(monkeypatch):
     monkeypatch.setattr(pair_setup, "trust_device", lambda *_args: calls.append("trust"))
     monkeypatch.setattr(
         pair_setup,
-        "_prefer_bredr",
-        lambda path: calls.append(("prefer-bredr", path)),
+        "_prefer_bearer",
+        lambda path, kind: calls.append((f"prefer-{kind}", path)),
     )
     monkeypatch.setattr(pair_setup, "write_local_env", lambda *_args: calls.append("persist"))
     monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: calls.append("daemon"))
@@ -1935,6 +2078,7 @@ def test_default_pairing_rediscovers_a_device_lost_before_connect(monkeypatch):
         "trust",
         ("prefer-bredr", paired.device_path),
         ("classic-settled", paired.device_path),
+        ("prefer-le", paired.device_path),
         "persist",
         "daemon",
         "advert-exit",

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -1561,7 +1561,7 @@ def test_classic_connect_treats_late_paired_as_success(monkeypatch):
         attempt=attempt,
     )
 
-    assert ("get", "Paired", 5.0) in calls
+    assert ("get", "Paired", 1.0) in calls
     assert calls[-1] == (
         "settled",
         "/org/bluez/hci0/dev_02_00_00_00_00_01",
@@ -1572,6 +1572,7 @@ def test_classic_connect_treats_late_paired_as_success(monkeypatch):
         "classic_connect_paired_after_error",
         "classic_connect_replied",
     ]
+    assert attempt["timeline"][2]["message"] == "br-connection-unknown"
 
 
 def test_classic_connect_still_fails_when_pairing_does_not_finish(monkeypatch):
@@ -1604,6 +1605,41 @@ def test_classic_connect_still_fails_when_pairing_does_not_finish(monkeypatch):
             settle=False,
             timeout=1.0,
         )
+
+
+def test_classic_connect_does_not_wait_on_access_denied(monkeypatch):
+    gets = []
+
+    class Interface:
+        @staticmethod
+        def Connect(*, error_handler, **_kwargs):
+            error_handler(
+                pair_setup.dbus.exceptions.DBusException(
+                    "Permission denied",
+                    name="org.freedesktop.DBus.Error.AccessDenied",
+                )
+            )
+
+        @staticmethod
+        def Get(_interface, _name, *, timeout):
+            gets.append(True)
+            return False
+
+    class Bus:
+        @staticmethod
+        def get_object(*_args):
+            return object()
+
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Interface())
+
+    with pytest.raises(pair_setup.PairingError, match="Permission denied"):
+        pair_setup._connect_classic(
+            "/org/bluez/hci0/dev_02_00_00_00_00_01",
+            settle=False,
+            timeout=1.0,
+        )
+    assert gets == []
 
 
 def test_pairing_rediscovery_waits_for_exact_device_on_selected_adapter(

--- a/tests/test_quirks_report.py
+++ b/tests/test_quirks_report.py
@@ -359,6 +359,31 @@ def test_wait_for_daemon_transports_records_split_ancs(monkeypatch) -> None:
     assert "ancs_ready" in events
 
 
+def test_scrub_text_redacts_device_aliases() -> None:
+    cleaned = quirks_report.scrub_text(
+        "paired Alex's iPhone at /org/bluez/hci0/dev_02_00_AA_BB_CC_DD",
+        aliases=["Alex's iPhone"],
+    )
+    assert "Alex" not in cleaned
+    assert "<alias-1>" in cleaned
+    assert "dev_REDACTED" in cleaned
+
+
+def test_save_report_redacts_aliases_and_drops_the_alias_list(tmp_path) -> None:
+    path = quirks_report.save_report(
+        {
+            "error": "could not pair Alex's iPhone",
+            "_aliases": ["Alex's iPhone"],
+        },
+        directory=tmp_path,
+    )
+    payload = path.read_text()
+    parsed = json.loads(payload)
+    assert "Alex" not in payload
+    assert parsed["error"] == "could not pair <alias-1>"
+    assert "_aliases" not in parsed
+
+
 def test_scrub_text_removes_mac_addresses_and_bluez_paths() -> None:
     raw = (
         "paired 02:00:AA:BB:CC:DD at "
@@ -502,6 +527,7 @@ def test_complete_pairing_writes_a_scrubbed_success_report(
             "bearer_api_active": True,
         },
     )
+    monkeypatch.setattr(pair_setup, "_prefer_bearer", lambda *_args: None)
     monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
     monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
     monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path, **_kwargs: None)
@@ -630,6 +656,7 @@ def test_pairing_report_keeps_last_le_error_when_ancs_stays_down(
             "bearer_api_active": True,
         },
     )
+    monkeypatch.setattr(pair_setup, "_prefer_bearer", lambda *_args: None)
     monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
     monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
     monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path, **_kwargs: None)
@@ -772,6 +799,7 @@ def test_unexpected_pairing_exception_still_writes_a_report(
             "bearer_api_active": True,
         },
     )
+    monkeypatch.setattr(pair_setup, "_prefer_bearer", lambda *_args: None)
     monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
     monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
     monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path, **_kwargs: None)

--- a/tests/test_quirks_report.py
+++ b/tests/test_quirks_report.py
@@ -369,6 +369,15 @@ def test_scrub_text_redacts_device_aliases() -> None:
     assert "dev_REDACTED" in cleaned
 
 
+def test_scrub_text_does_not_mangle_iphone_strategy_tokens() -> None:
+    cleaned = quirks_report.scrub_text(
+        '{"pairing_strategy":"iphone-initiated-connect","note":"paired iPhone"}',
+        aliases=["iPhone"],
+    )
+    assert "iphone-initiated-connect" in cleaned
+    assert '"note":"paired <alias-1>"' in cleaned
+
+
 def test_save_report_redacts_aliases_and_drops_the_alias_list(tmp_path) -> None:
     path = quirks_report.save_report(
         {

--- a/tests/test_solicitation_supervisor.py
+++ b/tests/test_solicitation_supervisor.py
@@ -90,6 +90,29 @@ def test_healthy_ancs_keeps_post_pair_solicitation_for_permission_window() -> No
     assert calls[-1] == ("unregister", "hci7")
 
 
+def test_outbound_dial_keeps_solicitation_during_post_pair_hold() -> None:
+    calls = []
+    state = {"registered": False}
+    scheduled = []
+    now = 0.0
+    supervisor = _supervisor(
+        calls,
+        state,
+        scheduled,
+        minimum_on_seconds=180,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    supervisor.set_dialing(True)
+
+    assert state["registered"] is True
+    assert ("unregister", "hci7") not in calls
+
+    now = 180.0
+    scheduled[0][1]()
+    assert calls[-1] == ("unregister", "hci7")
+
+
 def test_outbound_dial_withdraws_and_then_restores_solicitation() -> None:
     calls = []
     state = {"registered": False}


### PR DESCRIPTION
## Summary

- hand `PreferredBearer` back to `le` after Classic settles so BlueZ will accept the phone's inbound LE link
- treat an open MAP/PBAP session as Classic proof for the MAP-first LE gate
- keep ANCS solicitation up during the 180s post-pair hold even if an outbound LE dial is in flight
- after a refused `Device1.Connect`, wait briefly for `Paired` on Failed/NotReady only, and keep the D-Bus message on the timeline
- treat an empty `Bearer.LE1` interface as absent; redact device aliases without mangling `iphone-initiated-connect`

## Why

Tether A/B on MediaTek showed a bond left on `PreferredBearer=bredr` will not take the phone's inbound LE. BlueFerry only restored `le` after the first MAP/PBAP attempt with Classic up, which is a second #58 mechanism. The rest are small captured pairing/report fixes from that same review: Connect can refuse a profile while pairing still completes, `-E`-less BlueZ registers an empty `Bearer.LE1`, and the default iOS alias `iPhone` must not substring-replace strategy tokens.

MediaTek `btmon` on this machine showed host-initiated `LE Extended Create Connection` succeeding, including bluetoothd auto-connect after an LE-only drop. This PR does not skip the outbound dial when `LE.Paired`.

## Validation

- `uv run ruff check .`
- `uv run mypy src/blueferry`
- `uv run pytest -q` — 805 passed, 3 skipped