### PR TITLE
Fix ANCS recovery after fast LE reconnects

### DIFF
--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -278,6 +278,11 @@ class BearerSupervisor:
         """Request one serialized LE reset after GATT and bearer state diverge."""
         if not self._running:
             return
+        # A successful reset is published locally as disconnected before the
+        # polling source can see a replacement inbound link. Ignore duplicate
+        # failure reports during that synthetic down-state.
+        if self._states["le"] is False:
+            return
         if not self._le_reset_pending:
             log.warning(
                 "ANCS transport disagrees with BlueZ; resetting the LE bearer"
@@ -341,9 +346,7 @@ class BearerSupervisor:
 
         if self._le_reset_pending and self._le_enabled:
             if le is False:
-                self._le_reset_pending = False
-                self._le_reset_failures = 0
-                self._next_le_reset_attempt = 0.0
+                self._complete_le_reset()
             elif le is True:
                 self._request_le_disconnect()
                 return True
@@ -756,17 +759,21 @@ class BearerSupervisor:
         if generation != self._generation:
             return
         self._disconnecting.discard("le")
-        self._le_reset_failures += 1
-        delay = min(
-            POLL_SECONDS * (2 ** self._le_reset_failures),
-            BACKOFF_CAP_SECONDS,
-        )
-        self._next_le_reset_attempt = self._clock() + delay
-        log.info(
-            "iPhone LE bearer reset requested successfully; "
-            "waiting up to %ds for state change",
-            delay,
-        )
+        if not self._le_reset_pending:
+            return
+        # Disconnect success is the generation boundary because iOS may
+        # already be back before the next poll.
+        log.info("iPhone LE bearer reset completed")
+        self._complete_le_reset()
+
+    def _complete_le_reset(self) -> None:
+        """Publish a completed LE reset even if its down-state was transient."""
+        self._le_reset_pending = False
+        self._le_reset_failures = 0
+        self._next_le_reset_attempt = 0.0
+        self._update_state("le", False)
+        if self.bredr_connected and self._le_enabled:
+            self._schedule_le_connect()
 
     def _disconnect_failed(self, error: Exception, generation: int) -> None:
         if generation != self._generation:
@@ -777,10 +784,7 @@ class BearerSupervisor:
             "org.bluez.Error.NotConnected",
             "org.bluez.Error.AlreadyDisconnected",
         } or "not connected" in message.casefold():
-            self._le_reset_pending = False
-            self._update_state("le", False)
-            if self.bredr_connected and self._le_enabled:
-                self._schedule_le_connect()
+            self._complete_le_reset()
             return
         self._le_reset_failures += 1
         delay = min(

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -1338,6 +1338,7 @@ def test_le_observer_receives_only_lifecycle_transitions() -> None:
 def test_gatt_transport_failure_cycles_le_once_before_reconnecting() -> None:
     state = {"bredr": True, "le": True}
     disconnects = []
+    disconnect_callbacks = []
     connections = []
     observed = []
     scheduled = []
@@ -1352,7 +1353,7 @@ def test_gatt_transport_failure_cycles_le_once_before_reconnecting() -> None:
         ),
         disconnect=lambda kind, on_success, _on_error: (
             disconnects.append(kind),
-            on_success(),
+            disconnect_callbacks.append(on_success),
         ),
         on_le_state=observed.append,
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
@@ -1364,16 +1365,55 @@ def test_gatt_transport_failure_cycles_le_once_before_reconnecting() -> None:
     supervisor.recover_le_transport()
     assert disconnects == ["le"]
 
+    state["le"] = False
+    disconnect_callbacks[0]()
     scheduled[0][1]()
     assert disconnects == ["le"]
-
-    state["le"] = False
-    scheduled[0][1]()
     assert observed == [True, False]
     assert scheduled[-1][0] == bearer_supervisor.CLASSIC_SETTLE_SECONDS
 
     scheduled[-1][1]()
     assert connections == ["le"]
+
+
+def test_gatt_transport_reset_preserves_a_reconnect_between_polls() -> None:
+    state = {"bredr": True, "le": True}
+    disconnects = []
+    observed = []
+    scheduled = []
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda *_args: None,
+        disconnect=lambda kind, on_success, _on_error: (
+            disconnects.append(kind),
+            on_success(),
+        ),
+        on_le_state=observed.append,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        cancel=lambda _timer_id: None,
+    )
+    supervisor.start()
+
+    # The iPhone can reconnect before the five-second health poll. The
+    # successful reset reply must still publish the generation boundary so
+    # ANCS can discard its blocked transport and rebuild on the live bearer.
+    supervisor.recover_le_transport()
+    supervisor.recover_le_transport()
+    assert disconnects == ["le"]
+    assert observed == [True, False]
+
+    health_check = next(
+        callback
+        for delay, callback in scheduled
+        if delay == bearer_supervisor.POLL_SECONDS
+    )
+    health_check()
+
+    assert observed == [True, False, True]
+    assert disconnects == ["le"]
+    assert supervisor._le_reset_pending is False
 
 
 def test_gatt_transport_recovery_waits_for_profile_gate_to_reopen() -> None:


### PR DESCRIPTION
## Summary

- treat a successful targeted LE disconnect as the ANCS transport-generation boundary
- publish the otherwise invisible down-state when iOS reconnects before the next bearer poll
- suppress duplicate recovery requests until the replacement LE link is observed
- cover both ordinary and between-polls reconnect sequences with bearer-supervisor tests

## Why

BlueFerry previously waited for its five-second bearer poll to observe `Connected=false` after resetting a stale ANCS transport. If iOS reconnected sooner, every poll continued to see `Connected=true`, leaving ANCS blocked while reset attempts backed off indefinitely.

## Validation

- `dbus-run-session --config-file=tests/dbus-test.conf -- ... python -m coverage run -m pytest -q` — 811 passed
- `ruff check .`
- `mypy src/blueferry`
- `bandit -r src/blueferry -q`
