### PR TITLE
Treat missing ANCS as expected on Realtek and Broadcom adapters

### DIFF
--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -26,6 +26,8 @@ ShellRoot {
   property bool bluezActive: false
   property bool hardwareSupported: false
   property bool notificationsSupported: false
+  property bool ancsLimitedController: false
+  property string controllerVendor: ""
   property bool compatibilityLoaded: false
   property bool ancsEnabled: true
   property bool compatibilityModeOverride: false
@@ -148,6 +150,28 @@ ShellRoot {
       if (!messages[index].outgoing && messages[index].read === false) return true
     }
     return false
+  }
+
+  function ancsLimited() {
+    return root.backendStatus.ancs_limited_controller === true
+      || root.ancsLimitedController
+  }
+
+  function ancsVendorName() {
+    return String(root.backendStatus.controller_vendor || root.controllerVendor || "")
+  }
+
+  function ancsExpectedDetail() {
+    var vendor = root.ancsVendorName()
+    if (vendor !== "")
+      return "Messages and contacts are connected. This " + vendor
+        + " adapter does not support iPhone system notifications. Group texts will appear as separate messages from their sender."
+    return "Messages and contacts are connected. This Bluetooth adapter does not support iPhone system notifications. Group texts will appear as separate messages from their sender."
+  }
+
+  function ancsUnavailableHint() {
+    if (root.ancsLimited()) return root.ancsExpectedDetail()
+    return "FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Before re-pairing, run sudo systemctl restart bluetooth.service, then forget this computer on the iPhone and pair again. This briefly disconnects all Bluetooth devices."
   }
 
   function markSelectedThreadRead() {
@@ -536,6 +560,8 @@ ShellRoot {
           var parsed = JSON.parse(text)
           root.hardwareSupported = parsed.hardware_supported === true
           root.notificationsSupported = parsed.notifications_supported === true
+          root.ancsLimitedController = parsed.ancs_limited_controller === true
+          root.controllerVendor = parsed.controller_vendor || ""
           root.compatibilityLoaded = true
           root.bluezActive = parsed.bearer_api_active === true
           root.adapterName = parsed.adapter || ""
@@ -1278,7 +1304,9 @@ ShellRoot {
             text: root.onboardingStage === "ready"
               ? "Bluetooth services and iPhone permissions have been verified."
               : root.onboardingStage === "ready-without-ancs"
-                ? "Messages and contacts have been verified. System notifications are unavailable, so group texts may appear as individual conversations."
+                ? (root.ancsLimited()
+                  ? root.ancsExpectedDetail()
+                  : "Messages and contacts have been verified. System notifications are unavailable, so group texts may appear as individual conversations.")
                 : root.onboardingStage === "iphone-settings"
                     ? onboarding.mapConnectionRefused()
                       ? "Cannot retrieve or send messages - are you connected to another computer? We will reconnect once your phone is free"
@@ -1504,8 +1532,8 @@ ShellRoot {
               && root.backendStatus.map
               && root.backendStatus.pbap
               && !root.backendStatus.ancs
-            text: "FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Before re-pairing, run sudo systemctl restart bluetooth.service, then forget this computer on the iPhone and pair again. This briefly disconnects all Bluetooth devices."
-            color: theme.warning
+            text: root.ancsUnavailableHint()
+            color: root.ancsLimited() ? theme.surfaceText : theme.warning
             wrapMode: Text.Wrap
             Layout.fillWidth: true
           }

--- a/src/blueferry/bluetooth_capabilities.py
+++ b/src/blueferry/bluetooth_capabilities.py
@@ -32,6 +32,16 @@ _BT_COMPANIES = {
     305: "Cypress",
 }
 
+# These vendors usually expose LE + advertising, but iOS ANCS pairing
+# does not complete on them. Messages and contacts still work.
+ANCS_LIMITED_VENDORS = frozenset({"realtek", "broadcom", "cypress"})
+
+
+def ancs_limited_vendor(vendor: object) -> bool:
+    """Return True when iPhone notification pairing is not expected to finish."""
+    return str(vendor or "").strip().casefold() in ANCS_LIMITED_VENDORS
+
+
 # USB/PCI IDs whose sysfs product string is generic (e.g. Wireless_Device).
 _CHIPSETS = {
     "0bda:8771": "RTL8761BU",
@@ -524,11 +534,13 @@ def compatibility(
     )
     options: list[dict[str, object]] = []
     inspected: dict[str, tuple] = {}
+    hardware_by_name: dict[str, dict[str, object]] = {}
     for name in names:
         available, supported, current, error, identity = controller_settings(
             name, run_command=run_command,
         )
         hardware = controller_hardware(name, run_command=None)
+        hardware_by_name[name] = hardware
         manufacturer_id = identity.get("manufacturer_id")
         if isinstance(manufacturer_id, int):
             apply_company_id(hardware, manufacturer_id)
@@ -571,11 +583,14 @@ def compatibility(
             names[0],
         )
     _available, _supported, _current, _error, identity, fields = inspected[str(chosen)]
+    vendor = str(hardware_by_name.get(str(chosen), {}).get("vendor") or "")
     result: dict[str, object] = {
         "adapter": chosen,
         **fields,
         **stack,
         "adapters": options,
+        "controller_vendor": vendor,
+        "ancs_limited_controller": ancs_limited_vendor(vendor),
     }
     if "manufacturer_id" in identity:
         result["manufacturer_id"] = identity["manufacturer_id"]

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -18,6 +18,7 @@ from blueferry.ancs.client import AncsClient
 from blueferry.backend_lifecycle import installed_release
 from blueferry.backend_operations import BackendDependencies
 from blueferry.bearer_supervisor import BearerSupervisor
+from blueferry.bluetooth_capabilities import ancs_limited_vendor, controller_hardware
 from blueferry.build_info import build_id, installed_build_sha, running_build_sha
 from blueferry.bus import get_system_bus, main_loop
 from blueferry.connectivity import Connectivity
@@ -493,8 +494,22 @@ class Daemon:
             "storage_policy": self.storage.status.policy,
             "storage_state": self.storage.status.state,
             "storage_detail": self.storage.status.detail,
+            **self._controller_identity(),
             **self.connectivity.snapshot(),
         }
+
+    def _controller_identity(self) -> dict[str, object]:
+        cached = getattr(self, "_controller_identity_cache", None)
+        if cached is None:
+            vendor = str(
+                controller_hardware(config.ADAPTER).get("vendor") or ""
+            )
+            cached = {
+                "controller_vendor": vendor,
+                "ancs_limited_controller": ancs_limited_vendor(vendor),
+            }
+            self._controller_identity_cache = cached
+        return cached
 
     def _refresh_contacts(self) -> None:
         """Best-effort wrapper used by startup and the periodic timer."""

--- a/src/blueferry/models.py
+++ b/src/blueferry/models.py
@@ -49,6 +49,8 @@ class BackendStatus:
     storage_policy: str = "encrypted"
     storage_state: str = "locked"
     storage_detail: str = ""
+    controller_vendor: str = ""
+    ancs_limited_controller: bool = False
     extra: Mapping[str, Any] = field(default_factory=dict, repr=False)
 
     @property
@@ -83,6 +85,8 @@ class BackendStatus:
             "storage_state",
             "storage_detail",
             "map_connection_refused",
+            "controller_vendor",
+            "ancs_limited_controller",
         }
         return cls(
             daemon=_bool(value.get("daemon")),
@@ -111,6 +115,8 @@ class BackendStatus:
             storage_policy=_str(value.get("storage_policy"), "encrypted"),
             storage_state=_str(value.get("storage_state"), "locked"),
             storage_detail=_str(value.get("storage_detail")),
+            controller_vendor=_str(value.get("controller_vendor")),
+            ancs_limited_controller=_bool(value.get("ancs_limited_controller")),
             extra={key: item for key, item in value.items() if key not in known},
         )
 
@@ -138,6 +144,8 @@ class BackendStatus:
             "storage_state": self.storage_state,
             "storage_detail": self.storage_detail,
             "map_connection_refused": self.map_connection_refused,
+            "controller_vendor": self.controller_vendor,
+            "ancs_limited_controller": self.ancs_limited_controller,
         }
 
 

--- a/src/blueferry/onboarding.py
+++ b/src/blueferry/onboarding.py
@@ -7,8 +7,38 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Protocol
 
+from blueferry.i18n import _
 from blueferry.models import BackendStatus
 from blueferry.setup_verification import remaining_iphone_setup_tasks
+
+ANCS_REPAIR_HINT = _(
+    "FYI: If ANCS remains unavailable, BlueZ may be retaining stale "
+    "Bluetooth state. Before re-pairing, run sudo systemctl restart "
+    "bluetooth.service, then forget this computer on the iPhone and "
+    "pair again. This briefly disconnects all Bluetooth devices."
+)
+ANCS_REPAIR_HINT_CLI = _(
+    "FYI: If ANCS remains unavailable after setup, BlueZ may be "
+    "retaining stale Bluetooth state."
+)
+
+
+def ancs_unavailable_detail(*, limited: bool = False, vendor: str = "") -> str:
+    """Explain missing iPhone notifications after messages and contacts work."""
+    if not limited:
+        return ANCS_REPAIR_HINT
+    name = str(vendor or "").strip()
+    if name:
+        return _(
+            "Messages and contacts are connected. This {vendor} adapter "
+            "does not support iPhone system notifications. Group texts "
+            "will appear as separate messages from their sender."
+        ).format(vendor=name)
+    return _(
+        "Messages and contacts are connected. This Bluetooth adapter "
+        "does not support iPhone system notifications. Group texts "
+        "will appear as separate messages from their sender."
+    )
 
 
 class CompatibilityState(Protocol):

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -10,6 +10,7 @@ from blueferry.backend_lifecycle import ensure_backend_current
 from blueferry.bluetooth_devices import iphone_candidates
 from blueferry.client import BackendClient, BackendError
 from blueferry.errors import PairingError
+from blueferry.onboarding import ANCS_REPAIR_HINT_CLI, ancs_unavailable_detail
 from blueferry.quirks_report import cli_issue_hint, latest_report
 from blueferry.setup_client import DISCOVERY_SECONDS, SetupClient
 from blueferry.setup_verification import (
@@ -39,11 +40,18 @@ def _verification_detail(*, ancs_ready: bool, compatibility_mode: bool) -> str:
     return "messages and contacts; this controller has no ANCS support"
 
 
-def _print_ancs_repair_hint() -> None:
+def _print_ancs_repair_hint(*, limited: bool = False, vendor: str = "") -> None:
+    if limited:
+        typer.echo(
+            typer.style(
+                "\n" + ancs_unavailable_detail(limited=True, vendor=vendor),
+                fg=typer.colors.GREEN,
+            )
+        )
+        return
     typer.echo(
         typer.style(
-            "\nFYI: If ANCS remains unavailable after setup, BlueZ may be "
-            "retaining stale Bluetooth state.",
+            "\n" + ANCS_REPAIR_HINT_CLI,
             fg=typer.colors.YELLOW,
         )
     )
@@ -279,7 +287,10 @@ def run_wizard(
         ancs_ready=result.ancs_ready,
     )
     if ancs_enabled and not result.ancs_ready:
-        _print_ancs_repair_hint()
+        _print_ancs_repair_hint(
+            limited=bool(getattr(compatibility, "ancs_limited_controller", False)),
+            vendor=str(getattr(compatibility, "controller_vendor", "") or ""),
+        )
 
     prompt = (
         "Have you completed the remaining iPhone steps? Verify the connection now?"

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -1167,6 +1167,7 @@ Kirigami.ApplicationWindow {
                 }
 
                 OnboardingSummary {
+                    id: onboardingSummary
                     Layout.fillWidth: true
                     stage: compatibilityMode.checked
                         && iphonePage.effectiveStage === "activate-bluetooth"
@@ -1420,8 +1421,10 @@ Kirigami.ApplicationWindow {
                         && root.bridge.status.map === true
                         && root.bridge.status.pbap === true
                         && root.bridge.status.ancs === false
-                    type: Kirigami.MessageType.Information
-                    text: qsTr("FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Before re-pairing, run sudo systemctl restart bluetooth.service, then forget this computer on the iPhone and pair again. This briefly disconnects all Bluetooth devices.")
+                    type: onboardingSummary.ancsLimitedController()
+                        ? Kirigami.MessageType.Positive
+                        : Kirigami.MessageType.Information
+                    text: onboardingSummary.ancsUnavailableHint()
                 }
 
                 Kirigami.Heading { text: qsTr("Desktop Notifications"); level: 2 }

--- a/src/blueferry/qt/qml/OnboardingSummary.qml
+++ b/src/blueferry/qt/qml/OnboardingSummary.qml
@@ -74,8 +74,32 @@ Kirigami.InlineMessage {
             "starting": qsTr("The configured backend is starting. This normally takes a few seconds."),
             "iphone-settings": pendingTasksText(storagePolicy, storageState),
             "ready": qsTr("Bluetooth services and iPhone permissions have been verified."),
-            "ready-without-ancs": qsTr("Messages and contacts have been verified. System notifications are unavailable, so group texts may appear as individual conversations.")
+            "ready-without-ancs": ancsLimitedDetail()
         }
         return details[stage] || ""
+    }
+
+    function ancsLimitedController() {
+        return compatibility.ancs_limited_controller === true
+            || status.ancs_limited_controller === true
+    }
+
+    function controllerVendor() {
+        return String(status.controller_vendor || compatibility.controller_vendor || "")
+    }
+
+    function ancsLimitedDetail() {
+        if (!ancsLimitedController())
+            return qsTr("Messages and contacts have been verified. System notifications are unavailable, so group texts may appear as individual conversations.")
+        const vendor = controllerVendor()
+        if (vendor !== "")
+            return qsTr("Messages and contacts are connected. This %1 adapter does not support iPhone system notifications. Group texts will appear as separate messages from their sender.").arg(vendor)
+        return qsTr("Messages and contacts are connected. This Bluetooth adapter does not support iPhone system notifications. Group texts will appear as separate messages from their sender.")
+    }
+
+    function ancsUnavailableHint() {
+        if (!ancsLimitedController())
+            return qsTr("FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Before re-pairing, run sudo systemctl restart bluetooth.service, then forget this computer on the iPhone and pair again. This briefly disconnects all Bluetooth devices.")
+        return ancsLimitedDetail()
     }
 }

--- a/src/blueferry/setup_client.py
+++ b/src/blueferry/setup_client.py
@@ -193,6 +193,8 @@ class BluetoothCompatibility:
     issue: str
     supported_settings: tuple[str, ...]
     adapters: tuple[AdapterOption, ...] = ()
+    controller_vendor: str = ""
+    ancs_limited_controller: bool = False
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> BluetoothCompatibility:
@@ -219,6 +221,8 @@ class BluetoothCompatibility:
                 for item in raw_adapters
                 if isinstance(item, dict)
             ),
+            controller_vendor=str(value.get("controller_vendor") or ""),
+            ancs_limited_controller=bool(value.get("ancs_limited_controller")),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -28,6 +28,7 @@ from blueferry.conversation_state import (
     ReplyDisposition,
 )
 from blueferry.models import BackendStatus, Thread, ThreadMessage
+from blueferry.onboarding import ancs_unavailable_detail
 from blueferry.protocol import BUS_NAME, EVENTS_IFACE, OBJECT_PATH
 from blueferry.text_safety import terminal_text
 from blueferry.time_display import format_message_timestamp
@@ -865,13 +866,14 @@ class BlueFerryApp(App[None]):
             and self.state.status.pbap
             and not self.state.status.ancs
         ):
+            limited = self.state.status.ancs_limited_controller
             notice.update(
-                "FYI: If ANCS remains unavailable, BlueZ may be retaining stale "
-                "Bluetooth state. Before re-pairing, run sudo systemctl restart "
-                "bluetooth.service, then forget this computer on the iPhone and "
-                "pair again. This briefly disconnects all Bluetooth devices."
+                ancs_unavailable_detail(
+                    limited=limited,
+                    vendor=self.state.status.controller_vendor,
+                )
             )
-            notice.set_classes("warn")
+            notice.set_classes("success" if limited else "warn")
         else:
             notice.update("Ready  ·  Ctrl+P: Help")
             notice.set_classes("")

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -9,7 +9,7 @@ from gi.repository import Adw, Gio, GLib, Gtk
 from blueferry.bluetooth_devices import PairedDevice, iphone_candidates
 from blueferry.i18n import _
 from blueferry.models import BackendStatus
-from blueferry.onboarding import OnboardingState
+from blueferry.onboarding import OnboardingState, ancs_unavailable_detail
 from blueferry.quirks_report import issue_report, issue_url
 from blueferry.setup_client import (
     DISCOVERY_SECONDS,
@@ -277,12 +277,7 @@ class IPhonePage(Gtk.Box):
         self._ancs_icon = Gtk.Image()
         self._ancs_row.add_suffix(self._ancs_icon)
         self._ancs_recovery_label = Gtk.Label(
-            label=_(
-                "FYI: If ANCS remains unavailable, BlueZ may be retaining stale "
-                "Bluetooth state. Before re-pairing, run sudo systemctl restart "
-                "bluetooth.service, then forget this computer on the iPhone and "
-                "pair again. This briefly disconnects all Bluetooth devices."
-            ),
+            label=ancs_unavailable_detail(),
             selectable=True,
             wrap=True,
             xalign=0,
@@ -924,10 +919,23 @@ class IPhonePage(Gtk.Box):
         show_ancs_recovery = bool(
             status.map and status.pbap and not ancs_connected and ancs_expected
         )
-        ancs_subtitle = _("Connected") if ancs_connected else _("Unavailable")
+        limited_ancs = bool(status.ancs_limited_controller)
+        if ancs_connected:
+            ancs_subtitle = _("Connected")
+        elif limited_ancs:
+            ancs_subtitle = _("Expected on this adapter")
+        else:
+            ancs_subtitle = _("Unavailable")
         self._ancs_row.set_subtitle(ancs_subtitle)
-        self._ancs_icon.set_from_icon_name(
-            "emblem-ok-symbolic" if ancs_connected else "dialog-warning-symbolic"
+        if ancs_connected or limited_ancs:
+            self._ancs_icon.set_from_icon_name("emblem-ok-symbolic")
+        else:
+            self._ancs_icon.set_from_icon_name("dialog-warning-symbolic")
+        self._ancs_recovery_label.set_label(
+            ancs_unavailable_detail(
+                limited=limited_ancs,
+                vendor=status.controller_vendor,
+            )
         )
         self._ancs_recovery_label.set_visible(show_ancs_recovery)
         self._contacts_row.set_subtitle(str(status.contacts))

--- a/tests/test_controller_hardware.py
+++ b/tests/test_controller_hardware.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from blueferry.bluetooth_capabilities import (
     activate_bluez_support,
+    ancs_limited_vendor,
     bluez_bearer_api_supported,
     bluez_stack,
     controller_hardware,
@@ -11,6 +12,15 @@ from blueferry.errors import PairingError
 
 def _btmgmt(stdout: str):
     return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+
+
+def test_realtek_and_broadcom_are_ancs_limited_vendors() -> None:
+    assert ancs_limited_vendor("Realtek") is True
+    assert ancs_limited_vendor("BROADCOM") is True
+    assert ancs_limited_vendor("Cypress") is True
+    assert ancs_limited_vendor("Intel") is False
+    assert ancs_limited_vendor("MediaTek") is False
+    assert ancs_limited_vendor("") is False
 
 
 def test_bluez_bearer_api_requires_5_86_or_newer() -> None:

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -241,12 +241,12 @@ def test_gui_pairing_guidance_tells_users_to_recheck_iphone_toggles() -> None:
 
 
 def test_all_clients_offer_bluez_restart_as_ancs_repair_recovery() -> None:
+    shared = (ROOT / "src/blueferry/onboarding.py").read_text()
+    pairing_cli = (ROOT / "src/blueferry/pairing_cli.py").read_text()
     clients = (
-        (ROOT / "src/blueferry/ui/status.py").read_text(),
+        shared,
         _qml_bundle(ROOT / "src/blueferry/qt/qml"),
         _qml_bundle(ROOT / "data/quickshell"),
-        (ROOT / "src/blueferry/tui.py").read_text(),
-        (ROOT / "src/blueferry/pairing_cli.py").read_text(),
     )
 
     for client in clients:
@@ -256,6 +256,20 @@ def test_all_clients_offer_bluez_restart_as_ancs_repair_recovery() -> None:
         assert "forget this computer on the iPhone and" in client
         assert "pair again" in client
         assert "briefly disconnects all Bluetooth devices" in client
+    assert "ANCS_REPAIR_HINT_CLI" in pairing_cli
+    assert "sudo systemctl restart bluetooth.service" in pairing_cli
+    assert "ancs_unavailable_detail" in (ROOT / "src/blueferry/tui.py").read_text()
+    assert "ancs_unavailable_detail" in (ROOT / "src/blueferry/ui/status.py").read_text()
+
+
+def test_limited_bluetooth_vendors_get_an_expected_ancs_success_message() -> None:
+    clients = (
+        (ROOT / "src/blueferry/onboarding.py").read_text(),
+        _qml_bundle(ROOT / "src/blueferry/qt/qml"),
+        _qml_bundle(ROOT / "data/quickshell"),
+    )
+    for client in clients:
+        assert "does not support iPhone system notifications" in client
 
 
 def test_all_pairing_clients_expose_compatibility_mode() -> None:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from blueferry.models import BackendStatus
-from blueferry.onboarding import OnboardingStage, OnboardingState, derive_stage
+from blueferry.onboarding import (
+    OnboardingStage,
+    OnboardingState,
+    ancs_unavailable_detail,
+    derive_stage,
+)
 from blueferry.setup_client import ConfigurationState
 
 COMPATIBLE = {
@@ -11,6 +16,15 @@ COMPATIBLE = {
     "notifications_supported": True,
     "bearer_api_active": True,
 }
+
+
+def test_ancs_copy_is_a_success_when_the_adapter_cannot_pair_notifications() -> None:
+    repair = ancs_unavailable_detail()
+    expected = ancs_unavailable_detail(limited=True, vendor="Realtek")
+    assert "ANCS remains unavailable" in repair
+    assert "sudo systemctl restart bluetooth.service" in repair
+    assert "This Realtek adapter does not support iPhone system notifications" in expected
+    assert "sudo systemctl restart" not in expected
 
 
 def test_unconfigured_compatible_install_requests_a_device() -> None:

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -31,6 +31,14 @@ def test_cli_ancs_repair_hint_restarts_bluez_before_repairing(capsys) -> None:
     assert "briefly disconnects all Bluetooth devices" in output
 
 
+def test_cli_limited_vendor_treats_missing_ancs_as_expected(capsys) -> None:
+    _print_ancs_repair_hint(limited=True, vendor="Realtek")
+
+    output = capsys.readouterr().out
+    assert "This Realtek adapter does not support iPhone system notifications" in output
+    assert "sudo systemctl restart" not in output
+
+
 def test_cli_setup_always_prints_required_bluetooth_toggles(capsys) -> None:
     _print_iphone_steps(
         frozenset(),

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -330,6 +330,28 @@ def test_quickshell_thread_preview_stays_inside_one_line(qml_engine) -> None:
     preview.deleteLater()
 
 
+def test_qt_onboarding_summary_treats_realtek_as_expected_success(qml_engine) -> None:
+    component = _component(
+        qml_engine, "src/blueferry/qt/qml/OnboardingSummary.qml"
+    )
+    summary = component.createWithInitialProperties({
+        "stage": "ready-without-ancs",
+        "compatibility": {
+            "notifications_supported": False,
+            "ancs_limited_controller": True,
+            "controller_vendor": "Realtek",
+        },
+        "status": {"verified_iphone_setup": []},
+    })
+
+    assert summary is not None
+    text = summary.property("text")
+    assert "Messages Are Connected" in text
+    assert "This Realtek adapter does not support iPhone system notifications" in text
+    assert "System notifications are unavailable" not in text
+    summary.deleteLater()
+
+
 def test_qt_onboarding_summary_renders_stage_from_properties(qml_engine) -> None:
     component = _component(
         qml_engine, "src/blueferry/qt/qml/OnboardingSummary.qml"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -401,6 +401,38 @@ def test_delete_key_confirms_and_deletes_current_conversation() -> None:
     _run_headless(scenario())
 
 
+def test_textual_treats_realtek_ancs_gap_as_expected(monkeypatch) -> None:
+    class LimitedAncsBackend(_Backend):
+        @staticmethod
+        def status() -> BackendStatus:
+            return BackendStatus(
+                daemon=True,
+                map=True,
+                pbap=True,
+                ancs=False,
+                controller_vendor="Realtek",
+                ancs_limited_controller=True,
+            )
+
+    async def scenario() -> None:
+        app = BlueFerryApp(
+            TuiState(LimitedAncsBackend()), monitor_factory=lambda: None
+        )
+
+        async with app.run_test(size=(70, 36)) as pilot:
+            notice = await _wait_for_static_text_containing(
+                app,
+                pilot,
+                "#notice-bar",
+                "This Realtek adapter does not support iPhone system notifications",
+            )
+            assert notice.has_class("success")
+            assert "sudo systemctl restart bluetooth.service" not in notice.render().plain
+
+    monkeypatch.setattr(tui_module.config, "ANCS_ENABLED", True)
+    _run_headless(scenario())
+
+
 def test_textual_warns_about_bluez_restart_when_only_ancs_is_missing(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- detect Realtek, Broadcom, and Cypress controllers from sysfs / company ID
- expose `controller_vendor` and `ancs_limited_controller` on pairing compatibility and daemon status
- when messages and contacts are up but ANCS is not, those adapters get a success-style note: this adapter does not support iPhone system notifications, and group texts will appear as separate messages from their sender
- Intel/MediaTek and similar still get the existing BlueZ restart / re-pair FYI

## Why

ANCS pairing often never completes on Realtek and Broadcom cards even though LE looks capable. The old copy treated that as stale Bluetooth state and told people to restart BlueZ and re-pair. On those adapters the useful setup (MAP/PBAP) already succeeded.

## Validation

- `python -m pytest tests/test_onboarding.py tests/test_controller_hardware.py tests/test_pairing_cli.py tests/test_tui.py tests/test_namespace.py tests/test_qml_presenters.py tests/test_models.py tests/test_daemon_lifecycle.py tests/test_setup_client.py tests/test_pair_setup.py tests/test_cli_pairing.py -q` — 238 passed
- `mypy src/blueferry` — no issues