### PR TITLE
Open conversations from notifications and mark them read

### DIFF
--- a/data/blueferry-quickshell
+++ b/data/blueferry-quickshell
@@ -3,6 +3,43 @@ set -euo pipefail
 
 config=/usr/share/blueferry/quickshell
 if [[ -x /usr/bin/qs ]]; then
-    exec /usr/bin/qs -p "$config"
+    qs=/usr/bin/qs
+else
+    qs=/usr/bin/quickshell
 fi
-exec /usr/bin/quickshell -p "$config"
+
+thread=""
+message=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --thread)
+            thread="${2-}"
+            shift 2
+            ;;
+        --message)
+            message="${2-}"
+            shift 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+ipc() {
+    "$qs" -p "$config" ipc call blueferry "$@"
+}
+
+if [[ -n "$message" ]]; then
+    if ipc openMessage "$message"; then
+        exit 0
+    fi
+    export BLUEFERRY_OPEN_MESSAGE_HANDLE="$message"
+elif [[ -n "$thread" ]]; then
+    if ipc openThread "$thread"; then
+        exit 0
+    fi
+    export BLUEFERRY_OPEN_THREAD_KEY="$thread"
+fi
+
+exec "$qs" -p "$config" "$@"

--- a/data/io.weirdware.BlueFerry.xml
+++ b/data/io.weirdware.BlueFerry.xml
@@ -33,6 +33,12 @@
       <annotation name="io.weirdware.BlueFerry.Errors"
                   value="ResponseTooLarge"/>
     </method>
+    <method name="MarkThreadRead">
+      <arg name="thread_key" type="s" direction="in"/>
+      <arg name="updated" type="u" direction="out"/>
+      <annotation name="io.weirdware.BlueFerry.Errors"
+                  value="InvalidArgs,NotFound,NotReady"/>
+    </method>
     <method name="FindContacts">
       <arg name="query" type="s" direction="in"/>
       <arg name="json" type="s" direction="out"/>

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -127,6 +127,25 @@ ShellRoot {
     return null
   }
 
+  function threadIsUnread(thread) {
+    if (!thread) return false
+    if (thread.unread === true) return true
+    if (thread.unread === false) return false
+    var messages = thread.messages || []
+    for (var index = 0; index < messages.length; ++index) {
+      if (!messages[index].outgoing && messages[index].read === false) return true
+    }
+    return false
+  }
+
+  function markSelectedThreadRead() {
+    var thread = selectedThread()
+    if (!thread || !threadIsUnread(thread)) return
+    backendBridge.request("mark_thread_read", {thread_key: String(thread.key)})
+  }
+
+  onSelectedThreadKeyChanged: root.markSelectedThreadRead()
+
   function selectMessage(handle) {
     for (var threadIndex = 0; threadIndex < threads.length; ++threadIndex) {
       var thread = threads[threadIndex]
@@ -378,6 +397,7 @@ ShellRoot {
         if (root.pendingMessageHandle !== "")
           root.selectMessage(root.pendingMessageHandle)
         root.warnAboutRosterChanges()
+        root.markSelectedThreadRead()
         root.errorText = ""
       } else if (method === "contacts") {
         root.contactsBusy = false
@@ -399,6 +419,8 @@ ShellRoot {
         root.groupParticipantsBusy = false
         groupParticipantsPopup.close()
         root.reload()
+      } else if (method === "mark_thread_read") {
+        // HistoryChanged reloads the thread list.
       } else if (method === "delete_threads") {
         root.deleteThreadsBusy = false
         root.reload()
@@ -449,6 +471,8 @@ ShellRoot {
       } else if (method === "set_group_participants") {
         root.groupParticipantsBusy = false
         root.errorText = message
+      } else if (method === "mark_thread_read") {
+        // Keep the conversation open even if MAP write-back fails.
       } else if (method === "delete_threads") {
         root.deleteThreadsBusy = false
         root.errorText = message || "Could not delete local conversations"
@@ -865,7 +889,7 @@ ShellRoot {
                         color: theme.windowText
                         font.family: theme.fontFamily
                         font.pixelSize: theme.baseFontSize
-                        font.bold: threadDelegate.highlighted
+                        font.bold: root.threadIsUnread(threadDelegate.modelData)
                         wrapMode: Text.NoWrap
                         maximumLineCount: 1
                         elide: Text.ElideRight

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -13,6 +13,7 @@ ShellRoot {
   property string contactQuery: ""
   property string contactsRequestedQuery: ""
   property string selectedThreadKey: ""
+  property string pendingThreadKey: ""
   property string pendingMessageHandle: ""
   property string confirmedGroupSignature: ""
   property var groupParticipantsThread: null
@@ -142,10 +143,22 @@ ShellRoot {
     return false
   }
 
-  function openMessage(handle) {
-    pendingMessageHandle = handle
+  function presentWindow() {
     phoneSettingsVisible = false
     window.visible = true
+  }
+
+  function openThread(key) {
+    pendingThreadKey = key
+    selectedThreadKey = key
+    confirmedGroupSignature = ""
+    pendingMessageHandle = ""
+    presentWindow()
+  }
+
+  function openMessage(handle) {
+    pendingMessageHandle = handle
+    presentWindow()
     if (!selectMessage(handle)) reload()
   }
 
@@ -322,6 +335,13 @@ ShellRoot {
 
   BackendBridge { id: backendBridge }
 
+  IpcHandler {
+    target: "blueferry"
+    function open(): void { root.presentWindow() }
+    function openThread(key: string): void { root.openThread(key) }
+    function openMessage(handle: string): void { root.openMessage(handle) }
+  }
+
   Connections {
     target: backendBridge
 
@@ -348,7 +368,10 @@ ShellRoot {
       } else if (method === "threads") {
         root.threadsBusy = false
         root.threads = Array.isArray(result) ? result : []
-        if (root.selectedThreadKey !== "" && root.selectedThread() === null) {
+        if (root.pendingThreadKey !== "") {
+          root.selectedThreadKey = root.pendingThreadKey
+          if (root.selectedThread() !== null) root.pendingThreadKey = ""
+        } else if (root.selectedThreadKey !== "" && root.selectedThread() === null) {
           root.selectedThreadKey = ""
           root.confirmedGroupSignature = ""
         }
@@ -655,6 +678,10 @@ ShellRoot {
     compatibilityProcess.running = true
     configurationProcess.running = true
     loadPairingDevices(false)
+    var messageHandle = String(Quickshell.env("BLUEFERRY_OPEN_MESSAGE_HANDLE") || "")
+    var threadKey = String(Quickshell.env("BLUEFERRY_OPEN_THREAD_KEY") || "")
+    if (messageHandle !== "") root.openMessage(messageHandle)
+    else if (threadKey !== "") root.openThread(threadKey)
   }
 
   FloatingWindow {

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -32,6 +32,7 @@ from blueferry.history import (
     clear_events,
     delete_event_rows,
     history_revision,
+    mark_event_handles_read,
     read_event_rows,
     read_events,
 )
@@ -51,6 +52,7 @@ from blueferry.limits import (
     MAX_THREAD_QUERY_LIMIT,
 )
 from blueferry.obex.map_query import list_recent_messages
+from blueferry.obex.map_read import set_session_messages_read
 from blueferry.obex.map_send import send_group_message, send_message
 from blueferry.recipients import InvalidRecipient, validate_recipient
 from blueferry.storage_security import STORAGE_POLICIES, StorageSecurity
@@ -305,6 +307,38 @@ class BackendOperations:
     def list_threads(self, limit: int) -> list[dict]:
         bounded = max(1, min(int(limit), MAX_THREAD_QUERY_LIMIT))
         return self._conversations.threads()[:bounded]
+
+    def mark_thread_read(self, thread_key: str) -> int:
+        """Mark incoming messages in one conversation read locally and on MAP."""
+        if not thread_key.strip() or len(thread_key) > 1024:
+            raise InvalidArgumentsError("invalid thread key")
+        thread = self._conversations.find(thread_key)
+        if thread is None:
+            raise NotFoundError("thread no longer exists in local history")
+        handles = [
+            str(message.get("handle") or "")
+            for message in thread.get("messages") or []
+            if not message.get("outgoing")
+            and not message.get("read")
+            and message.get("handle")
+        ]
+        handles = [handle for handle in handles if handle]
+        if not handles:
+            return 0
+        storage = self.dependencies.storage
+        if storage is not None and not storage.status.can_write:
+            raise NotReadyError(storage.status.detail)
+        updated = mark_event_handles_read(handles, storage=storage)
+        self._conversations.invalidate()
+        if self.sessions.map is None:
+            return updated
+        map_path = self.sessions.map_path
+        self._queue(
+            lambda: set_session_messages_read(map_path, handles),
+            lambda _result: None,
+            lambda error: log.debug("MAP mark-read failed: %s", error),
+        )
+        return updated
 
     def find_contacts(self, query: str) -> list[dict[str, str]]:
         selected = str(query).strip()

--- a/src/blueferry/client.py
+++ b/src/blueferry/client.py
@@ -78,6 +78,14 @@ class BackendClient:
         except (dbus.exceptions.DBusException, ValueError) as error:
             raise BackendError(str(error)) from error
 
+    def mark_thread_read(self, thread_key: str) -> int:
+        try:
+            return int(self._iface(MESSAGES_IFACE).MarkThreadRead(
+                thread_key, timeout=SNAPSHOT_CALL_TIMEOUT_SEC,
+            ))
+        except dbus.exceptions.DBusException as error:
+            raise BackendError(error.get_dbus_message() or str(error)) from error
+
     def events(self, kinds: list[str], limit: int = 1000) -> list[EventRecord]:
         try:
             return decode_events(self._iface(MESSAGES_IFACE).ListEvents(

--- a/src/blueferry/dbus_service.py
+++ b/src/blueferry/dbus_service.py
@@ -147,6 +147,18 @@ class MessagesService(dbus.service.Object):
         ))
 
     @dbus.service.method(
+        IFACE, in_signature="s", out_signature="u", sender_keyword="sender"
+    )
+    def MarkThreadRead(self, thread_key: str, sender=None) -> int:
+        def mark() -> int:
+            updated = self.operations.mark_thread_read(thread_key)
+            if updated:
+                self.emit_history_changed()
+            return updated
+
+        return self._sync(lambda: self._authorized(sender, "read", mark))
+
+    @dbus.service.method(
         IFACE, in_signature="s", out_signature="s", sender_keyword="sender"
     )
     def FindContacts(self, query: str, sender=None) -> str:

--- a/src/blueferry/history.py
+++ b/src/blueferry/history.py
@@ -31,6 +31,10 @@ CREATE TABLE IF NOT EXISTS events (
     occurred_at  REAL,
     payload_json TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value INTEGER NOT NULL
+);
 CREATE INDEX IF NOT EXISTS idx_events_kind_id ON events(kind, id);
 CREATE INDEX IF NOT EXISTS idx_events_occurred_at ON events(occurred_at);
 """
@@ -255,17 +259,77 @@ def delete_event_rows(
     return int(removed)
 
 
+def _bump_generation(database: sqlite3.Connection) -> None:
+    database.execute(
+        "INSERT INTO meta(key, value) VALUES ('generation', 1) "
+        "ON CONFLICT(key) DO UPDATE SET value = value + 1"
+    )
+
+
+def mark_event_handles_read(
+    handles: Iterable[str],
+    *,
+    path: Path | None = None,
+    storage: StorageSecurity | None = None,
+) -> int:
+    """Set ``is_read`` on matching ``sms_received`` history events.
+
+    Payload updates do not change row ids, so a generation counter is bumped
+    when anything changes and conversation caches can observe the revision.
+    """
+    selected = {str(handle) for handle in handles if str(handle)}
+    if not selected:
+        return 0
+    if storage is not None and not storage.status.can_write:
+        return 0
+    updated = 0
+    with closing(_open_database(path)) as database, database:
+        for event_id, payload in database.execute(
+            "SELECT id, payload_json FROM events"
+        ):
+            try:
+                event = _deserialize(payload, storage)
+            except CorruptStorageError:
+                if storage is not None:
+                    storage.fail_closed(
+                        "Encrypted local history could not be authenticated"
+                    )
+                return 0
+            except (ValueError, RuntimeError):
+                continue
+            if event is None:
+                continue
+            if str(event.get("kind") or "") != "sms_received":
+                continue
+            handle = str(event.get("handle") or "")
+            if handle not in selected or event.get("is_read") is True:
+                continue
+            event["is_read"] = True
+            database.execute(
+                "UPDATE events SET payload_json = ? WHERE id = ?",
+                (_serialize(event, storage), int(event_id)),
+            )
+            updated += 1
+        if updated:
+            _bump_generation(database)
+    return updated
+
+
 def history_revision(
     *, path: Path | None = None, storage: StorageSecurity | None = None
-) -> tuple[int, int]:
-    """Return a cheap cache key that changes for every append or deletion."""
+) -> tuple[int, int, int]:
+    """Return a cheap cache key that changes for every append, update, or deletion."""
     if storage is not None and not storage.status.can_read:
-        return 0, 0
+        return 0, 0, 0
     with closing(_open_database(path)) as database:
         count, newest = database.execute(
             "SELECT COUNT(*), COALESCE(MAX(id), 0) FROM events"
         ).fetchone()
-    return int(count), int(newest)
+        generation_row = database.execute(
+            "SELECT value FROM meta WHERE key = 'generation'"
+        ).fetchone()
+    generation = int(generation_row[0]) if generation_row else 0
+    return int(count), int(newest), generation
 
 
 def history_count(

--- a/src/blueferry/models.py
+++ b/src/blueferry/models.py
@@ -213,6 +213,7 @@ class Thread:
             "unexpected_sender",
             "prompt_sender",
             "roster_warning_id",
+            "unread",
         }
         raw_recipients = value.get("recipients")
         raw_messages = value.get("messages")
@@ -239,6 +240,12 @@ class Thread:
             extra={key: item for key, item in value.items() if key not in known},
         )
 
+    @property
+    def unread(self) -> bool:
+        return any(
+            not message.outgoing and not message.read for message in self.messages
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             **self.extra,
@@ -255,6 +262,7 @@ class Thread:
             "unexpected_sender": self.unexpected_sender,
             "prompt_sender": self.prompt_sender,
             "roster_warning_id": self.roster_warning_id,
+            "unread": self.unread,
         }
 
 

--- a/src/blueferry/obex/map_read.py
+++ b/src/blueferry/obex/map_read.py
@@ -1,0 +1,43 @@
+"""Best-effort MAP write-back of message read state to the iPhone."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable
+
+import dbus
+import dbus.exceptions
+
+from blueferry.bus import obex
+
+log = logging.getLogger(__name__)
+
+_HANDLE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def set_message_read(message_path: str) -> None:
+    """Set ``org.bluez.obex.Message1.Read`` on one live Message1 object."""
+    obex(message_path, "org.freedesktop.DBus.Properties").Set(
+        "org.bluez.obex.Message1", "Read", dbus.Boolean(True), timeout=10.0
+    )
+
+
+def set_session_messages_read(session_path: str, handles: Iterable[str]) -> None:
+    """Mark reconstructed Message1 objects read on the current MAP session.
+
+    Handles are history-opaque path tails. After a session reconnect they may
+    no longer exist; failures are expected and ignored.
+    """
+    root = str(session_path or "").rstrip("/")
+    if not root:
+        return
+    for handle in handles:
+        value = str(handle or "")
+        if value in {".", ".."} or not _HANDLE_RE.fullmatch(value):
+            continue
+        path = f"{root}/{value}"
+        try:
+            set_message_read(path)
+        except dbus.exceptions.DBusException as error:
+            log.debug("MAP mark-read failed for %s: %s", value, error)

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -542,6 +542,18 @@ class BridgeController(QObject):
             lambda _value: self.refresh(),
         )
 
+    @Slot(str)
+    def markThreadRead(self, thread_key: str) -> None:
+        key = str(thread_key or "").strip()
+        if not key:
+            return
+        self._run(
+            lambda: self._backend.mark_thread_read(key),
+            lambda _value: None,
+            lambda _message: None,
+            busy=False,
+        )
+
     @Slot("QVariantList")
     def deleteThreads(self, thread_keys) -> None:
         selected = [str(value) for value in thread_keys]

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -10,6 +10,7 @@ Kirigami.ApplicationWindow {
 
     required property var bridge
     property string selectedThreadKey: ""
+    onSelectedThreadKeyChanged: root.markSelectedThreadRead()
     property bool firstRunRedirected: false
     property var iphoneSettingsPage: null
     property string pendingMessageHandle: ""
@@ -79,6 +80,27 @@ Kirigami.ApplicationWindow {
             }
         }
         return null
+    }
+
+    function threadIsUnread(thread) {
+        if (!thread)
+            return false
+        if (thread.unread === true)
+            return true
+        if (thread.unread === false)
+            return false
+        const messages = thread.messages || []
+        for (let index = 0; index < messages.length; ++index) {
+            if (!messages[index].outgoing && messages[index].read === false)
+                return true
+        }
+        return false
+    }
+
+    function markSelectedThreadRead() {
+        const thread = selectedThread()
+        if (thread && threadIsUnread(thread))
+            bridge.markThreadRead(thread.key)
     }
 
     function selectMessage(handle) {
@@ -198,6 +220,7 @@ Kirigami.ApplicationWindow {
             if (root.pendingMessageHandle !== "")
                 root.selectMessage(root.pendingMessageHandle)
             root.warnAboutRosterChanges()
+            root.markSelectedThreadRead()
         }
 
         function onMessageOpenRequested(handle) {
@@ -777,7 +800,7 @@ Kirigami.ApplicationWindow {
                                 required property var modelData
                                 width: threadList.width
                                 highlighted: root.selectedThreadKey === modelData.key
-                                Accessible.name: preview.text
+                                Accessible.name: threadDelegate.modelData.name
                                 onClicked: root.selectedThreadKey = modelData.key
                                 contentItem: RowLayout {
                                     spacing: Kirigami.Units.smallSpacing
@@ -788,18 +811,26 @@ Kirigami.ApplicationWindow {
                                         implicitWidth: Kirigami.Units.iconSizes.smallMedium
                                         implicitHeight: implicitWidth
                                     }
-                                    Controls.Label {
-                                        id: preview
+                                    ColumnLayout {
                                         Layout.fillWidth: true
-                                        text: threadDelegate.modelData.name + "\n" + (
-                                            threadDelegate.modelData.messages.length
+                                        spacing: 0
+                                        Controls.Label {
+                                            id: preview
+                                            Layout.fillWidth: true
+                                            text: threadDelegate.modelData.name
+                                            textFormat: Text.PlainText
+                                            font.bold: root.threadIsUnread(threadDelegate.modelData)
+                                            elide: Text.ElideRight
+                                        }
+                                        Controls.Label {
+                                            Layout.fillWidth: true
+                                            text: threadDelegate.modelData.messages.length
                                                 ? threadDelegate.modelData.messages[threadDelegate.modelData.messages.length - 1].body
                                                 : qsTr("No Messages")
-                                        )
-                                        textFormat: Text.PlainText
-                                        maximumLineCount: 2
-                                        wrapMode: Text.Wrap
-                                        elide: Text.ElideRight
+                                            textFormat: Text.PlainText
+                                            opacity: 0.7
+                                            elide: Text.ElideRight
+                                        }
                                     }
                                 }
                                 TapHandler {

--- a/src/blueferry/quickshell_bridge.py
+++ b/src/blueferry/quickshell_bridge.py
@@ -105,6 +105,8 @@ class QuickshellBridge:
             ).to_dict()
         if method == "delete_threads":
             return self.client.delete_threads(_texts(args, "thread_keys"))
+        if method == "mark_thread_read":
+            return self.client.mark_thread_read(_text(args, "thread_key"))
         if method == "set_notification_policy":
             return self.client.set_notification_policy(_text(args, "policy"))
         if method == "set_contacts_only_notifications":

--- a/src/blueferry/sinks/libnotify.py
+++ b/src/blueferry/sinks/libnotify.py
@@ -16,8 +16,10 @@ back over MAP within a few seconds of opening the Messages app.
 """
 from __future__ import annotations
 
+import json
 import logging
 from html import escape
+from pathlib import Path
 from typing import Protocol
 
 import dbus
@@ -59,6 +61,41 @@ _ANCS_EXPIRE_MS = config.NOTIFICATION_TIMEOUT_MS
 # because the iPhone marked it read (so we'd be in a write-self-write loop).
 # Reason 1 is the normal finite-timeout path and must not mark the phone read.
 _REASON_DISMISSED = 2
+_CLIENT_LAUNCHERS = (
+    "/usr/bin/blueferry-quickshell",
+    "/usr/bin/blueferry-gtk",
+    "/usr/bin/blueferry-qt",
+)
+
+
+def _open_conversation_argv(handle: str) -> list[str]:
+    """Return an argv that focuses a client on this opaque message handle."""
+    if not handle:
+        return []
+    for binary in _CLIENT_LAUNCHERS:
+        if Path(binary).is_file():
+            if binary.endswith("quickshell"):
+                return [binary, "--message", handle]
+            return [binary]
+    return []
+
+
+def _notification_hints(handle: str) -> dict[str, object]:
+    hints: dict[str, object] = {"urgency": dbus.Byte(1)}
+    argv = _open_conversation_argv(handle)
+    if not argv:
+        return hints
+    binary = argv[0]
+    if binary.endswith("quickshell"):
+        hints["desktop-entry"] = "io.weirdware.BlueFerry.Quickshell"
+    elif binary.endswith("gtk"):
+        hints["desktop-entry"] = "io.weirdware.BlueFerry.Gtk"
+    elif binary.endswith("-qt"):
+        hints["desktop-entry"] = "io.weirdware.BlueFerry.Qt"
+    # Omarchy's notification shell prefers this JSON argv over a live
+    # libnotify action, and it survives a shell restart.
+    hints["omarchy-exec-argv"] = json.dumps(argv)
+    return hints
 
 
 def _mark_message_read(message_path: str) -> None:
@@ -172,7 +209,7 @@ class LibnotifySink:
                 title,
                 body,
                 dbus.Array(actions, signature="s"),
-                dbus.Dictionary({"urgency": dbus.Byte(1)}, signature="sv"),
+                dbus.Dictionary(_notification_hints(handle), signature="sv"),
                 dbus.Int32(_MESSAGE_EXPIRE_MS),
             ))
         except dbus.exceptions.DBusException as e:

--- a/src/blueferry/sinks/libnotify.py
+++ b/src/blueferry/sinks/libnotify.py
@@ -27,7 +27,7 @@ import dbus.exceptions
 
 from blueferry import config
 from blueferry.ancs.events import AncsEvent
-from blueferry.bus import get_session_bus, obex
+from blueferry.bus import get_session_bus
 from blueferry.events import SmsEvent
 from blueferry.limits import MAX_DESKTOP_MESSAGE_TRACKERS
 from blueferry.notification_policy import (
@@ -99,9 +99,9 @@ def _notification_hints(handle: str) -> dict[str, object]:
 
 
 def _mark_message_read(message_path: str) -> None:
-    obex(message_path, "org.freedesktop.DBus.Properties").Set(
-        "org.bluez.obex.Message1", "Read", dbus.Boolean(True), timeout=10.0
-    )
+    from blueferry.obex.map_read import set_message_read
+
+    set_message_read(message_path)
 
 
 class LibnotifySink:

--- a/src/blueferry/threads.py
+++ b/src/blueferry/threads.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import TypeAlias
 
 from blueferry.events import (
     canonical_address,
@@ -14,6 +15,7 @@ from blueferry.history import history_revision
 from blueferry.limits import MAX_THREAD_MESSAGES
 
 MESSAGE_KINDS = {"sms_received", "sms_sent"}
+CacheKey: TypeAlias = tuple[int, ...]
 
 
 class ConversationIndex:
@@ -25,7 +27,7 @@ class ConversationIndex:
         builder: Callable[[list[dict]], list[dict]],
         *,
         source: Path | None = None,
-        revision: Callable[[], tuple[int, int]] | None = None,
+        revision: Callable[[], CacheKey] | None = None,
     ) -> None:
         self._loader = loader
         self._builder = builder
@@ -35,7 +37,7 @@ class ConversationIndex:
             if source is not None
             else history_revision
         )
-        self._signature: tuple[int, int] | None = None
+        self._signature: CacheKey | None = None
         self._threads: list[dict] | None = None
 
     @staticmethod
@@ -200,7 +202,7 @@ def build_threads(events: list[dict], resolver=None) -> list[dict]:
                 "" if event.get("kind") == "sms_sent"
                 else _message_sender(event, address, resolver)
             ) if is_group else "",
-            "read": bool(event.get("is_read", False)),
+            "read": bool(event["is_read"]) if "is_read" in event else True,
             "body_truncated": bool(event.get("body_truncated", False)),
         }
         thread["messages"].append(message)
@@ -214,6 +216,10 @@ def build_threads(events: list[dict], resolver=None) -> list[dict]:
             thread["reply_ready"] = False
         if len(thread["messages"]) > MAX_THREAD_MESSAGES:
             thread["messages"] = thread["messages"][-MAX_THREAD_MESSAGES:]
+        thread["unread"] = any(
+            not message.get("outgoing") and not message.get("read")
+            for message in thread["messages"]
+        )
     return sorted(by_key.values(), key=lambda item: item["last_ts"], reverse=True)
 
 

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -55,6 +55,8 @@ class _Client(Protocol):
 
     def delete_threads(self, thread_keys: list[str]) -> int: ...
 
+    def mark_thread_read(self, thread_key: str) -> int: ...
+
 
 class _Monitor(Protocol):
     def pump(self) -> tuple[bool, str | None]: ...
@@ -245,7 +247,10 @@ class ConversationItem(ListItem):
         unread = _unread_count(thread)
         detail = f"{unread} unread" if unread else ("group" if thread.is_group else "direct")
         avatar = Static(Text(_initials(thread.name), justify="center"), classes="avatar")
-        title = Static(Text(_one_line(thread.name), style="bold"), classes="thread-name")
+        title = Static(
+            Text(_one_line(thread.name), style="bold" if unread else ""),
+            classes="thread-name",
+        )
         timestamp = Static(
             Text(_short_timestamp(thread.last_ts), justify="right"),
             classes="thread-time",
@@ -649,6 +654,7 @@ class BlueFerryApp(App[None]):
         await self._render_conversation()
         self.query_one("#workspace").add_class("chat-open")
         self._update_notice()
+        self._maybe_mark_selected_read()
 
     @work(thread=True, exclusive=True, group="refresh", exit_on_error=False)
     def _load_data(self) -> None:
@@ -688,6 +694,7 @@ class BlueFerryApp(App[None]):
             self._update_notice()
         if threads_changed:
             self._warn_about_roster_changes()
+        self._maybe_mark_selected_read()
 
     def _warn_about_roster_changes(self) -> None:
         thread = self.state.next_roster_warning()
@@ -861,6 +868,19 @@ class BlueFerryApp(App[None]):
             notice.update("Ready  ·  Ctrl+P: Help")
             notice.set_classes("")
 
+    def _maybe_mark_selected_read(self) -> None:
+        thread = self.state.selected
+        if thread is None or not thread.unread:
+            return
+        self._mark_thread_read(thread.key)
+
+    @work(thread=True, exit_on_error=False)
+    def _mark_thread_read(self, thread_key: str) -> None:
+        try:
+            self.state.client.mark_thread_read(thread_key)
+        except BackendError:
+            return
+
     @on(ListView.Highlighted, "#thread-list")
     async def thread_highlighted(self, event: ListView.Highlighted) -> None:
         if not isinstance(event.item, ConversationItem):
@@ -869,12 +889,14 @@ class BlueFerryApp(App[None]):
         self.state.notice = ""
         await self._render_conversation()
         self._update_notice()
+        self._maybe_mark_selected_read()
 
     @on(ListView.Selected, "#thread-list")
     def thread_selected(self, event: ListView.Selected) -> None:
         if isinstance(event.item, ConversationItem):
             self.state.selected_key = event.item.thread_key
         self.action_open_thread()
+        self._maybe_mark_selected_read()
 
     @on(Input.Changed, "#thread-search")
     async def search_changed(self) -> None:

--- a/src/blueferry/ui/client.py
+++ b/src/blueferry/ui/client.py
@@ -288,6 +288,16 @@ class DaemonClient(GObject.Object):
             on_err,
         )
 
+    def mark_thread_read_async(self, thread_key: str, on_ok=None, on_err=None) -> None:
+        self._submit(
+            lambda: self._call_backend(
+                lambda backend: backend.mark_thread_read(thread_key)
+            ),
+            on_ok or (lambda _value: None),
+            on_err,
+            mutation=True,
+        )
+
     def find_contacts_async(self, query: str, on_ok, on_err=None) -> None:
         """Find cached message destinations without blocking the GTK thread."""
         selected = query.strip()

--- a/src/blueferry/ui/conversations.py
+++ b/src/blueferry/ui/conversations.py
@@ -552,6 +552,7 @@ class ConversationsPage(Gtk.Box):
         self._reload_finished()
         self._select_pending_message()
         self._maybe_warn_roster_change()
+        self._mark_selected_read()
         return False
 
     # ---- thread list ---------------------------------------------------
@@ -585,7 +586,7 @@ class ConversationsPage(Gtk.Box):
                     Gtk.Label(
                         label=thread.name,
                         xalign=0,
-                        css_classes=["heading"],
+                        css_classes=["heading"] if thread.unread else [],
                         ellipsize=_ELLIPSIZE_END,
                     )
                 )
@@ -628,6 +629,13 @@ class ConversationsPage(Gtk.Box):
         for message in thread.messages:
             self._append_bubble(message, is_group=thread.is_group)
         self._scroll_to_bottom()
+        self._mark_selected_read()
+
+    def _mark_selected_read(self) -> None:
+        thread = self._state.selected
+        if thread is None or not thread.unread:
+            return
+        self._client.mark_thread_read_async(thread.key)
 
     def _show_thread_context_menu(
         self, _gesture, _press_count, x, y, row

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -437,6 +437,83 @@ def test_named_group_key_survives_roster_save_and_history_reload(
     assert updated["roster_changed"] is False
 
 
+def test_mark_thread_read_updates_local_history_and_queues_map(
+    tmp_path, monkeypatch,
+) -> None:
+    path = tmp_path / "events.sqlite"
+    monkeypatch.setattr(config, "EVENTS_DB", path)
+    append_event({
+        "kind": "sms_received",
+        "handle": "message-alice",
+        "sender_address": "+15551111111",
+        "contact_name": "Alice",
+        "body": "hello",
+        "is_read": False,
+        "seen_at": "2026-08-12T10:00:00+00:00",
+    }, path=path)
+    append_event({
+        "kind": "sms_received",
+        "handle": "message-bob",
+        "sender_address": "+15552222222",
+        "contact_name": "Bob",
+        "body": "later",
+        "is_read": False,
+        "seen_at": "2026-08-12T10:01:00+00:00",
+    }, path=path)
+    mapped = []
+    monkeypatch.setattr(
+        backend_operations,
+        "set_session_messages_read",
+        lambda session, handles: mapped.append((session, list(handles))),
+    )
+    operations = _operations()
+    alice = next(
+        thread for thread in operations.list_threads(10) if thread["name"] == "Alice"
+    )
+
+    assert alice["unread"] is True
+    assert operations.mark_thread_read(alice["key"]) == 1
+    assert mapped == [("/session/map", ["message-alice"])]
+    events = {event["handle"]: event for event in read_events(path=path)}
+    assert events["message-alice"]["is_read"] is True
+    assert events["message-bob"]["is_read"] is False
+    alice = next(
+        thread for thread in operations.list_threads(10) if thread["name"] == "Alice"
+    )
+    assert alice["unread"] is False
+    assert operations.mark_thread_read(alice["key"]) == 0
+
+
+def test_mark_thread_read_skips_map_without_a_session(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "events.sqlite"
+    monkeypatch.setattr(config, "EVENTS_DB", path)
+    append_event({
+        "kind": "sms_received",
+        "handle": "message-alice",
+        "sender_address": "+15551111111",
+        "contact_name": "Alice",
+        "body": "hello",
+        "is_read": False,
+        "seen_at": "2026-08-12T10:00:00+00:00",
+    }, path=path)
+    mapped = []
+    monkeypatch.setattr(
+        backend_operations,
+        "set_session_messages_read",
+        lambda *_args: mapped.append(True),
+    )
+    sessions = _Sessions()
+    sessions.map = None
+    operations = BackendOperations(
+        sessions, BackendDependencies(submit_obex=lambda *_a, **_k: None)
+    )
+
+    thread = operations.list_threads(10)[0]
+    assert operations.mark_thread_read(thread["key"]) == 1
+    assert mapped == []
+    assert read_events(path=path)[0]["is_read"] is True
+
+
 def test_history_snapshot_validates_kinds_and_caps_bodies(monkeypatch) -> None:
     captured = {}
 

--- a/tests/test_client_models.py
+++ b/tests/test_client_models.py
@@ -62,6 +62,10 @@ class _Messages:
         assert bool(confirmed) is True
         return len(keys)
 
+    def MarkThreadRead(self, key, **_kwargs):
+        assert key == "address:email:test@example.com"
+        return 3
+
 
 def test_backend_client_returns_shared_models(monkeypatch):
     messages = _Messages()
@@ -72,6 +76,7 @@ def test_backend_client_returns_shared_models(monkeypatch):
     assert client.status().contacts == 3
     assert isinstance(client.threads()[0], Thread)
     assert client.threads()[0].recipients == ("test@example.com",)
+    assert client.mark_thread_read("address:email:test@example.com") == 3
     assert isinstance(client.events([])[0], EventRecord)
     assert client.events([])[0].title == "Test"
     assert client.list_contacts() == [

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -16,8 +16,9 @@ from blueferry.ui import conversations  # noqa: E402
 
 
 class _FakeWidget:
-    def __init__(self, **_kwargs):
+    def __init__(self, **kwargs):
         self.children = []
+        self.css_classes = kwargs.get("css_classes", [])
 
     def append(self, child):
         self.children.append(child)
@@ -123,6 +124,71 @@ def test_sidebar_rebuild_does_not_fire_selection_callback(monkeypatch):
     assert len(thread_list.rows[0].controllers) == 1
     assert thread_list.selection_callbacks == 0
     assert thread_list.blocked is False
+    assert thread_list.rows[0].child.children[0].css_classes == []
+
+
+def test_unread_thread_name_uses_heading_style(monkeypatch):
+    monkeypatch.setattr(conversations, "Gtk", _FakeGtk)
+    monkeypatch.setattr(conversations, "Gdk", _FakeGdk)
+    thread_list = _FakeThreadList()
+    unread = _thread(
+        key="Bob",
+        name="Bob",
+        messages=(
+            ThreadMessage(
+                handle="2",
+                body="hey",
+                timestamp="2026-08-08T11:00:00-04:00",
+                outgoing=False,
+                read=False,
+            ),
+        ),
+    )
+    state = ConversationState(select_first=False)
+    state.apply_snapshot(ConversationSnapshot(None, (unread,)))
+    page = SimpleNamespace(
+        _thread_list=thread_list,
+        _thread_selected_handler=42,
+        _show_thread_context_menu=lambda *_args: None,
+        _state=state,
+    )
+
+    conversations.ConversationsPage._rebuild_thread_list(page)
+
+    assert thread_list.rows[0].child.children[0].css_classes == ["heading"]
+
+
+def test_selected_unread_thread_is_marked_read():
+    marked = []
+    unread = _thread(
+        key="Bob",
+        name="Bob",
+        messages=(
+            ThreadMessage(
+                handle="2",
+                body="hey",
+                timestamp="2026-08-08T11:00:00-04:00",
+                outgoing=False,
+                read=False,
+            ),
+        ),
+    )
+    state = ConversationState(select_first=False)
+    state.apply_snapshot(ConversationSnapshot(None, (unread, _thread())))
+    state.selected_key = "Bob"
+    page = SimpleNamespace(
+        _state=state,
+        _client=SimpleNamespace(
+            mark_thread_read_async=lambda key: marked.append(key)
+        ),
+    )
+
+    conversations.ConversationsPage._mark_selected_read(page)
+    assert marked == ["Bob"]
+
+    state.selected_key = "Alice"
+    conversations.ConversationsPage._mark_selected_read(page)
+    assert marked == ["Bob"]
 
 
 def test_map_refusal_reveals_prominent_message_banner() -> None:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -11,6 +11,7 @@ from blueferry.history import (
     delete_event_rows,
     history_count,
     history_revision,
+    mark_event_handles_read,
     minimize_ancs_history,
     prune_events,
     read_event_rows,
@@ -85,6 +86,35 @@ def test_plaintext_prune_scrubs_deleted_payload_bytes(tmp_path) -> None:
     assert prune_events(path=path, max_events=1) == 1
 
     assert secret.encode() not in path.read_bytes()
+
+
+def test_mark_event_handles_read_updates_payload_and_revision(tmp_path) -> None:
+    path = tmp_path / "events.sqlite"
+    append_event({
+        "kind": "sms_received",
+        "handle": "message-unread",
+        "body": "hello",
+        "is_read": False,
+    }, path=path)
+    append_event({
+        "kind": "sms_received",
+        "handle": "message-read",
+        "body": "later",
+        "is_read": True,
+    }, path=path)
+    append_event({
+        "kind": "sms_sent",
+        "handle": "message-unread",
+        "body": "outgoing",
+        "is_read": False,
+    }, path=path)
+    before = history_revision(path=path)
+
+    assert mark_event_handles_read(["message-unread"], path=path) == 1
+    events = read_events(path=path)
+    assert [event["is_read"] for event in events] == [True, True, False]
+    assert history_revision(path=path) != before
+    assert mark_event_handles_read(["message-unread"], path=path) == 0
 
 
 def test_clear_preserves_private_database_and_changes_revision(tmp_path) -> None:

--- a/tests/test_libnotify.py
+++ b/tests/test_libnotify.py
@@ -1,6 +1,7 @@
 """Desktop popup policy tests."""
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -106,6 +107,40 @@ def test_clicking_message_popup_requests_opaque_message_handle(monkeypatch) -> N
     sink._on_closed(1, 1)
     sink._on_action(1, "default")
     assert opened == ["message-opaque-42"]
+
+
+def test_message_popup_includes_omarchy_open_argv(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "blueferry.sinks.libnotify.config.SHOW_NOTIFICATION_CONTENT", True
+    )
+    launcher = tmp_path / "blueferry-quickshell"
+    launcher.write_text("#!/bin/sh\n")
+    launcher.chmod(0o755)
+    monkeypatch.setattr(
+        libnotify_mod, "_CLIENT_LAUNCHERS", (str(launcher),)
+    )
+    sink = LibnotifySink.__new__(LibnotifySink)
+    sink._notif = _FakeNotifications()
+    sink._pending = {}
+    sink._open_messages = {}
+    sink._msg_subs = {}
+    event = SimpleNamespace(
+        kind="sms_received",
+        handle="message-opaque-42",
+        display_sender="Alice",
+        body="Hello",
+        message_path=None,
+    )
+
+    sink.handle(event)
+
+    hints = sink._notif.calls[0][-2]
+    assert hints["desktop-entry"] == "io.weirdware.BlueFerry.Quickshell"
+    assert json.loads(str(hints["omarchy-exec-argv"])) == [
+        str(launcher),
+        "--message",
+        "message-opaque-42",
+    ]
 
 
 def test_remote_markup_is_escaped_before_notification(monkeypatch) -> None:

--- a/tests/test_map_read.py
+++ b/tests/test_map_read.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from blueferry.obex import map_read
+
+
+def test_session_mark_read_skips_unsafe_handles(monkeypatch) -> None:
+    marked = []
+    monkeypatch.setattr(map_read, "set_message_read", marked.append)
+
+    map_read.set_session_messages_read(
+        "/org/bluez/obex/client/session5",
+        ["message1", "../other", "message/evil", ".", "message-ok"],
+    )
+
+    assert marked == [
+        "/org/bluez/obex/client/session5/message1",
+        "/org/bluez/obex/client/session5/message-ok",
+    ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -86,6 +86,34 @@ def test_thread_normalizes_nested_messages(monkeypatch):
     assert thread.to_dict()["prompt_sender"] == "Alice"
     assert thread.to_dict()["roster_warning_id"] == "route-1:casey"
     assert thread.to_dict()["future_thread_field"] == "preserved"
+    assert thread.unread is False
+    assert thread.to_dict()["unread"] is False
+
+
+def test_thread_unread_ignores_outgoing_and_read_incoming():
+    unread = Thread.from_dict({
+        "key": "address:phone:15550000000",
+        "name": "Bob",
+        "messages": [
+            {
+                "handle": "out",
+                "body": "hi",
+                "timestamp": "today",
+                "outgoing": True,
+                "read": True,
+            },
+            {
+                "handle": "in",
+                "body": "hey",
+                "timestamp": "today",
+                "outgoing": False,
+                "read": False,
+            },
+        ],
+    })
+
+    assert unread.unread is True
+    assert unread.to_dict()["unread"] is True
 
 
 def test_event_record_exposes_common_fields_without_discarding_payload():

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -532,6 +532,20 @@ def test_all_clients_expand_and_scroll_long_message_drafts() -> None:
     assert "max-height: 8" in composer_styles
 
 
+def test_quickshell_launcher_can_focus_an_existing_conversation() -> None:
+    launcher = (ROOT / "data" / "blueferry-quickshell").read_text()
+    qml = (ROOT / "data" / "quickshell" / "shell.qml").read_text()
+
+    assert "--thread" in launcher
+    assert "--message" in launcher
+    assert "ipc call blueferry" in launcher
+    assert 'target: "blueferry"' in qml
+    assert "function openThread(key: string)" in qml
+    assert "function openMessage(handle: string)" in qml
+    assert "BLUEFERRY_OPEN_THREAD_KEY" in qml
+    assert "BLUEFERRY_OPEN_MESSAGE_HANDLE" in qml
+
+
 def test_quickshell_keeps_private_dbus_values_out_of_process_arguments() -> None:
     quickshell = _qml_bundle(ROOT / "data/quickshell")
 

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -48,6 +48,26 @@ class _Backend:
         self.deleted = list(keys)
         return len(keys)
 
+    def mark_thread_read(self, key):
+        self.marked = key
+        return 1
+
+
+def test_mark_thread_read_is_silent_and_not_busy():
+    backend = _Backend()
+    controller = BridgeController(
+        backend=backend,
+        setup=object(),
+        subscribe=False,
+        autostart=False,
+    )
+
+    controller.markThreadRead("address:email:test@example.com")
+    controller._pool.waitForDone(1000)
+
+    assert backend.marked == "address:email:test@example.com"
+    assert controller.busy is False
+
 
 def test_snapshot_converts_typed_client_models_for_qml():
     controller = BridgeController(

--- a/tests/test_quickshell_bridge.py
+++ b/tests/test_quickshell_bridge.py
@@ -35,6 +35,10 @@ class FakeClient:
         self.calls.append(("delete_threads", thread_keys))
         return len(thread_keys)
 
+    def mark_thread_read(self, thread_key):
+        self.calls.append(("mark_thread_read", thread_key))
+        return 2
+
     def set_contacts_only_notifications(self, enabled):
         self.calls.append(("set_contacts_only_notifications", enabled))
         return enabled
@@ -62,6 +66,9 @@ def test_bridge_dispatches_private_values_without_command_arguments() -> None:
     assert bridge.dispatch("delete_threads", {
         "thread_keys": ["thread-one", "thread-two"],
     }) == 2
+    assert bridge.dispatch("mark_thread_read", {
+        "thread_key": "private-thread",
+    }) == 2
     assert bridge.dispatch("set_contacts_only_notifications", {
         "enabled": True,
     }) is True
@@ -76,6 +83,7 @@ def test_bridge_dispatches_private_values_without_command_arguments() -> None:
             ["+15550000001", "+15550000002"],
         ),
         ("delete_threads", ["thread-one", "thread-two"]),
+        ("mark_thread_read", "private-thread"),
         ("set_contacts_only_notifications", True),
     ]
 

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -62,6 +62,23 @@ def test_historical_number_uses_the_current_contact_name() -> None:
     assert thread["name"] == "Alice Example"
 
 
+def test_unread_follows_incoming_read_state() -> None:
+    read = _sms("+15551111111", "Alice", "one", "2026-08-08T10:00:00+00:00")
+    read["is_read"] = True
+    unread = _sms("+15552222222", "Bob", "two", "2026-08-08T10:01:00+00:00")
+    unread["is_read"] = False
+    missing = _sms("+15553333333", "Cara", "three", "2026-08-08T10:02:00+00:00")
+
+    threads = {thread["name"]: thread for thread in build_threads([read, unread, missing])}
+
+    assert threads["Alice"]["unread"] is False
+    assert threads["Alice"]["messages"][0]["read"] is True
+    assert threads["Bob"]["unread"] is True
+    assert threads["Bob"]["messages"][0]["read"] is False
+    assert threads["Cara"]["unread"] is False
+    assert threads["Cara"]["messages"][0]["read"] is True
+
+
 def test_thread_snapshot_keeps_only_the_newest_bounded_messages(monkeypatch) -> None:
     monkeypatch.setattr(threads_module, "MAX_THREAD_MESSAGES", 2)
     events = [

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -64,6 +64,7 @@ class _Backend:
         ]
         self.sent = []
         self.deleted = []
+        self.marked = []
         self.group_participants = None
 
     @staticmethod
@@ -81,6 +82,10 @@ class _Backend:
     def send(self, recipient: str, body: str) -> str:
         self.sent.append((recipient, body))
         return "/transfer/2"
+
+    def mark_thread_read(self, thread_key: str) -> int:
+        self.marked.append(thread_key)
+        return 0
 
     def delete_threads(self, thread_keys: list[str]) -> int:
         self.deleted.append(list(thread_keys))


### PR DESCRIPTION
## Summary

- Quickshell `--thread` / `--message` focuses a running client or starts one on that conversation
- notification clicks use an Omarchy exec argv so they open the same message even when no client is listening
- opening a conversation marks its incoming messages read in local history and, when MAP is up, on the iPhone
- unread threads render bold in Quickshell, GTK, Qt, and the TUI

## Why

Clicking a conversation in the Omarchy plugin or a desktop notification only launched the client, not the thread. Once that path exists, viewing a conversation should clear unread the same way Messages does, and unread rows need a visible mark.

Payload-only history updates do not change row ids, so `ConversationIndex` now keys off a generation counter as well as `(count, newest)`.

## Validation

- `python -m pytest tests/test_history.py tests/test_threads.py tests/test_models.py tests/test_backend_operations.py tests/test_map_read.py tests/test_dbus_contract.py tests/test_quickshell_bridge.py tests/test_client_models.py tests/test_conversations.py tests/test_qt_controller.py tests/test_tui.py tests/test_libnotify.py -q` — 125 passed
- `mypy src/blueferry` — 77 source files, no issues