### PR TITLE
Do not RemoveSession when the daemon stops

### DIFF
--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -603,7 +603,13 @@ class Daemon:
             self._sleep_match = None
         if self._dbus_service is not None:
             self._dbus_service.close()
-        self.obex_worker.shutdown(cleanup=self.sessions.close_all)
+        # BlueZ 5.87 SIGSEGVs in gobex when RemoveSession runs on shutdown,
+        # including after a healthy MAP/PBAP lifetime. Drop local session
+        # state only; the D-Bus disconnect and the next open's stale cleanup
+        # release whatever obexd still holds.
+        self.obex_worker.shutdown(
+            cleanup=lambda: self.sessions.close_all(remove_remote=False),
+        )
         self.storage.close()
         self.sessions.stop_monitoring()
         main_loop.quit()

--- a/src/blueferry/obex/sessions.py
+++ b/src/blueferry/obex/sessions.py
@@ -217,9 +217,10 @@ class SessionManager:
 
         Recovery from an observed transport loss must not call RemoveSession:
         BlueZ 5.87 can crash when that request drives an already-disconnected
-        GObex channel into read_packet(). Normal shutdown and partial-open
-        cleanup still remove live remote sessions; the next open attempt can
-        clean up any surviving stale object after the reconnect delay.
+        GObex channel into read_packet(). Daemon shutdown must not call it
+        either: the same D-Bus dispatch path SIGSEGVs even after a long-lived
+        healthy session. The next open attempt can clean up any surviving
+        stale object after the reconnect delay.
         """
         self._closing = True
         try:

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -100,6 +100,32 @@ def test_start_publishes_dbus_before_scheduling_bluetooth(monkeypatch):
     assert instance._initializing is False
 
 
+def test_stop_does_not_ask_obexd_to_remove_sessions(monkeypatch):
+    instance = _bare_daemon()
+    closed = []
+    instance.adapter_class = SimpleNamespace(stop=lambda: None)
+    instance.bearers = SimpleNamespace(stop=lambda: None)
+    instance.profiles = SimpleNamespace(stop=lambda: None)
+    instance.listener = None
+    instance.ancs = None
+    instance.solicitation = SimpleNamespace(stop=lambda: None)
+    instance.events = SimpleNamespace(stop=lambda: None)
+    instance._sleep_match = None
+    instance.storage = SimpleNamespace(close=lambda: None)
+    instance.sessions = SimpleNamespace(
+        close_all=lambda **kwargs: closed.append(kwargs),
+        stop_monitoring=lambda: None,
+    )
+    instance.obex_worker = SimpleNamespace(
+        shutdown=lambda **kwargs: kwargs["cleanup"]()
+    )
+    monkeypatch.setattr(daemon_mod.main_loop, "quit", lambda: None)
+
+    instance.stop()
+
+    assert closed == [{"remove_remote": False}]
+
+
 def test_no_storage_policy_reasserts_empty_local_data(monkeypatch):
     instance = _bare_daemon()
     status = SimpleNamespace(


### PR DESCRIPTION
## Summary

- on daemon stop, drop local MAP/PBAP session state without calling `Client1.RemoveSession`
- leave stale-session cleanup to the next open after the D-Bus disconnect

## Why

BlueZ 5.87 `obexd` SIGSEGVs in `dbus_connection_dispatch` when shutdown calls `RemoveSession`. This happened both after a long-lived healthy session (daemon restart) and during forget/re-pair while the ACL was already flapping. The reconnect path already skips `RemoveSession` after transport loss for the same GObex bug; shutdown still used it.

## Validation

- `python -m pytest tests/test_daemon_lifecycle.py tests/test_session_reconnect.py -q` — 22 passed