### PR TITLE
Keep bearer backoff from being reset by a flapping link

### DIFF
--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -30,6 +30,13 @@ BACKOFF_CAP_SECONDS = 300
 # may still decline a page temporarily, but it must not inherit the five-minute
 # absence backoff while ANCS is demonstrably reachable.
 LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS = 30
+# Connected=true is observed on every poll, not only on genuine transitions,
+# so clearing the failure counter on each observation let a phone that connects
+# and drops in a loop reset the backoff before it could grow -- pinning the
+# retry interval at its minimum. Require a bearer to hold this long before its
+# penalty is forgiven. Longer than POLL_SECONDS so a link must survive at least
+# one full probe cycle to count as stable.
+STABLE_CONNECTION_SECONDS = 15
 _INTERFACES = {
     "bredr": "org.bluez.Bearer.BREDR1",
     "le": "org.bluez.Bearer.LE1",
@@ -177,6 +184,7 @@ class BearerSupervisor:
         self._states: dict[str, bool | None] = {"bredr": None, "le": None}
         self._failures: dict[str, int] = {"bredr": 0, "le": 0}
         self._next_attempt: dict[str, float] = {"bredr": 0.0, "le": 0.0}
+        self._connected_since: dict[str, float | None] = {"bredr": None, "le": None}
 
     @property
     def bredr_connected(self) -> bool:
@@ -266,6 +274,7 @@ class BearerSupervisor:
         self._states = {"bredr": None, "le": None}
         self._failures = {"bredr": 0, "le": 0}
         self._next_attempt = {"bredr": 0.0, "le": 0.0}
+        self._connected_since = {"bredr": None, "le": None}
         self._last_errors.clear()
         if self._on_le_state is not None:
             self._on_le_state(None)
@@ -446,9 +455,11 @@ class BearerSupervisor:
             # device that remains absent still receives only one attempt.
             self._rearm_le_dial("iPhone LE disconnected")
         if value is True:
-            self._last_errors.pop(kind, None)
-            self._failures[kind] = 0
-            self._next_attempt[kind] = 0.0
+            if previous is not True:
+                self._connected_since[kind] = self._clock()
+            self._clear_backoff_if_stable(kind)
+        else:
+            self._connected_since[kind] = None
         if kind == "le" and value is True and previous is not True:
             # An inbound LE connection is the missing presence event for a
             # Classic backoff accumulated while the phone was out of range.
@@ -684,6 +695,22 @@ class BearerSupervisor:
             kind.upper(),
             delay,
         )
+
+    def _clear_backoff_if_stable(self, kind: str) -> None:
+        """Forgive a bearer's backoff only once it has held long enough.
+
+        A bearer that connects and immediately drops is not evidence that the
+        phone is reachable; treating it as such reset the penalty faster than
+        it could accumulate.
+        """
+        since = self._connected_since[kind]
+        if since is None:
+            return
+        if self._clock() - since < STABLE_CONNECTION_SECONDS:
+            return
+        self._last_errors.pop(kind, None)
+        self._failures[kind] = 0
+        self._next_attempt[kind] = 0.0
 
     def _reset_classic_backoff_from_le(self) -> None:
         """Treat any live LE link as proof that the phone is in range."""

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -262,6 +262,7 @@ def test_untyped_classic_connect_restores_le_preference_before_le_dial() -> None
     state = {"bredr": False, "le": False}
     calls = []
     scheduled = []
+    now = 0.0
     supervisor = BearerSupervisor(
         "/device",
         read_connected=state.get,
@@ -271,6 +272,7 @@ def test_untyped_classic_connect_restores_le_preference_before_le_dial() -> None
             on_success(),
         ),
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        clock=lambda: now,
     )
 
     supervisor.start()
@@ -289,6 +291,11 @@ def test_untyped_classic_connect_restores_le_preference_before_le_dial() -> None
         ("prefer", "le"),
         ("connect", "le"),
     ]
+
+    # Hold the link past the dwell window so it counts as a real session and
+    # its earlier penalty is forgiven. This tick issues no new calls.
+    now = bearer_supervisor.STABLE_CONNECTION_SECONDS + 1.0
+    scheduled[0][1]()
 
     # A later out-of-range cycle repeats the handoff instead of leaving the
     # idle preference on BR/EDR after its untyped bootstrap.
@@ -816,9 +823,14 @@ def test_backoff_resets_once_the_bearer_connects() -> None:
     supervisor.start()
     assert attempts == ["bredr"]
 
-    # The bearer connecting through any path clears the penalty, so the next
-    # genuine disconnect is retried promptly instead of inheriting old delays.
+    # A bearer that HOLDS clears the penalty, so the next genuine disconnect is
+    # retried promptly instead of inheriting old delays. The link has to survive
+    # the dwell window: a connection that drops immediately is a flap, not
+    # evidence that the phone is reachable.
+    now = 1.0
     state["bredr"] = True
+    scheduled[0][1]()
+    now = 1.0 + bearer_supervisor.STABLE_CONNECTION_SECONDS
     scheduled[0][1]()
     state["bredr"] = False
     scheduled[0][1]()
@@ -1533,3 +1545,107 @@ def test_stop_cancels_health_check() -> None:
     supervisor.stop()
 
     assert cancelled == [7]
+
+
+def test_flapping_bearer_does_not_clear_backoff() -> None:
+    """A phone that connects then drops at once must not pin the retry delay.
+
+    Connected=true is observed on every five-second poll, not just on genuine
+    transitions, so clearing the failure counter on each observation let a
+    flapping device reset the backoff before it could ever grow. The retry
+    interval stayed pinned at its five-second minimum forever.
+    """
+    state = {"bredr": False, "le": False}
+    attempts = []
+    scheduled = []
+    now = 0.0
+
+    def connect(kind, _on_success, on_error):
+        attempts.append(kind)
+        on_error(RuntimeError("not ready"))
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=connect,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        cancel=lambda _timer_id: None,
+        clock=lambda: now,
+    )
+
+    supervisor.start()
+    assert attempts == ["bredr"]
+
+    # The bearer appears and drops again well inside the dwell window.
+    now = 1.0
+    state["bredr"] = True
+    scheduled[0][1]()
+    now = 2.0
+    state["bredr"] = False
+    scheduled[0][1]()
+
+    # The 10s penalty earned by the first failure must still be in force.
+    assert attempts == ["bredr"]
+
+    # ...and once it genuinely expires, the retry proceeds as normal.
+    now = 11.0
+    scheduled[0][1]()
+    assert attempts == ["bredr", "bredr"]
+
+
+def test_backoff_grows_across_repeated_flaps() -> None:
+    """Repeated connect/drop cycles must escalate the retry delay.
+
+    Reproduces an observed field failure: a phone whose bearer flapped
+    continuously kept every retry pinned at ten seconds -- POLL_SECONDS * 2**1
+    -- because each Connected=true observation zeroed the failure counter
+    before it could ever grow past one. The five-minute ceiling was therefore
+    unreachable and the phone was re-dialled every ten seconds indefinitely.
+    """
+    state = {"bredr": False, "le": False}
+    attempts = []
+    scheduled = []
+    now = 0.0
+
+    def connect(_kind, _on_success, on_error):
+        attempts.append(now)
+        on_error(RuntimeError("not ready"))
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=connect,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        cancel=lambda _timer_id: None,
+        clock=lambda: now,
+    )
+
+    def flap(at: float) -> None:
+        """A bearer that appears and drops again inside the dwell window."""
+        nonlocal now
+        now = at
+        state["bredr"] = True
+        scheduled[0][1]()
+        now = at + 1.0
+        state["bredr"] = False
+        scheduled[0][1]()
+
+    supervisor.start()
+    assert attempts == [0.0]
+
+    # First failure earns a 10s penalty; a flap must not forgive it.
+    flap(1.0)
+    now = 11.0
+    scheduled[0][1]()
+    assert attempts == [0.0, 11.0]
+
+    # The second failure escalates to 20s. Another flap must not reset that
+    # either -- under the old behaviour the delay collapsed back to 10s here.
+    flap(12.0)
+    now = 25.0
+    scheduled[0][1]()
+    assert attempts == [0.0, 11.0]
+
+    now = 32.0
+    scheduled[0][1]()
+    assert attempts == [0.0, 11.0, 32.0]


### PR DESCRIPTION
## The defect

`BearerSupervisor._tick()` runs every `POLL_SECONDS` and calls `_update_state(kind, value)` with whatever it just read from BlueZ. The reset was:

```python
if value is True:
    self._last_errors.pop(kind, None)
    self._failures[kind] = 0
    self._next_attempt[kind] = 0.0
```

That fires on every *observation* of `Connected=true`, not on transitions into it. (The comment a few lines below already notes that repeated stale `Connected=true` readings happen.) So the failure counter is zeroed on every poll where the bearer happens to read connected.

For a device whose bearer flaps, the counter is cleared faster than it can accumulate and never exceeds 1. Since the delay is `POLL_SECONDS * (2 ** failures)`, every retry computes `5 * 2**1` = 10s indefinitely, and `BACKOFF_CAP_SECONDS = 300` is unreachable.

The backoff added in the `BACKOFF_CAP_SECONDS` comment ("Repeating Connect every poll turned into a five-second hammer against the iPhone") is therefore inert. It became a ten-second hammer rather than a five-second one. The code reads correctly in isolation; the defect only appears in the interaction with the poll loop.

## Evidence

From a live journal, ten consecutive retries:

```
could not connect iPhone BREDR bearer: ... (next attempt in 10s)   x10
```

Never 20s, never 40s. On the same boot: 3 `connecting iPhone BREDR bearer` lines against **35** `iPhone BR/EDR connected` events. Presence flapped roughly twelve times per connect attempt, and each `true` reset the counter.

`test_backoff_grows_across_repeated_flaps` reproduces this deterministically. Against unpatched source a flap at t=1 produces a retry at t=2, ignoring the 10s penalty:

```
assert [0.0, 2.0] == [0.0, 11.0]
```

## Impact beyond the daemon

A Bluetooth controller has a single LE connection initiator: only one `LE Create Connection` may be outstanding. The kernel reconnects bonded LE peripherals through the accept-list background scan using that same initiator, so an explicit `Connect()` preempts it.

A retry every 10 seconds means BlueFerry repeatedly seizes the slot every other LE device needs. On the affected machine an LE keyboard and mouse took 2m28s and 2m45s to attach after boot, against a realistic floor of a few seconds.

This reproduced identically across two consecutive boots, measured as deltas from the kernel bringing up `hci0`:

| boot | Logitech Pebble K380s | MX Master 4 | backoff delays seen |
| --- | --- | --- | --- |
| 16:43 | +148s | +165s | 10s only |
| 12:51 | +149s | +164s | 10s only |

Both devices are LE-only, so they depend entirely on the accept-list background scan. Stopping BlueFerry took the adapter from seeing 0 LE devices in an 8s scan to 17, and both peripherals then connected on the first attempt.

The trigger needs no unusual hardware: a phone drifting to the edge of range, iOS power management, a dropped MAP/PBAP session (the same journal shows `Unable to find service record` and `MAP session disappeared`), or any host suspend/resume. Laptop users would hit a flap on every lid close.

It is also silent. Nothing errors, peripherals are just slow, and the natural assumption is that the keyboard or the distro is at fault rather than the iPhone bridge, so I would expect this to be under-reported.

## The change

Record when each bearer became connected, and forgive its penalty only once the link has held for `STABLE_CONNECTION_SECONDS` (15, deliberately longer than `POLL_SECONDS` so a link must survive a full probe cycle). A connection that drops inside that window is a flap, not evidence the phone is reachable. The existing backoff machinery is otherwise untouched.

## Two existing tests changed, and why

`test_backoff_resets_once_the_bearer_connects` and `test_untyped_classic_connect_restores_le_preference_before_le_dial` both held their clock frozen, so they were asserting that a *zero-duration* connection forgives the penalty, which is the defect stated as a requirement.

I preserved their intent rather than deleting them, by letting the link actually hold past the dwell window. The first still asserts that a genuine connect clears the backoff; the second still asserts the preference handoff repeats on a later out-of-range cycle, and needed only an injected clock plus one extra tick that issues no new calls.

If instant forgiveness is intended behaviour rather than an artifact of the frozen clock, then this patch is wrong and I would appreciate being told why.

## An observation, not a change

`_reset_classic_backoff_from_le()` has the same shape. I confirmed that a briefly appearing LE link still hands Classic a free retry ahead of its backoff.

I deliberately did **not** touch it. Three tests assert that behaviour on purpose, and an *inbound* LE connection is genuine presence evidence in a way that our own briefly succeeding dial is not. Gating it on the same dwell broke all three, which I read as a clear signal it is designed rather than incidental. Flagging it only in case the flapping case is of interest.

## Limitations

- Observed on a single machine, though it reproduced identically on two consecutive boots of it, so it is not a one-off bad boot. What makes it more than an anecdote is that the mechanism is deterministic and reproducible in a unit test with an injected clock, independent of hardware.
- `STABLE_CONNECTION_SECONDS = 15` is a judgment call, not a derived value. Any value above `POLL_SECONDS` addresses the pathology; happy to change it.

## Testing

`809 passed, 3 skipped` on the standard suite. `ruff check`, `mypy`, and `bandit` are clean on the touched files. I did not run `ruff format`, since the repository already reports these files as unformatted at HEAD and reformatting would bury the change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRbmomtz8jpSGTfpgPKw9e

