### PR TITLE
Continue compatibility setup without ANCS advert

### DIFF
--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -1409,7 +1409,13 @@ def _register_solicitation(
     log.debug("registering ANCS solicitation advertisement on %s", adapter)
     quirks_report.mark(attempt, "advert_register_sent")
     if not bluez_setup.register_advert(adapter, settle_for_pairing=True):
-        raise PairingError("The ANCS advertisement did not activate")
+        quirks_report.mark(attempt, "advert_unavailable")
+        if policy.ancs_enabled:
+            raise PairingError("The ANCS advertisement did not activate")
+        log.warning(
+            "ANCS solicitation is unavailable; continuing with MAP/PBAP"
+        )
+        return
     resources.advert_registered = True
     quirks_report.mark(attempt, "advert_ready")
     _record_bluez_state(attempt, device.device_path, "advert_ready", force=True)

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -1371,6 +1371,109 @@ def test_complete_pairing_starts_profiles_while_pairing_advert_is_active(monkeyp
     ]
 
 
+def test_compatibility_pairing_continues_when_solicitation_is_unavailable(
+    monkeypatch,
+    caplog,
+):
+    device = _device(paired=True)
+    policy = pair_setup.resolve_pairing_policy(
+        {
+            "notifications_supported": False,
+            "low_energy": True,
+            "advertising": True,
+        },
+        force_compatibility=True,
+        interactive=False,
+    )
+    attempt = pair_setup.quirks_report.start_attempt(interactive=False)
+    calls = []
+
+    monkeypatch.setattr(
+        pair_setup,
+        "_prepare_pairing",
+        lambda *_args, **_kwargs: pair_setup._PairingPreparation(
+            device=device,
+            adapter="hci0",
+            policy=policy,
+        ),
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_prepare_classic_transport",
+        lambda adapter, _attempt: calls.append(("prepare", adapter)),
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_run_pairing_transaction",
+        lambda *_args, **_kwargs: calls.append(("pair", device.mac)) or device,
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_trust_and_settle",
+        lambda selected, _attempt: calls.append(("settle", selected.mac)),
+    )
+    monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        pair_setup,
+        "_handoff_to_daemon",
+        lambda selected, adapter, selected_policy, _attempt: calls.append(
+            ("handoff", selected.mac, adapter, selected_policy.ancs_enabled)
+        )
+        or pair_setup.PairingTransports(map=True, pbap=True, ancs=False),
+    )
+    monkeypatch.setattr(pair_setup, "_device", lambda *_args, **_kwargs: device)
+
+    outcome = pair_setup._execute_pairing(
+        device.mac,
+        compatibility_mode=True,
+        attempt=attempt,
+    )
+
+    assert outcome.transports == pair_setup.PairingTransports(
+        map=True,
+        pbap=True,
+        ancs=False,
+    )
+    assert outcome.ancs == "disabled"
+    assert calls == [
+        ("prepare", "hci0"),
+        ("pair", device.mac),
+        ("settle", device.mac),
+        ("handoff", device.mac, "hci0", False),
+    ]
+    assert "ANCS solicitation is unavailable; continuing with MAP/PBAP" in caplog.text
+    assert [entry["event"] for entry in attempt["timeline"]][-2:] == [
+        "advert_register_sent",
+        "advert_unavailable",
+    ]
+
+
+def test_full_pairing_still_requires_solicitation(monkeypatch):
+    device = _device(paired=True)
+    policy = pair_setup.resolve_pairing_policy(
+        {
+            "notifications_supported": True,
+            "low_energy": True,
+            "advertising": True,
+        }
+    )
+    attempt = pair_setup.quirks_report.start_attempt(interactive=False)
+    resources = pair_setup._PairingResources()
+    monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: False)
+
+    with pytest.raises(pair_setup.PairingError, match="advertisement did not activate"):
+        pair_setup._register_solicitation(
+            device,
+            "hci0",
+            policy,
+            attempt,
+            resources,
+        )
+
+    assert resources.advert_registered is False
+    assert attempt["timeline"][-1]["event"] == "advert_unavailable"
+
+
 def test_unverified_controller_reaches_the_real_pairing_transaction(
     monkeypatch,
     caplog,


### PR DESCRIPTION
## Summary

- treat ANCS solicitation activation as optional during compatibility-mode pairing
- continue to daemon handoff and MAP/PBAP verification when the advertisement is unavailable
- record `advert_unavailable` in the pairing timeline for diagnostics
- preserve the existing fatal advertisement requirement in full ANCS mode

## Why

Compatibility mode deliberately uses MAP and PBAP as its success boundary. A controller can be fully usable for those Classic profiles even when BlueZ rejects the optional ANCS solicitation advertisement. Setup previously aborted before either profile was tested, leaving pairing reports with `map: null` and `pbap: null`.

Fixes #109.

## Validation

- isolated D-Bus suite: 815 passed
- `ruff check src tests`
- `mypy src/blueferry`
- `bandit -r src/blueferry -q`
