### PR TITLE
Harden bearer backoff dwell against None reads and LE flaps

### DIFF
--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -16,6 +16,9 @@ from blueferry.bus import get_system_bus
 log = logging.getLogger(__name__)
 
 POLL_SECONDS = 5
+# Forgive backoff only after the bearer has stayed Connected=true this long,
+# so a flap cannot reset the penalty. Three poll intervals.
+STABLE_CONNECTION_SECONDS = POLL_SECONDS * 3
 CLASSIC_SETTLE_SECONDS = 3
 # org.bluez.Bearer*.Connect uses this same timeout below. An InProgress reply
 # means BlueZ owns an overlapping request, so Connected=false cannot settle it
@@ -24,19 +27,13 @@ CONNECT_TIMEOUT_SECONDS = 45
 # A phone that rejects a connection keeps rejecting it for a while (powered
 # off, out of range, or a broken bond). Repeating Connect every poll turned
 # into a five-second hammer against the iPhone; back off exponentially
-# instead, up to this ceiling, and reset as soon as a bearer connects.
+# instead, up to this ceiling. Forgive the penalty only after the bearer has
+# stayed connected for STABLE_CONNECTION_SECONDS.
 BACKOFF_CAP_SECONDS = 300
 # A live LE bearer proves that the phone is in range and answering.  Classic
 # may still decline a page temporarily, but it must not inherit the five-minute
 # absence backoff while ANCS is demonstrably reachable.
 LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS = 30
-# Connected=true is observed on every poll, not only on genuine transitions,
-# so clearing the failure counter on each observation let a phone that connects
-# and drops in a loop reset the backoff before it could grow -- pinning the
-# retry interval at its minimum. Require a bearer to hold this long before its
-# penalty is forgiven. Longer than POLL_SECONDS so a link must survive at least
-# one full probe cycle to count as stable.
-STABLE_CONNECTION_SECONDS = 15
 _INTERFACES = {
     "bredr": "org.bluez.Bearer.BREDR1",
     "le": "org.bluez.Bearer.LE1",
@@ -185,6 +182,9 @@ class BearerSupervisor:
         self._failures: dict[str, int] = {"bredr": 0, "le": 0}
         self._next_attempt: dict[str, float] = {"bredr": 0.0, "le": 0.0}
         self._connected_since: dict[str, float | None] = {"bredr": None, "le": None}
+        # One-shot: a held LE link may forgive Classic backoff earned while the
+        # phone was away, not failures that happened with ANCS already up.
+        self._le_dwell_should_forgive_classic = False
 
     @property
     def bredr_connected(self) -> bool:
@@ -275,6 +275,7 @@ class BearerSupervisor:
         self._failures = {"bredr": 0, "le": 0}
         self._next_attempt = {"bredr": 0.0, "le": 0.0}
         self._connected_since = {"bredr": None, "le": None}
+        self._le_dwell_should_forgive_classic = False
         self._last_errors.clear()
         if self._on_le_state is not None:
             self._on_le_state(None)
@@ -458,15 +459,18 @@ class BearerSupervisor:
             # device that remains absent still receives only one attempt.
             self._rearm_le_dial("iPhone LE disconnected")
         if value is True:
-            if previous is not True:
+            if self._connected_since[kind] is None:
                 self._connected_since[kind] = self._clock()
+                if kind == "le":
+                    self._le_dwell_should_forgive_classic = (
+                        self._failures["bredr"] > 0
+                        or self._clock() < self._next_attempt["bredr"]
+                    )
             self._clear_backoff_if_stable(kind)
-        else:
+        elif value is False:
             self._connected_since[kind] = None
-        if kind == "le" and value is True and previous is not True:
-            # An inbound LE connection is the missing presence event for a
-            # Classic backoff accumulated while the phone was out of range.
-            self._reset_classic_backoff_from_le()
+            if kind == "le":
+                self._le_dwell_should_forgive_classic = False
         # Repeating stale Connected=true after a failed GATT operation can
         # race BlueZ's pending CCC registration with ATT teardown. Consumers
         # therefore receive only genuine bearer lifecycle transitions.
@@ -490,9 +494,9 @@ class BearerSupervisor:
             "retargeting Classic bearer"
         )
         self._clear_connect_request("bredr")
-        # The live LE link is current reachability evidence, so the replacement
-        # request must not inherit a quiet window from the obsolete request.
-        self._reset_classic_backoff_from_le()
+        # The replacement request must not inherit a quiet window from the
+        # obsolete untyped request.
+        self._next_attempt["bredr"] = 0.0
         self._request_connect("bredr")
 
     def _request_connect(self, kind: str) -> None:
@@ -700,12 +704,7 @@ class BearerSupervisor:
         )
 
     def _clear_backoff_if_stable(self, kind: str) -> None:
-        """Forgive a bearer's backoff only once it has held long enough.
-
-        A bearer that connects and immediately drops is not evidence that the
-        phone is reachable; treating it as such reset the penalty faster than
-        it could accumulate.
-        """
+        """Forgive backoff after the bearer has stayed Connected=true long enough."""
         since = self._connected_since[kind]
         if since is None:
             return
@@ -714,9 +713,12 @@ class BearerSupervisor:
         self._last_errors.pop(kind, None)
         self._failures[kind] = 0
         self._next_attempt[kind] = 0.0
+        if kind == "le" and self._le_dwell_should_forgive_classic:
+            self._reset_classic_backoff_from_le()
+            self._le_dwell_should_forgive_classic = False
 
     def _reset_classic_backoff_from_le(self) -> None:
-        """Treat any live LE link as proof that the phone is in range."""
+        """Forgive Classic absence backoff once LE has held long enough."""
         self._last_errors.pop("bredr", None)
         self._failures["bredr"] = 0
         self._next_attempt["bredr"] = 0.0

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -296,6 +296,8 @@ def test_untyped_classic_connect_restores_le_preference_before_le_dial() -> None
     # its earlier penalty is forgiven. This tick issues no new calls.
     now = bearer_supervisor.STABLE_CONNECTION_SECONDS + 1.0
     scheduled[0][1]()
+    assert supervisor._failures["bredr"] == 0
+    assert supervisor._next_attempt["bredr"] == 0.0
 
     # A later out-of-range cycle repeats the handoff instead of leaving the
     # idle preference on BR/EDR after its untyped bootstrap.
@@ -823,15 +825,19 @@ def test_backoff_resets_once_the_bearer_connects() -> None:
     supervisor.start()
     assert attempts == ["bredr"]
 
-    # A bearer that HOLDS clears the penalty, so the next genuine disconnect is
-    # retried promptly instead of inheriting old delays. The link has to survive
-    # the dwell window: a connection that drops immediately is a flap, not
-    # evidence that the phone is reachable.
+    # Leave a penalty that would still be blocking at the drop instant unless
+    # the held link actually forgave it (the original 10s quiet window expires
+    # during a 15s dwell).
+    supervisor._failures["bredr"] = 6
+    supervisor._next_attempt["bredr"] = 300.0
+
     now = 1.0
     state["bredr"] = True
     scheduled[0][1]()
     now = 1.0 + bearer_supervisor.STABLE_CONNECTION_SECONDS
     scheduled[0][1]()
+    assert supervisor._failures["bredr"] == 0
+    assert supervisor._next_attempt["bredr"] == 0.0
     state["bredr"] = False
     scheduled[0][1]()
 
@@ -860,10 +866,15 @@ def test_returning_le_link_retries_classic_without_rewriting_preference() -> Non
     supervisor.start()
     assert attempts == ["bredr"]
 
-    # The old retry is ten seconds away. Live LE clears that penalty and the
-    # targeted Classic retry may run, but it must not change PreferredBearer
-    # underneath the working ANCS link.
+    # The old retry is ten seconds away. A brief LE appearance must not clear
+    # that penalty; a held LE link does. The targeted Classic retry must not
+    # change PreferredBearer underneath the working ANCS link.
     state["le"] = True
+    scheduled[0][1]()
+    assert attempts == ["bredr"]
+    assert supervisor._failures["bredr"] == 1
+
+    now = bearer_supervisor.STABLE_CONNECTION_SECONDS
     scheduled[0][1]()
 
     assert attempts == ["bredr", "bredr"]
@@ -1533,6 +1544,13 @@ def test_inbound_le_during_hold_resets_and_caps_classic_backoff() -> None:
     scheduled[0][1]()
 
     assert supervisor.le_connected is True
+    assert supervisor._failures["bredr"] == 6
+    assert supervisor._next_attempt["bredr"] == 300.0
+    assert connect_callbacks == []
+
+    now = bearer_supervisor.STABLE_CONNECTION_SECONDS
+    scheduled[0][1]()
+
     assert supervisor._failures["bredr"] == 0
     assert supervisor._next_attempt["bredr"] == 0.0
     assert [kind for kind, _on_error in connect_callbacks] == ["bredr"]
@@ -1540,7 +1558,7 @@ def test_inbound_le_during_hold_resets_and_caps_classic_backoff() -> None:
     supervisor._failures["bredr"] = 9
     connect_callbacks[0][1](RuntimeError("not now"))
     assert supervisor._next_attempt["bredr"] == (
-        bearer_supervisor.LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS
+        now + bearer_supervisor.LE_CONNECTED_CLASSIC_BACKOFF_CAP_SECONDS
     )
 
 
@@ -1590,10 +1608,10 @@ def test_stop_cancels_health_check() -> None:
 def test_flapping_bearer_does_not_clear_backoff() -> None:
     """A phone that connects then drops at once must not pin the retry delay.
 
-    Connected=true is observed on every five-second poll, not just on genuine
-    transitions, so clearing the failure counter on each observation let a
-    flapping device reset the backoff before it could ever grow. The retry
-    interval stayed pinned at its five-second minimum forever.
+    Connected=true is observed on every poll, not just on genuine transitions,
+    so clearing the failure counter on each observation let a flapping device
+    reset the backoff before it could ever grow. The retry interval stayed
+    pinned at POLL_SECONDS * 2**1 (10s) forever.
     """
     state = {"bredr": False, "le": False}
     attempts = []
@@ -1689,3 +1707,122 @@ def test_backoff_grows_across_repeated_flaps() -> None:
     now = 32.0
     scheduled[0][1]()
     assert attempts == [0.0, 11.0, 32.0]
+
+
+def test_unavailable_connected_read_does_not_restart_dwell() -> None:
+    """A None Connected read must not restart the 15s timer.
+
+    _read() maps D-Bus errors to None, and only a concrete False is a
+    disconnect. Restarting the dwell on blips would keep a live session from
+    ever forgiving its penalty.
+    """
+    state: dict[str, bool | None] = {"bredr": False, "le": False}
+    scheduled = []
+    now = 0.0
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=lambda _kind, _on_success, on_error: on_error(RuntimeError("not ready")),
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        cancel=lambda _timer_id: None,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    supervisor._failures["bredr"] = 6
+    supervisor._next_attempt["bredr"] = 300.0
+
+    now = 1.0
+    state["bredr"] = True
+    scheduled[0][1]()
+    now = 2.0
+    state["bredr"] = None
+    scheduled[0][1]()
+    now = 1.0 + bearer_supervisor.STABLE_CONNECTION_SECONDS
+    state["bredr"] = True
+    scheduled[0][1]()
+
+    assert supervisor._failures["bredr"] == 0
+    assert supervisor._next_attempt["bredr"] == 0.0
+
+
+def test_brief_le_link_does_not_clear_classic_backoff() -> None:
+    """An LE blip is not evidence the phone is stably in range for Classic."""
+    state = {"bredr": False, "le": False}
+    attempts = []
+    scheduled = []
+    now = 0.0
+
+    def connect(kind, _on_success, on_error):
+        attempts.append(kind)
+        on_error(RuntimeError("not ready"))
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=connect,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        cancel=lambda _timer_id: None,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    assert attempts == ["bredr"]
+    supervisor._failures["bredr"] = 6
+    supervisor._next_attempt["bredr"] = 300.0
+
+    now = 1.0
+    state["le"] = True
+    scheduled[0][1]()
+    now = 2.0
+    state["le"] = False
+    scheduled[0][1]()
+
+    assert attempts == ["bredr"]
+    assert supervisor._failures["bredr"] == 6
+    assert supervisor._next_attempt["bredr"] == 300.0
+
+
+def test_stable_le_clears_classic_backoff_once() -> None:
+    """A held LE link forgives Classic absence backoff once, not every poll."""
+    state = {"bredr": False, "le": False}
+    attempts = []
+    scheduled = []
+    now = 0.0
+
+    def connect(kind, _on_success, on_error):
+        attempts.append((kind, now))
+        on_error(RuntimeError("not ready"))
+
+    supervisor = BearerSupervisor(
+        "/device",
+        read_connected=state.get,
+        connect=connect,
+        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
+        cancel=lambda _timer_id: None,
+        clock=lambda: now,
+    )
+    supervisor.start()
+    supervisor._failures["bredr"] = 6
+    supervisor._next_attempt["bredr"] = 300.0
+
+    now = 1.0
+    state["le"] = True
+    scheduled[0][1]()
+    assert attempts == [("bredr", 0.0)]
+    assert supervisor._failures["bredr"] == 6
+
+    retry_at = 1.0 + bearer_supervisor.STABLE_CONNECTION_SECONDS
+    now = retry_at
+    scheduled[0][1]()
+    assert supervisor._failures["bredr"] == 1
+    assert attempts == [("bredr", 0.0), ("bredr", retry_at)]
+    quiet_until = supervisor._next_attempt["bredr"]
+    assert quiet_until > retry_at
+
+    now = retry_at + 1.0
+    scheduled[0][1]()
+    assert attempts == [("bredr", 0.0), ("bredr", retry_at)]
+
+    now = quiet_until
+    scheduled[0][1]()
+    assert attempts == [("bredr", 0.0), ("bredr", retry_at), ("bredr", quiet_until)]


### PR DESCRIPTION
## Summary

- treat only `Connected=false` as the end of a dwell; a `None` read (D-Bus blip) no longer restarts the 15s timer
- forgive Classic absence backoff only after LE has held `STABLE_CONNECTION_SECONDS`, and only once per dwell
- keep the 30s Classic cap for failures that happen while ANCS is already up
- retarget an in-flight untyped Classic request by clearing its quiet window, not the failure counter
- prove forgiveness against a still-blocking penalty, and cover the None-read and LE-blip cases

## Why

#107 stopped same-bearer flaps from zeroing backoff on every `Connected=true` poll. Two leftovers remained:

- `_read()` maps D-Bus errors to `None`, and that path aborted the dwell the same way a real disconnect does, so probe blips could keep a live session from ever forgiving.
- `_reset_classic_backoff_from_le()` still zeroed Classic `_failures` on any LE `True` transition. A 1s LE blip handed Classic a free retry and pinned it at 10s whenever both bearers flapped at the edge of range.

A held LE link is still presence evidence. A blip is not. In-flight retargeting is a different case: the replacement request must run now, but it should not wipe a failure count that later Classic flaps still need to escalate.

Follow-up to #107.

## Validation

- `python -m pytest tests/test_bearer_supervisor.py -q` — 51 passed
- `ruff check` on the touched files
- `mypy src/blueferry/bearer_supervisor.py`