### PR TITLE
Enable adapter Pairable during pairing

### DIFF
--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -1196,6 +1196,51 @@ def _prepare_classic_transport(adapter: str, attempt: PairingAttempt) -> None:
     quirks_report.mark(attempt, "obex_mns_ready")
 
 
+@contextmanager
+def _pairable_window(adapter: str, *, attempt: PairingAttempt | None = None):
+    """Force Adapter1.Pairable for the pairing transaction, then restore it.
+
+    Connect-first makes the iPhone the authentication initiator. BlueZ refuses
+    that inbound request when Pairable is off (Linux shows the passkey, the
+    phone never does, ``br-connection-key-missing``). Discoverable is not
+    required once the ACL exists and would advertise the adapter during
+    Classic pairing.
+    """
+    path = f"/org/bluez/{adapter}"
+    props = dbus.Interface(
+        get_system_bus().get_object("org.bluez", path),
+        "org.freedesktop.DBus.Properties",
+    )
+    previous: bool | None = None
+    try:
+        previous = bool(props.Get("org.bluez.Adapter1", "Pairable", timeout=5.0))
+        if not previous:
+            props.Set(
+                "org.bluez.Adapter1",
+                "Pairable",
+                dbus.Boolean(True),
+                timeout=5.0,
+            )
+    except dbus.exceptions.DBusException as error:
+        log.warning("could not enable Adapter1.Pairable: %s", error)
+        previous = None
+    if previous is not None:
+        quirks_report.mark(attempt, "pairable_window_open", pairable=previous)
+    try:
+        yield
+    finally:
+        if previous is not None:
+            try:
+                props.Set(
+                    "org.bluez.Adapter1",
+                    "Pairable",
+                    dbus.Boolean(previous),
+                    timeout=5.0,
+                )
+            except dbus.exceptions.DBusException as error:
+                log.warning("could not restore Adapter1.Pairable: %s", error)
+
+
 def _run_pairing_transaction(
     mac: str,
     device: PairedDevice,
@@ -1209,6 +1254,30 @@ def _run_pairing_transaction(
 ) -> PairedDevice:
     if device.paired:
         return device
+    with _pairable_window(adapter, attempt=attempt):
+        return _complete_pairing_transaction(
+            mac,
+            device,
+            adapter,
+            policy,
+            confirmation=confirmation,
+            display=display,
+            attempt=attempt,
+            resources=resources,
+        )
+
+
+def _complete_pairing_transaction(
+    mac: str,
+    device: PairedDevice,
+    adapter: str,
+    policy: PairingPolicy,
+    *,
+    confirmation: ConfirmationCallback | None,
+    display: DisplayCallback | None,
+    attempt: PairingAttempt,
+    resources: _PairingResources,
+) -> PairedDevice:
     try:
         if confirmation is None:
             # complete_pairing permits this only with explicit _allow_headless.

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import stat
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 import pytest
 
@@ -1305,6 +1305,11 @@ def _compatible(
     )
     monkeypatch.setattr(pair_setup, "_prefer_bearer", lambda *_args: None)
     monkeypatch.setattr(pair_setup, "_prefer_bredr", lambda _path: None)
+    monkeypatch.setattr(
+        pair_setup,
+        "_pairable_window",
+        lambda *_args, **_kwargs: nullcontext(),
+    )
     monkeypatch.setattr(pair_setup, "_activate_obex_mns", lambda: None)
     monkeypatch.setattr(pair_setup, "_wait_for_classic_settled", lambda _path, **_kwargs: None)
     monkeypatch.setattr(
@@ -1805,6 +1810,71 @@ def test_post_pair_bearer_preference_can_select_le(monkeypatch):
     pair_setup._prefer_bearer("/org/bluez/hci0/dev_02_00_00_00_00_01", "le")
 
     assert calls[-1] == ("org.bluez.Device1", "PreferredBearer", "le")
+
+
+def test_pairable_window_enables_and_restores_pairable_only(monkeypatch):
+    state = {"Pairable": False, "Discoverable": False}
+    calls = []
+
+    class Properties:
+        @staticmethod
+        def Get(_interface, name, *, timeout):
+            calls.append(("get", name))
+            return state[name]
+
+        @staticmethod
+        def Set(_interface, name, value, *, timeout):
+            calls.append(("set", name, bool(value)))
+            state[name] = bool(value)
+
+    class Bus:
+        @staticmethod
+        def get_object(_service, path):
+            assert path == "/org/bluez/hci0"
+            return object()
+
+    monkeypatch.setattr(pair_setup, "get_system_bus", Bus)
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Properties())
+    attempt = {"timeline": []}
+
+    with pair_setup._pairable_window("hci0", attempt=attempt):
+        assert state == {"Pairable": True, "Discoverable": False}
+
+    assert state == {"Pairable": False, "Discoverable": False}
+    assert calls == [
+        ("get", "Pairable"),
+        ("set", "Pairable", True),
+        ("set", "Pairable", False),
+    ]
+    assert attempt["timeline"][-1]["event"] == "pairable_window_open"
+
+
+def test_pairable_window_restores_after_an_error(monkeypatch):
+    state = {"Pairable": False, "Discoverable": True}
+
+    class Properties:
+        @staticmethod
+        def Get(_interface, name, *, timeout):
+            return state[name]
+
+        @staticmethod
+        def Set(_interface, name, value, *, timeout):
+            state[name] = bool(value)
+
+    monkeypatch.setattr(
+        pair_setup,
+        "get_system_bus",
+        type("Bus", (), {"get_object": staticmethod(lambda *_args: object())}),
+    )
+    monkeypatch.setattr(pair_setup.dbus, "Interface", lambda *_args: Properties())
+
+    with pytest.raises(RuntimeError, match="pairing failed"):
+        with pair_setup._pairable_window("hci1"):
+            assert state["Pairable"] is True
+            assert state["Discoverable"] is True
+            raise RuntimeError("pairing failed")
+
+    assert state == {"Pairable": False, "Discoverable": True}
 
 
 def test_post_pair_bearer_preference_is_optional_when_bluez_omits_it(monkeypatch):


### PR DESCRIPTION
## Summary

- for an unpaired Connect-first or Pair() transaction, set `Adapter1.Pairable=true` and restore the previous value afterwards
- leave `Discoverable` unchanged
- skip the window on the already-paired resume path; restore runs before trust/settle and the ANCS advert

## Why

Connect-first makes the iPhone the authentication initiator. When the adapter idles with `Pairable=no` (common on KDE/GNOME/`main.conf`), BlueZ refuses that inbound pairing request: Linux shows the numeric comparison, the phone never does, and the journal reports `br-connection-key-missing`. Forcing Pairable for the transaction is the captured fix.

Discoverable is not part of that failure. The ACL already exists, and making the adapter discoverable during Classic pairing can surface the computer under iOS Other Devices and is the two-record path PROTOCOL avoids. Tether bundled both as a pairing-mode blanket; only Pairable is evidenced.

## Validation

- `uv run pytest tests/test_pair_setup.py -q` — 71 passed