### PR TITLE
Install the phone-audio fragment before pairing

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -110,7 +110,10 @@ connection. MAP and PBAP are its successful end state; absence of Notification
 Access is expected and group messages may consequently lack ANCS-derived group
 metadata.
 
-Both modes activate obexd's local Message Notification Server before pairing.
+Both modes activate obexd's local Message Notification Server before pairing
+and install BlueFerry's WirePlumber phone-audio fragment so this computer is
+not an A2DP/HFP sink when iOS first connects. A failed pairing attempt removes
+that fragment if this attempt created it.
 After authentication, setup trusts the bond, selects BR/EDR as the preferred
 bearer, lets the existing Classic ACL settle, and only then registers the
 short-lived solicitation advertisement. The daemon starts while that advert

--- a/README.md
+++ b/README.md
@@ -277,11 +277,13 @@ Restart the user service after editing `local.env` settings.
 When WirePlumber 0.5 or newer is installed, BlueFerry keeps calls and music on
 the iPhone by writing
 `~/.config/wireplumber/wireplumber.conf.d/99-blueferry-keep-phone-audio.conf`
-and reloading WirePlumber if that fragment changed. The fragment removes the
-adapter roles that make this computer an A2DP/HFP sink, and disables
+before pairing and waiting for WirePlumber to reload it. The fragment removes
+the adapter roles that make this computer an A2DP/HFP sink, and disables
 auto-connect on phone cards so a later `bluetooth-a2dp-autoconnect` rule cannot
-steal the stream. Set `BLUEFERRY_KEEP_PHONE_AUDIO_ON_PHONE=false` to remove
-BlueFerry's fragment only.
+steal the stream. A failed pairing attempt removes a fragment that attempt
+installed. After a successful bond the daemon keeps reconciling the same
+file. Set `BLUEFERRY_KEEP_PHONE_AUDIO_ON_PHONE=false` to remove BlueFerry's
+fragment only.
 
 ## Command line
 

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -97,7 +97,11 @@ def _char_path_to_device_path(char_path: str) -> str:
 def _connection_was_lost(error: dbus.exceptions.DBusException) -> bool:
     name = (error.get_dbus_name() or "").casefold()
     detail = (error.get_dbus_message() or str(error)).casefold()
-    return name.endswith(".notconnected") or "not connected" in detail
+    return (
+        name.endswith(".notconnected")
+        or "not connected" in detail
+        or "no att transport" in detail
+    )
 
 
 def _notification_is_already_stopped(
@@ -634,17 +638,10 @@ class AncsClient:
             return
         if self._transport_blocked:
             return
-        # During first-time authorization, registering the GATT notification
-        # subscriptions is part of the connection bootstrap on some iPhone
-        # and controller combinations. In particular, BlueZ can expose the
-        # bonded ANCS characteristics while Bearer.LE1 remains disconnected
-        # and its explicit Connect method fails. Once authorization has ever
-        # succeeded, retain the stricter settled-bearer requirement so stale
-        # GATT objects cannot masquerade as a live subscription after a
-        # reconnect.
-        if self._was_authorized and (
-            self._bearer_connected is not True or not self._bearer_ready
-        ):
+        # BlueZ keeps bonded ANCS objects after ATT drops. StartNotify/CP on
+        # those objects returns Not connected / No ATT transport and never
+        # reaches iOS, so the notification-access prompt does not appear.
+        if self._bearer_connected is not True or not self._bearer_ready:
             return
         if not (self._ns_path and self._ds_path and self._cp_path):
             return
@@ -714,7 +711,7 @@ class AncsClient:
                     match.remove()
                 except Exception:
                     log.debug("could not roll back ANCS signal watch", exc_info=True)
-            if _connection_was_lost(e) and self._was_authorized:
+            if _connection_was_lost(e):
                 self._mark_transport_failed()
             else:
                 # Do not StopNotify a characteristic that succeeded before a
@@ -942,7 +939,7 @@ class AncsClient:
             name = error.get_dbus_name() or type(error).__name__
             detail = error.get_dbus_message() or str(error)
             log.warning("ANCS CP WriteValue failed: %s: %s", name, detail)
-            if _connection_was_lost(error) and self._was_authorized:
+            if _connection_was_lost(error):
                 self._mark_transport_failed()
                 return
             self._abandon_request(request)

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -280,7 +280,6 @@ class Daemon:
         self._startup_id = None
         self._initialization_retry_id = None
         try:
-            self.phone_audio.reconcile(enabled=config.KEEP_PHONE_AUDIO_ON_PHONE)
             self._initialize_bluetooth()
         except PairingRequiredError as error:
             log.warning("Bluetooth setup is incomplete: %s", error)
@@ -302,6 +301,8 @@ class Daemon:
             raise PairingRequiredError(
                 "the saved iPhone is not currently paired; open a client to pair it"
             )
+
+        self.phone_audio.reconcile(enabled=config.KEEP_PHONE_AUDIO_ON_PHONE)
 
         # Class-of-Device is controller state, not durable configuration.
         # Repair it before opening either bearer and continue supervising it

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -26,6 +26,7 @@ from blueferry.pairing_policy import PairingPolicy, resolve_pairing_policy
 from blueferry.pairing_types import PairingAttempt, PairingOutcome, PairingTransports
 from blueferry.private_files import atomic_write_private_text, read_private_text
 from blueferry.setup_verification import clear_setup_verification
+from blueferry.wireplumber_policy import WirePlumberPhoneAudioPolicy
 
 log = logging.getLogger(__name__)
 
@@ -723,6 +724,28 @@ def _prefer_bearer(device_path: str, kind: str) -> None:
 def _prefer_bredr(device_path: str) -> None:
     """Prefer BR/EDR after pairing when BlueZ exposes PreferredBearer."""
     _prefer_bearer(device_path, "bredr")
+
+
+def _apply_phone_audio_policy(attempt: PairingAttempt) -> bool:
+    """Load the phone-audio fragment before iOS probes A2DP/HFP on Connect.
+
+    Returns whether this attempt wrote or replaced the owned fragment, so a
+    later failure can remove only what pairing just installed.
+    """
+    if not config.KEEP_PHONE_AUDIO_ON_PHONE:
+        quirks_report.mark(attempt, "phone_audio_policy_skipped")
+        return False
+    changed = WirePlumberPhoneAudioPolicy(wait_for_restart=True).reconcile(
+        enabled=True
+    )
+    quirks_report.mark(attempt, "phone_audio_policy_ready", changed=changed)
+    return changed
+
+
+def _revert_phone_audio_policy(attempt: PairingAttempt) -> None:
+    """Drop a fragment this pairing attempt installed, so a failed setup does not linger."""
+    WirePlumberPhoneAudioPolicy(wait_for_restart=True).reconcile(enabled=False)
+    quirks_report.mark(attempt, "phone_audio_policy_removed")
 
 
 def _activate_obex_mns() -> None:
@@ -1501,65 +1524,73 @@ def _execute_pairing(
     device = preparation.device
     selected_adapter = preparation.adapter
     policy = preparation.policy
-    _prepare_classic_transport(selected_adapter, attempt)
-
-    resources = _PairingResources()
+    phone_audio_installed = _apply_phone_audio_policy(attempt)
+    success = False
     try:
-        device = _run_pairing_transaction(
-            mac,
-            device,
-            selected_adapter,
-            policy,
-            confirmation=confirmation,
-            display=display,
-            attempt=attempt,
-            resources=resources,
-        )
-        _trust_and_settle(device, attempt)
-        _register_solicitation(
-            device,
-            selected_adapter,
-            policy,
-            attempt,
-            resources,
-        )
-        transports = _handoff_to_daemon(
-            device,
-            selected_adapter,
-            policy,
-            attempt,
-        )
-    finally:
-        _cleanup_pairing_resources(
-            device,
-            selected_adapter,
-            attempt,
-            resources,
-        )
+        _prepare_classic_transport(selected_adapter, attempt)
 
-    device = _device(mac, adapter=selected_adapter)
-    _snapshot_phone(attempt, device)
-    _record_bluez_state(attempt, device.device_path, "finished", force=True)
-    return PairingOutcome(
-        device=device,
-        config=str(LOCAL_ENV_PATH),
-        service="package-enabled and restarted",
-        ancs=(
-            "disabled"
-            if not policy.ancs_enabled
-            else "connected"
-            if transports.ancs
-            else "daemon connecting"
-        ),
-        ancs_enabled=policy.ancs_enabled,
-        transports=transports,
-        iphone_steps=(
-            "Open Settings → Bluetooth and tap ⓘ next to this computer",
-            "If this computer is listed twice, check both entries",
-            "Toggle on Show Message Notifications and Sync Contacts",
-            "You may need to back out and tap ⓘ again to make these toggles appear",
-        ),
-    )
+        resources = _PairingResources()
+        try:
+            device = _run_pairing_transaction(
+                mac,
+                device,
+                selected_adapter,
+                policy,
+                confirmation=confirmation,
+                display=display,
+                attempt=attempt,
+                resources=resources,
+            )
+            _trust_and_settle(device, attempt)
+            _register_solicitation(
+                device,
+                selected_adapter,
+                policy,
+                attempt,
+                resources,
+            )
+            transports = _handoff_to_daemon(
+                device,
+                selected_adapter,
+                policy,
+                attempt,
+            )
+        finally:
+            _cleanup_pairing_resources(
+                device,
+                selected_adapter,
+                attempt,
+                resources,
+            )
+
+        device = _device(mac, adapter=selected_adapter)
+        _snapshot_phone(attempt, device)
+        _record_bluez_state(attempt, device.device_path, "finished", force=True)
+        outcome = PairingOutcome(
+            device=device,
+            config=str(LOCAL_ENV_PATH),
+            service="package-enabled and restarted",
+            ancs=(
+                "disabled"
+                if not policy.ancs_enabled
+                else "connected"
+                if transports.ancs
+                else "daemon connecting"
+            ),
+            ancs_enabled=policy.ancs_enabled,
+            transports=transports,
+            iphone_steps=(
+                "Open Settings → Bluetooth and tap ⓘ next to this computer",
+                "If this computer is listed twice, check both entries",
+                "Toggle on Show Message Notifications and Sync Contacts",
+                "You may need to back out and tap ⓘ again to make these toggles appear",
+            ),
+        )
+        success = True
+        return outcome
+    finally:
+        if not success and phone_audio_installed:
+            _revert_phone_audio_policy(attempt)
 
 
 def forget_device(mac: str, *, adapter: str | None = None) -> None:

--- a/src/blueferry/wireplumber_policy.py
+++ b/src/blueferry/wireplumber_policy.py
@@ -116,17 +116,12 @@ def _wireplumber_05_or_newer() -> bool:
     return version >= (0, 5)
 
 
-def _restart_wireplumber() -> None:
-    run_command(
-        [
-            "/usr/bin/systemctl",
-            "--user",
-            "--no-block",
-            "try-restart",
-            "wireplumber.service",
-        ],
-        timeout=5,
-    )
+def _restart_wireplumber(*, wait: bool = False) -> None:
+    command = ["/usr/bin/systemctl", "--user"]
+    if not wait:
+        command.append("--no-block")
+    command.extend(["try-restart", "wireplumber.service"])
+    run_command(command, timeout=30 if wait else 5)
 
 
 def _matches(path: Path, expected: str) -> bool:
@@ -170,12 +165,15 @@ class WirePlumberPhoneAudioPolicy:
         path: Path | None = None,
         active: ActiveCheck = _wireplumber_active,
         supported: SupportedCheck = _wireplumber_05_or_newer,
-        restart: Restart = _restart_wireplumber,
+        restart: Restart | None = None,
+        wait_for_restart: bool = False,
     ) -> None:
         self.path = path or fragment_path()
         self._active = active
         self._supported = supported
-        self._restart = restart
+        self._restart = restart or (
+            lambda: _restart_wireplumber(wait=wait_for_restart)
+        )
 
     def reconcile(self, *, enabled: bool) -> bool:
         """Apply or remove the policy and reload WirePlumber on change.

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -534,9 +534,7 @@ def test_start_notify_failure_retries_without_rediscovery(monkeypatch) -> None:
     assert ds.start_calls == 1
 
 
-def test_initial_subscription_bootstraps_a_disconnected_le_bearer(
-    monkeypatch,
-) -> None:
+def test_initial_subscription_waits_for_a_settled_le_bearer(monkeypatch) -> None:
     calls = []
 
     class _Characteristic:
@@ -571,51 +569,32 @@ def test_initial_subscription_bootstraps_a_disconnected_le_bearer(
 
     client._try_subscribe()
 
-    assert calls == [
-        ("start", "ns"),
-        ("start", "ds"),
-        ("write", "cp"),
-    ]
-    assert client.subscribed is True
-    assert client.authorized is False
-    assert client.connected is False
+    assert calls == []
+    assert client.subscribed is False
+
+    client.observe_bearer_state(True)
+    assert client._bearer_settle_id is not None
 
 
-def test_disconnected_initial_subscription_keeps_retrying(monkeypatch) -> None:
+def test_missing_att_transport_resets_a_connected_le_bearer(monkeypatch) -> None:
     scheduled = []
     resets = []
 
     class _Characteristic:
-        def __init__(self, *, fail_once: bool = False) -> None:
-            self.fail_once = fail_once
-            self.start_calls = 0
-
-        def StartNotify(self, **_kwargs) -> None:
-            self.start_calls += 1
-            if self.fail_once:
-                self.fail_once = False
-                raise client_module.dbus.exceptions.DBusException(
-                    "Not connected",
-                    name="org.bluez.Error.NotConnected",
-                )
-
         @staticmethod
-        def WriteValue(_value, _options, **_kwargs) -> None:
-            return None
+        def StartNotify(**_kwargs) -> None:
+            raise client_module.dbus.exceptions.DBusException(
+                "No ATT transport",
+                name="org.bluez.Error.Failed",
+            )
 
-    ns = _Characteristic(fail_once=True)
-    ds = _Characteristic()
-    cp = _Characteristic()
-    bus = _CharacteristicBus(
-        {"/device/ns": ns, "/device/ds": ds, "/device/cp": cp}
-    )
+    bus = _CharacteristicBus({
+        "/device/ns": _Characteristic(),
+        "/device/ds": _Characteristic(),
+        "/device/cp": _Characteristic(),
+    })
     monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
     monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
-    monkeypatch.setattr(
-        client_module.GLib,
-        "timeout_add_seconds",
-        lambda _delay, _callback: 9,
-    )
     monkeypatch.setattr(client_module.GLib, "source_remove", lambda _timer: None)
     client = AncsClient(
         "/device",
@@ -624,8 +603,8 @@ def test_disconnected_initial_subscription_keeps_retrying(monkeypatch) -> None:
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
     )
     client._started = True
-    client._bearer_connected = False
-    client._bearer_ready = False
+    client._bearer_connected = True
+    client._bearer_ready = True
     client._ns_path = "/device/ns"
     client._ds_path = "/device/ds"
     client._cp_path = "/device/cp"
@@ -633,82 +612,10 @@ def test_disconnected_initial_subscription_keeps_retrying(monkeypatch) -> None:
     client._try_subscribe()
 
     assert client.subscribed is False
-    assert client._transport_blocked is False
-    assert resets == []
-    assert scheduled[0][0] == client_module.SUBSCRIBE_RETRY_SECONDS
-
+    assert client._transport_blocked is True
+    assert scheduled[0][0] == client_module.TRANSPORT_RESET_SECONDS
     scheduled[0][1]()
-
-    assert ns.start_calls == 2
-    assert ds.start_calls == 1
-    assert client.subscribed is True
-    assert client._transport_blocked is False
-
-
-def test_disconnected_initial_authorization_write_keeps_retrying(
-    monkeypatch,
-) -> None:
-    scheduled = []
-    resets = []
-
-    class _Characteristic:
-        @staticmethod
-        def StartNotify(**_kwargs) -> None:
-            return None
-
-    class _ControlPoint:
-        def __init__(self) -> None:
-            self.write_calls = 0
-
-        def WriteValue(self, _value, _options, **_kwargs) -> None:
-            self.write_calls += 1
-            if self.write_calls == 1:
-                raise client_module.dbus.exceptions.DBusException(
-                    "Not connected",
-                    name="org.bluez.Error.NotConnected",
-                )
-
-    cp = _ControlPoint()
-    bus = _CharacteristicBus({
-        "/device/ns": _Characteristic(),
-        "/device/ds": _Characteristic(),
-        "/device/cp": cp,
-    })
-    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
-    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
-    monkeypatch.setattr(
-        client_module.GLib,
-        "timeout_add_seconds",
-        lambda _delay, _callback: 9,
-    )
-    monkeypatch.setattr(client_module.GLib, "source_remove", lambda _timer: None)
-    client = AncsClient(
-        "/device",
-        lambda _event: None,
-        on_transport_failure=lambda: resets.append(True),
-        schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
-    )
-    client._started = True
-    client._bearer_connected = False
-    client._bearer_ready = False
-    client._ns_path = "/device/ns"
-    client._ds_path = "/device/ds"
-    client._cp_path = "/device/cp"
-
-    client._try_subscribe()
-
-    assert client.subscribed is True
-    assert client.authorized is False
-    assert client._transport_blocked is False
-    assert resets == []
-    assert scheduled[0][0] == client_module.AUTHORIZATION_RETRY_SECONDS
-
-    scheduled[0][1]()
-
-    assert cp.write_calls == 2
-    _complete_authorization_probe(client)
-    assert client.authorized is True
-    assert client.connected is False
+    assert resets == [True]
 
 
 def test_previously_authorized_subscription_waits_for_a_settled_bearer(

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -96,7 +96,7 @@ def test_start_publishes_dbus_before_scheduling_bluetooth(monkeypatch):
 
     scheduled[0]()
 
-    assert order == ["dirs", "claim", "storage", "service", "audio", "bluetooth"]
+    assert order == ["dirs", "claim", "storage", "service", "bluetooth"]
     assert instance._initializing is False
 
 
@@ -187,6 +187,8 @@ def test_failed_hardware_initialization_leaves_control_service_alive(monkeypatch
 def test_missing_bond_never_prepares_or_connects_bluetooth(monkeypatch):
     instance = _bare_daemon()
     prepared = []
+    audio = []
+    instance.phone_audio = SimpleNamespace(reconcile=lambda **kwargs: audio.append(kwargs))
     monkeypatch.setattr(daemon_mod, "bond_status", lambda *_args: False)
     monkeypatch.setattr(
         daemon_mod.bluez_setup,
@@ -198,6 +200,25 @@ def test_missing_bond_never_prepares_or_connects_bluetooth(monkeypatch):
         instance._initialize_bluetooth()
 
     assert prepared == []
+    assert audio == []
+
+
+def test_bonded_start_reconciles_phone_audio_before_adapter_class(monkeypatch):
+    instance = _bare_daemon()
+    order = []
+    monkeypatch.setattr(daemon_mod.config, "KEEP_PHONE_AUDIO_ON_PHONE", True)
+    monkeypatch.setattr(daemon_mod, "bond_status", lambda *_args: True)
+    instance.phone_audio = SimpleNamespace(
+        reconcile=lambda **kwargs: order.append(("audio", kwargs["enabled"]))
+    )
+    instance.adapter_class = SimpleNamespace(
+        start=lambda: order.append("class") or (_ for _ in ()).throw(RuntimeError("stop"))
+    )
+
+    with pytest.raises(RuntimeError, match="stop"):
+        instance._initialize_bluetooth()
+
+    assert order == [("audio", True), "class"]
 
 
 def test_transient_missing_release_marker_does_not_stop_daemon(monkeypatch):

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -80,6 +80,9 @@ def _daemon(calls):
     value.profiles = _Profiles(calls)
     value.adapter_class = _AdapterClass(calls)
     value.solicitation = _Solicitation(calls)
+    value.phone_audio = type(
+        "Audio", (), {"reconcile": lambda self, **_kwargs: False}
+    )()
     value.notification_policy = type(
         "Policy", (), {"value": "messages", "contacts_only": False}
     )()

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -12,6 +12,8 @@ from blueferry import bluez_setup, config, pair_setup
 from blueferry.bluetooth_devices import iphone_candidates
 
 _BLUEZ_DEVICE_SNAPSHOT = pair_setup._bluez_device_snapshot
+_REAL_APPLY_PHONE_AUDIO_POLICY = pair_setup._apply_phone_audio_policy
+_REAL_REVERT_PHONE_AUDIO_POLICY = pair_setup._revert_phone_audio_policy
 
 
 @pytest.fixture(autouse=True)
@@ -34,6 +36,8 @@ def _pairing_reports_in_tmp(tmp_path, monkeypatch):
         "_bluez_device_snapshot",
         lambda _path: {"device_present": False},
     )
+    monkeypatch.setattr(pair_setup, "_apply_phone_audio_policy", lambda _attempt: False)
+    monkeypatch.setattr(pair_setup, "_revert_phone_audio_policy", lambda _attempt: None)
 
 
 def _device(*, paired: bool) -> pair_setup.PairedDevice:
@@ -1446,6 +1450,200 @@ def test_compatibility_pairing_continues_when_solicitation_is_unavailable(
         "advert_register_sent",
         "advert_unavailable",
     ]
+
+
+def _stub_execute_pairing_body(monkeypatch, device, *, pair=None, prepare=None):
+    policy = pair_setup.resolve_pairing_policy(
+        {
+            "notifications_supported": True,
+            "low_energy": True,
+            "advertising": True,
+        }
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_prepare_pairing",
+        lambda *_args, **_kwargs: pair_setup._PairingPreparation(
+            device=device,
+            adapter="hci0",
+            policy=policy,
+        ),
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_prepare_classic_transport",
+        prepare or (lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_run_pairing_transaction",
+        pair or (lambda *_args, **_kwargs: device),
+    )
+    monkeypatch.setattr(pair_setup, "_trust_and_settle", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(bluez_setup, "register_advert", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(bluez_setup, "unregister_advert", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        pair_setup,
+        "_handoff_to_daemon",
+        lambda *_args, **_kwargs: pair_setup.PairingTransports(True, True, True),
+    )
+    monkeypatch.setattr(pair_setup, "_device", lambda *_args, **_kwargs: device)
+
+
+def test_phone_audio_policy_is_applied_before_classic_prepare(monkeypatch):
+    device = _device(paired=True)
+    order = []
+    monkeypatch.setattr(
+        pair_setup,
+        "_apply_phone_audio_policy",
+        lambda _attempt: order.append("audio") or True,
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_revert_phone_audio_policy",
+        lambda _attempt: order.append("revert"),
+    )
+    _stub_execute_pairing_body(
+        monkeypatch,
+        device,
+        prepare=lambda *_args, **_kwargs: order.append("classic"),
+        pair=lambda *_args, **_kwargs: order.append("pair") or device,
+    )
+
+    pair_setup._execute_pairing(
+        device.mac,
+        attempt=pair_setup.quirks_report.start_attempt(interactive=False),
+    )
+
+    assert order == ["audio", "classic", "pair"]
+
+
+def test_failed_pairing_removes_phone_audio_policy_it_installed(monkeypatch):
+    device = _device(paired=False)
+    calls = []
+    monkeypatch.setattr(
+        pair_setup,
+        "_apply_phone_audio_policy",
+        lambda _attempt: calls.append("apply") or True,
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_revert_phone_audio_policy",
+        lambda _attempt: calls.append("revert"),
+    )
+    _stub_execute_pairing_body(
+        monkeypatch,
+        device,
+        pair=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            pair_setup.PairingError("confirmation cancelled")
+        ),
+    )
+
+    with pytest.raises(pair_setup.PairingError, match="confirmation cancelled"):
+        pair_setup._execute_pairing(
+            device.mac,
+            attempt=pair_setup.quirks_report.start_attempt(interactive=False),
+        )
+
+    assert calls == ["apply", "revert"]
+
+
+def test_failed_pairing_keeps_a_preexisting_phone_audio_policy(monkeypatch):
+    device = _device(paired=False)
+    calls = []
+    monkeypatch.setattr(
+        pair_setup,
+        "_apply_phone_audio_policy",
+        lambda _attempt: calls.append("apply") or False,
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_revert_phone_audio_policy",
+        lambda _attempt: calls.append("revert"),
+    )
+    _stub_execute_pairing_body(
+        monkeypatch,
+        device,
+        prepare=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            pair_setup.PairingError("adapter prepare failed")
+        ),
+    )
+
+    with pytest.raises(pair_setup.PairingError, match="adapter prepare failed"):
+        pair_setup._execute_pairing(
+            device.mac,
+            attempt=pair_setup.quirks_report.start_attempt(interactive=False),
+        )
+
+    assert calls == ["apply"]
+
+
+def test_successful_pairing_keeps_phone_audio_policy(monkeypatch):
+    device = _device(paired=True)
+    calls = []
+    monkeypatch.setattr(
+        pair_setup,
+        "_apply_phone_audio_policy",
+        lambda _attempt: calls.append("apply") or True,
+    )
+    monkeypatch.setattr(
+        pair_setup,
+        "_revert_phone_audio_policy",
+        lambda _attempt: calls.append("revert"),
+    )
+    _stub_execute_pairing_body(monkeypatch, device)
+
+    pair_setup._execute_pairing(
+        device.mac,
+        attempt=pair_setup.quirks_report.start_attempt(interactive=False),
+    )
+
+    assert calls == ["apply"]
+
+
+def test_apply_phone_audio_policy_skips_when_disabled(monkeypatch):
+    monkeypatch.setattr(
+        pair_setup, "_apply_phone_audio_policy", _REAL_APPLY_PHONE_AUDIO_POLICY
+    )
+    monkeypatch.setattr(config, "KEEP_PHONE_AUDIO_ON_PHONE", False)
+    constructed = []
+
+    class FakePolicy:
+        def __init__(self, **kwargs):
+            constructed.append(kwargs)
+
+        def reconcile(self, **_kwargs):
+            raise AssertionError("disabled policy must not write a fragment")
+
+    monkeypatch.setattr(pair_setup, "WirePlumberPhoneAudioPolicy", FakePolicy)
+    attempt = pair_setup.quirks_report.start_attempt(interactive=False)
+
+    assert pair_setup._apply_phone_audio_policy(attempt) is False
+    assert constructed == []
+    assert attempt["timeline"][-1]["event"] == "phone_audio_policy_skipped"
+
+
+def test_apply_phone_audio_policy_waits_for_wireplumber(monkeypatch):
+    monkeypatch.setattr(
+        pair_setup, "_apply_phone_audio_policy", _REAL_APPLY_PHONE_AUDIO_POLICY
+    )
+    monkeypatch.setattr(config, "KEEP_PHONE_AUDIO_ON_PHONE", True)
+    constructed = []
+
+    class FakePolicy:
+        def __init__(self, **kwargs):
+            constructed.append(kwargs)
+
+        def reconcile(self, *, enabled):
+            assert enabled is True
+            return True
+
+    monkeypatch.setattr(pair_setup, "WirePlumberPhoneAudioPolicy", FakePolicy)
+    attempt = pair_setup.quirks_report.start_attempt(interactive=False)
+
+    assert pair_setup._apply_phone_audio_policy(attempt) is True
+    assert constructed == [{"wait_for_restart": True}]
+    assert attempt["timeline"][-1]["event"] == "phone_audio_policy_ready"
 
 
 def test_full_pairing_still_requires_solicitation(monkeypatch):

--- a/tests/test_quirks_report.py
+++ b/tests/test_quirks_report.py
@@ -19,6 +19,8 @@ def _pairing_diagnostics(monkeypatch):
         "_bluez_device_snapshot",
         lambda _path: {"device_present": False},
     )
+    monkeypatch.setattr(pair_setup, "_apply_phone_audio_policy", lambda _attempt: False)
+    monkeypatch.setattr(pair_setup, "_revert_phone_audio_policy", lambda _attempt: None)
 
 
 @pytest.fixture

--- a/tests/test_wireplumber_policy.py
+++ b/tests/test_wireplumber_policy.py
@@ -1,11 +1,14 @@
 """WirePlumber phone-audio policy is owned, reversible, and change-driven."""
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from blueferry.wireplumber_policy import (
     FRAGMENT_TEXT,
     LEGACY_FRAGMENT_NAME,
     WirePlumberPhoneAudioPolicy,
     _parse_wireplumber_version,
+    _restart_wireplumber,
 )
 
 
@@ -110,3 +113,53 @@ def test_parse_wireplumber_version_from_linked_banner() -> None:
     assert _parse_wireplumber_version(
         "wireplumber\nCompiled with libwireplumber 0.5.15\n"
     ) == (0, 5)
+
+
+def test_blocking_restart_waits_for_wireplumber(monkeypatch) -> None:
+    seen: list[tuple[list[str], float]] = []
+
+    def fake_run(argv, **kwargs):
+        seen.append((list(argv), kwargs["timeout"]))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("blueferry.wireplumber_policy.run_command", fake_run)
+
+    _restart_wireplumber(wait=True)
+    _restart_wireplumber()
+
+    assert seen == [
+        (
+            ["/usr/bin/systemctl", "--user", "try-restart", "wireplumber.service"],
+            30,
+        ),
+        (
+            [
+                "/usr/bin/systemctl",
+                "--user",
+                "--no-block",
+                "try-restart",
+                "wireplumber.service",
+            ],
+            5,
+        ),
+    ]
+
+
+def test_pairing_policy_waits_for_wireplumber_reload(tmp_path, monkeypatch) -> None:
+    seen: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        seen.append(list(argv))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("blueferry.wireplumber_policy.run_command", fake_run)
+    path = tmp_path / "wireplumber.conf.d" / "99-blueferry-keep-phone-audio.conf"
+    policy = WirePlumberPhoneAudioPolicy(
+        path=path,
+        active=lambda: True,
+        supported=lambda: True,
+        wait_for_restart=True,
+    )
+
+    assert policy.reconcile(enabled=True) is True
+    assert seen == [["/usr/bin/systemctl", "--user", "try-restart", "wireplumber.service"]]


### PR DESCRIPTION
## Summary

- install `99-blueferry-keep-phone-audio.conf` before the pairing transaction and wait for WirePlumber to reload it
- if this pairing attempt fails, remove only the fragment it installed
- daemon still reconciles the same file after a successful bond, and does not write it when no phone is paired

## Why

iOS probes A2DP/HFP on first `Connect`. The previous path applied the WirePlumber policy only after the daemon started, so the phone could still treat this PC as a headset/speaker during first pair.

## Validation

- `python -m pytest tests/test_wireplumber_policy.py tests/test_daemon_lifecycle.py tests/test_pair_setup.py tests/test_quirks_report.py -q` — 126 passed
- `ruff check` on the touched Python files