### PR TITLE
Add BLUEFERRY_READ_SYNC_ENABLED to make desktop-to-phone read sync optional

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -168,7 +168,10 @@ the tested phone they are indistinguishable on the wire:
   full bMessage download.
 - Changing `Message1.Read` is reflected on the phone. Conversely, opening a
   message on the phone produces a read-property update that can close the
-  corresponding desktop popup.
+  corresponding desktop popup. The desktop-to-phone write is optional:
+  `BLUEFERRY_READ_SYNC_ENABLED=false` (default true) disables it so dismissing
+  a desktop popup leaves the phone-side message unread. The phone-to-desktop
+  popup close is always enabled because it writes nothing back.
 
 MAP does not say whether a message used SMS or iMessage, and BlueFerry must not
 infer the transport from `sms-gsm`. It also does not provide reactions, typing

--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ BLUEFERRY_NOTIFICATION_TIMEOUT_MS=8000
 BLUEFERRY_HISTORY_RETENTION_DAYS=30
 BLUEFERRY_HISTORY_MAX_EVENTS=10000
 BLUEFERRY_HISTORY_MAX_PAYLOAD_BYTES=268435456
+
+# Keep messages unread on the iPhone (no iMessage read receipts when you
+# dismiss a desktop popup). Phone-to-desktop sync is unaffected.
+BLUEFERRY_READ_SYNC_ENABLED=false
 ```
 
 When **All iPhone Notifications** is selected, optional exact bundle-ID rules

--- a/src/blueferry/config.py
+++ b/src/blueferry/config.py
@@ -16,6 +16,7 @@ LOCAL_ENV_KEYS = frozenset({
     "BLUEFERRY_ANCS_APP_ALLOWLIST",
     "BLUEFERRY_ANCS_APP_BLOCKLIST",
     "BLUEFERRY_SHOW_NOTIFICATION_CONTENT",
+    "BLUEFERRY_READ_SYNC_ENABLED",
     "BLUEFERRY_NOTIFICATION_TIMEOUT_MS",
     "BLUEFERRY_HISTORY_RETENTION_DAYS",
     "BLUEFERRY_HISTORY_MAX_EVENTS",
@@ -196,6 +197,16 @@ def include_ancs_app(app_id: str) -> bool:
 SHOW_NOTIFICATION_CONTENT: bool = _env_bool(
     "BLUEFERRY_SHOW_NOTIFICATION_CONTENT", True
 )
+READ_SYNC_ENABLED: bool = _env_bool("BLUEFERRY_READ_SYNC_ENABLED", True)
+"""Whether dismissing a desktop message popup marks the message read on the
+iPhone via MAP.
+
+Enabled by default. Set to ``false`` to keep messages unread on the phone so
+iMessage shows no read receipt to the other party. The phone-to-desktop
+direction is unaffected: opening a message on the iPhone still closes the
+corresponding desktop popup.
+"""
+
 NOTIFICATION_TIMEOUT_MS: int = _env_int(
     "BLUEFERRY_NOTIFICATION_TIMEOUT_MS", 8_000, 1_000, 60_000
 )

--- a/src/blueferry/sinks/libnotify.py
+++ b/src/blueferry/sinks/libnotify.py
@@ -11,6 +11,12 @@ Read-state sync:
   Linux dismiss → MAP Message1.Properties.Set(Read=true)  → iPhone marks read
   iPhone reads  → MAP PropertiesChanged(Read=true)         → we close popup
 
+The desktop-to-phone direction is optional (BLUEFERRY_READ_SYNC_ENABLED,
+default true). With it disabled, dismissing a popup leaves the message unread
+on the iPhone. The phone-to-desktop direction always stays on: opening a
+message on the iPhone closes the corresponding desktop popup without writing
+anything back.
+
 Empirical on iOS 26.5: both directions work. iPhone propagates Read=true
 back over MAP within a few seconds of opening the Messages app.
 """
@@ -85,6 +91,7 @@ class LibnotifySink:
         self._notification_policy = notification_policy
         self._contacts_only_notifications = contacts_only_notifications
         self._on_open_message = on_open_message
+        self._read_sync_enabled = config.READ_SYNC_ENABLED
         self._notif = dbus.Interface(
             get_session_bus().get_object(
                 "org.freedesktop.Notifications",
@@ -109,7 +116,12 @@ class LibnotifySink:
         self._action_match = self._notif.connect_to_signal(
             "ActionInvoked", self._on_action,
         )
-        log.info("libnotify sink ready (expiring + bidirectional read-sync)")
+        log.info(
+            "libnotify sink ready (expiring + %s)",
+            "bidirectional read-sync"
+            if self._read_sync_enabled
+            else "incoming read-sync only",
+        )
 
     def close(self) -> None:
         """Release signal watches before a notification-daemon replacement."""
@@ -327,8 +339,12 @@ class LibnotifySink:
         # Only propagate read-state to iPhone when the human actively
         # dismissed (reason=2). Don't loop on programmatic close (reason=3,
         # which is fired when we closed it ourselves because iPhone already
-        # marked it read).
+        # marked it read). Reason 1 (expiry) never writes read state.
         if reason_i != _REASON_DISMISSED:
+            return
+        # BLUEFERRY_READ_SYNC_ENABLED=false leaves the message unread on the
+        # iPhone; the desktop popup is closed and nothing is written back.
+        if not getattr(self, "_read_sync_enabled", config.READ_SYNC_ENABLED):
             return
         def succeeded(_result) -> None:
             log.info("marked %s as read on iPhone (user dismissed popup)",

--- a/tests/test_libnotify.py
+++ b/tests/test_libnotify.py
@@ -291,6 +291,55 @@ def test_expiry_and_phone_read_do_not_write_read_state(reason) -> None:
     assert queued == []
 
 
+def test_disabled_read_sync_does_not_write_read_state() -> None:
+    """BLUEFERRY_READ_SYNC_ENABLED=false: user dismissal must not mark read."""
+    queued = []
+    sink = LibnotifySink.__new__(LibnotifySink)
+    sink._pending = {7: "/session/message1"}
+    sink._msg_subs = {}
+    sink._open_messages = {}
+    sink._read_sync_enabled = False
+    sink._submit_obex = lambda operation, **callbacks: queued.append(
+        (operation, callbacks)
+    )
+
+    sink._on_closed(7, 2)
+
+    assert queued == []
+    assert sink._pending == {}
+
+
+def test_disabled_read_sync_falls_back_to_config_when_uninitialized(
+    monkeypatch,
+) -> None:
+    """Sinks built before the flag existed (or via __new__) honor config."""
+    queued = []
+    sink = LibnotifySink.__new__(LibnotifySink)
+    sink._pending = {7: "/session/message1"}
+    sink._msg_subs = {}
+    sink._open_messages = {}
+    sink._submit_obex = lambda operation, **callbacks: queued.append(
+        (operation, callbacks)
+    )
+    monkeypatch.setattr(
+        "blueferry.sinks.libnotify.config.READ_SYNC_ENABLED", False
+    )
+
+    sink._on_closed(7, 2)
+
+    assert queued == []
+
+    queued.clear()
+    sink._pending[8] = "/session/message2"
+    monkeypatch.setattr(
+        "blueferry.sinks.libnotify.config.READ_SYNC_ENABLED", True
+    )
+
+    sink._on_closed(8, 2)
+
+    assert len(queued) == 1
+
+
 def test_close_releases_all_signal_watches_and_trackers() -> None:
     sink = LibnotifySink.__new__(LibnotifySink)
     sink._match = _Match()


### PR DESCRIPTION
## Summary

Dismissing a BlueFerry message popup currently writes `Read=true` back to the iPhone over MAP. That is what makes iMessage show a read receipt to the other party — even when the user never opened the conversation and read the message on the desktop, or read it on the phone instead and just cleared the popup.

This PR adds an opt-out, following the existing `local.env` boolean conventions (`BLUEFERRY_ANCS_ENABLED`, `BLUEFERRY_SHOW_NOTIFICATION_CONTENT`):

```bash
# ~/.config/blueferry/local.env
BLUEFERRY_READ_SYNC_ENABLED=false
```

- Default `true` — current behavior is unchanged for everyone.
- When `false`, a user dismissal (NotificationClosed reason 2) closes the popup and cleans up trackers but never writes read state to the phone. Expiry (reason 1) and phone-initiated closes (reason 3) already never write, and remain unchanged.
- The phone-to-desktop direction is deliberately kept: opening a message on the iPhone still closes the corresponding desktop popup, since that path writes nothing back. This is the direction that matters for users who read on the phone — they get popup cleanup without leaking read state.

I did not find an existing issue for this (searched open + closed for read receipt / read sync); the closest prior art is #74/#84, and the maintainer-accepted pattern there — backend-owned behavior behind an env-backed policy — is what this follows.

## Changes

- `config.py`: `BLUEFERRY_READ_SYNC_ENABLED` in `LOCAL_ENV_KEYS`, module-level `READ_SYNC_ENABLED` (`_env_bool`, default true) with docstring.
- `sinks/libnotify.py`: gate the mark-read write in `_on_closed` on the flag (falling back to `config.READ_SYNC_ENABLED` for sinks constructed without the attribute, e.g. tests or older call sites); module docstring documents both directions; the ready log distinguishes `bidirectional read-sync` from `incoming read-sync only`.
- `tests/test_libnotify.py`: flag-off dismissal writes nothing; uninitialized sink falls back to config in both states; existing reason 1/3 tests unchanged and still green.
- `README.md` / `PROTOCOL.md`: document the setting and the two directions.

## Testing

- Full suite: `809 passed, 3 skipped` (same GLib teardown warning noise as on main).
- Repo gates on the touched modules: `ruff check src tests` clean, `mypy` clean, `bandit` clean.
- Manual check on Arch + iPhone (Realtek UB500, iOS 26.x): with the flag off, dismissing a popup closed the desktop notification and the sender saw no read receipt; the popup still auto-closed when the message was opened on the phone.