### PR TITLE
Fix unintended read sync and protect conversation preferences

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,6 +191,13 @@ managers; distro systemd hooks reload changed user-unit metadata.
   Service. GNOME Keyring and KWallet are reached through the same libsecret
   interface; toolkit clients never handle the key. Generic key lookup
   attributes are intentionally non-sensitive.
+- Starred thread keys and confirmed group rosters are also sensitive: keys
+  can contain contact addresses. Each complete collection in `settings.json`
+  is encrypted with its own purpose string under the history storage policy.
+  Legacy plaintext collections are encrypted on first access, or scrubbed when
+  the wallet is locked or retention is disabled. Settings have a separate
+  4 MiB bound for the two 200-entry collections and encryption framing;
+  `local.env` retains its 64 KiB bound.
 - Passive daemon startup loads an existing key only from an already unlocked
   collection. It neither creates an item nor requests a wallet prompt. If the
   key is unavailable or ciphertext authentication fails, storage fails closed

--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ can also choose unencrypted storage or **Do not retain local data**. Changing
 storage modes clears the existing cache so encrypted and plaintext records are
 never mixed.
 
+Starred conversations and saved group confirmations follow the same storage
+policy as history. Older plaintext preferences are encrypted during upgrade
+when the wallet is available; if it is locked, those old preferences are
+cleared so contact identities are no longer retained in plaintext. You can
+star conversations and confirm group rosters again after unlocking.
+
 Configuration lives in `~/.config/blueferry`; local state lives in
 `~/.local/state/blueferry`. Uninstalling packages does not delete either
 directory.

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -175,12 +175,14 @@ ShellRoot {
   }
 
   function markSelectedThreadRead() {
+    if (!window.visible || !applicationSurface.Window.active || phoneSettingsVisible) return
     var thread = selectedThread()
     if (!thread || !threadIsUnread(thread)) return
     backendBridge.request("mark_thread_read", {thread_key: String(thread.key)})
   }
 
   onSelectedThreadKeyChanged: root.markSelectedThreadRead()
+  onPhoneSettingsVisibleChanged: root.markSelectedThreadRead()
 
   function selectMessage(handle) {
     for (var threadIndex = 0; threadIndex < threads.length; ++threadIndex) {
@@ -786,6 +788,7 @@ ShellRoot {
 
     Pane {
       id: applicationSurface
+      Window.onActiveChanged: root.markSelectedThreadRead()
       anchors.fill: parent
       padding: 0
       font.family: theme.fontFamily

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -353,7 +353,7 @@ class BackendOperations:
             return
         try:
             store.remember(thread_key, token)
-        except OSError:
+        except (OSError, ValueError, RuntimeError):
             log.exception("could not persist confirmed group roster")
 
     def _forget_confirmed_groups(self, thread_keys: Iterable[str]) -> None:

--- a/src/blueferry/confirmed_groups.py
+++ b/src/blueferry/confirmed_groups.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 from blueferry import config
 from blueferry.limits import MAX_CONFIRMED_GROUPS, MAX_THREAD_KEY_CHARS
-from blueferry.settings_store import SettingsStore
+from blueferry.private_preferences import PrivatePreference
+from blueferry.storage_security import StorageSecurity
 
 _SETTINGS_KEY = "confirmed_group_rosters"
 _DIGEST_LENGTH = 64
@@ -38,11 +39,15 @@ def _normalized_digest(value: object) -> str:
 class ConfirmedGroupsStore:
     """Remember which group rosters the user has already confirmed."""
 
-    def __init__(self, path: Path | None = None) -> None:
-        self._settings = SettingsStore(path or config.SETTINGS_JSON)
+    def __init__(
+        self, path: Path | None = None, *, storage: StorageSecurity | None = None,
+    ) -> None:
+        self._preference = PrivatePreference(
+            path or config.SETTINGS_JSON, _SETTINGS_KEY, storage,
+        )
 
     def _mapping(self) -> dict[str, str]:
-        raw = self._settings.read().get(_SETTINGS_KEY)
+        raw = self._preference.read()
         if not isinstance(raw, dict):
             return {}
         selected: dict[str, str] = {}
@@ -55,6 +60,9 @@ class ConfirmedGroupsStore:
             if len(selected) >= MAX_CONFIRMED_GROUPS:
                 break
         return selected
+
+    def migrate(self) -> None:
+        self._preference.read()
 
     def matches(self, thread_key: str, token: str) -> bool:
         key = _normalized_key(thread_key)
@@ -74,7 +82,7 @@ class ConfirmedGroupsStore:
         elif len(current) >= MAX_CONFIRMED_GROUPS:
             current.pop(next(iter(current)))
         current[key] = digest
-        self._settings.update(**{_SETTINGS_KEY: current})
+        self._preference.write(current)
 
     def forget(self, thread_keys: Iterable[str]) -> None:
         remove = {_normalized_key(key) for key in thread_keys}
@@ -86,8 +94,7 @@ class ConfirmedGroupsStore:
             key: digest for key, digest in current.items() if key not in remove
         }
         if updated != current:
-            self._settings.update(**{_SETTINGS_KEY: updated})
+            self._preference.write(updated)
 
     def clear(self) -> None:
-        if self._mapping():
-            self._settings.update(**{_SETTINGS_KEY: {}})
+        self._preference.clear()

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -92,8 +92,8 @@ class Daemon:
         self.contacts = ContactsResolver(storage=self.storage)
         self.connectivity = Connectivity()
         self.notification_policy = NotificationPolicyStore()
-        self.starred_threads = StarredThreadsStore()
-        self.confirmed_groups = ConfirmedGroupsStore()
+        self.starred_threads = StarredThreadsStore(storage=self.storage)
+        self.confirmed_groups = ConfirmedGroupsStore(storage=self.storage)
         self.setup_verification = SetupVerification(config.IPHONE_MAC)
         self.events = EventDispatcher(
             self.contacts,
@@ -252,6 +252,9 @@ class Daemon:
 
     def _initialize_storage(self) -> None:
         status = self.storage.refresh(allow_prompt=False)
+        # Upgrade/scrub legacy preferences even if the wallet is locked.
+        self.starred_threads.keys()
+        self.confirmed_groups.migrate()
         if status.policy == NO_STORAGE:
             clear_events()
             clear_contact_cache()

--- a/src/blueferry/private_preferences.py
+++ b/src/blueferry/private_preferences.py
@@ -1,0 +1,62 @@
+"""Policy-protected conversation preferences in the shared settings file."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from blueferry.settings_store import SettingsStore
+from blueferry.storage_security import (
+    NO_STORAGE,
+    CorruptStorageError,
+    StorageSecurity,
+)
+
+
+class PrivatePreference:
+    """Encrypt an entire preference, including identity-bearing mapping keys.
+
+    An absent storage policy is only for standalone, explicitly addressed stores.
+    The daemon always supplies its shared history/keyring policy.
+    """
+
+    def __init__(self, path: Path, key: str, storage: StorageSecurity | None) -> None:
+        self._settings = SettingsStore(path)
+        self._key = key
+        self._storage = storage
+
+    def read(self) -> object:
+        value = self._settings.read().get(self._key)
+        storage = self._storage
+        if storage is None or value is None:
+            return value
+        if storage.status.policy == NO_STORAGE:
+            self.clear()
+            return None
+        if not isinstance(value, str):
+            # Upgrade legacy plaintext records while the wallet is available.
+            # If it is locked, scrub them rather than retain exposed identities.
+            if storage.status.can_write:
+                self.write(value)
+                return value
+            self.clear()
+            return None
+        if not storage.status.can_read:
+            return None
+        try:
+            return json.loads(storage.decrypt(value, purpose=self._key + "-v1"))
+        except (CorruptStorageError, ValueError):
+            storage.fail_closed("Saved conversation preferences could not be authenticated")
+            return None
+
+    def write(self, value: object) -> None:
+        if self._storage is not None:
+            value = self._storage.encrypt(
+                json.dumps(value, ensure_ascii=False, separators=(",", ":")),
+                purpose=self._key + "-v1",
+            )
+        self._settings.update(**{self._key: value})
+
+    def clear(self) -> None:
+        # Clearing must also work while the keyring is locked or policy changes.
+        if self._settings.read().get(self._key) is not None:
+            self._settings.update(**{self._key: None})

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -11,6 +11,8 @@ Kirigami.ApplicationWindow {
     required property var bridge
     property string selectedThreadKey: ""
     onSelectedThreadKeyChanged: root.markSelectedThreadRead()
+    onActiveChanged: root.markSelectedThreadRead()
+    onIphoneSettingsPageChanged: Qt.callLater(root.markSelectedThreadRead)
     property bool firstRunRedirected: false
     property var iphoneSettingsPage: null
     property string pendingMessageHandle: ""
@@ -102,6 +104,8 @@ Kirigami.ApplicationWindow {
     }
 
     function markSelectedThreadRead() {
+        if (!root.visible || !root.active || root.iphoneSettingsPage !== null)
+            return
         const thread = selectedThread()
         if (thread && threadIsUnread(thread))
             bridge.markThreadRead(thread.key)

--- a/src/blueferry/settings_store.py
+++ b/src/blueferry/settings_store.py
@@ -8,6 +8,11 @@ from typing import Any
 from blueferry import config
 from blueferry.private_files import atomic_write_private_text, read_private_text
 
+# Two bounded collections can each contain 200 UTF-8 thread keys (1024
+# characters), plus roster digests and encryption framing. Keep local.env
+# parsing on its smaller, independent config limit.
+MAX_SETTINGS_FILE_BYTES = 4 * 1024 * 1024
+
 
 class SettingsStore:
     """Read and atomically update the owner-only settings document."""
@@ -18,7 +23,7 @@ class SettingsStore:
     def read(self) -> dict[str, Any]:
         try:
             value = json.loads(read_private_text(
-                self.path, maximum_bytes=config.MAX_CONFIG_FILE_BYTES
+                self.path, maximum_bytes=MAX_SETTINGS_FILE_BYTES
             ))
         except (OSError, UnicodeError, ValueError, TypeError):
             return {}
@@ -31,5 +36,5 @@ class SettingsStore:
         atomic_write_private_text(
             self.path,
             encoded,
-            maximum_bytes=config.MAX_CONFIG_FILE_BYTES,
+            maximum_bytes=MAX_SETTINGS_FILE_BYTES,
         )

--- a/src/blueferry/starred_threads.py
+++ b/src/blueferry/starred_threads.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 from blueferry import config
 from blueferry.limits import MAX_STARRED_THREADS, MAX_THREAD_KEY_CHARS
-from blueferry.settings_store import SettingsStore
+from blueferry.private_preferences import PrivatePreference
+from blueferry.storage_security import StorageSecurity
 
 _SETTINGS_KEY = "starred_thread_keys"
 
@@ -21,11 +22,15 @@ def _normalized_key(value: object) -> str:
 class StarredThreadsStore:
     """Keep a bounded set of opaque thread keys the user has starred."""
 
-    def __init__(self, path: Path | None = None) -> None:
-        self._settings = SettingsStore(path or config.SETTINGS_JSON)
+    def __init__(
+        self, path: Path | None = None, *, storage: StorageSecurity | None = None,
+    ) -> None:
+        self._preference = PrivatePreference(
+            path or config.SETTINGS_JSON, _SETTINGS_KEY, storage,
+        )
 
     def keys(self) -> list[str]:
-        raw = self._settings.read().get(_SETTINGS_KEY)
+        raw = self._preference.read()
         if not isinstance(raw, list):
             return []
         selected: list[str] = []
@@ -58,7 +63,7 @@ class StarredThreadsStore:
             current = [item for item in current if item != key]
         else:
             return False
-        self._settings.update(**{_SETTINGS_KEY: current})
+        self._preference.write(current)
         return bool(starred)
 
     def discard(self, thread_keys: Iterable[str]) -> None:
@@ -69,8 +74,7 @@ class StarredThreadsStore:
         current = self.keys()
         updated = [key for key in current if key not in remove]
         if updated != current:
-            self._settings.update(**{_SETTINGS_KEY: updated})
+            self._preference.write(updated)
 
     def clear(self) -> None:
-        if self.keys():
-            self._settings.update(**{_SETTINGS_KEY: []})
+        self._preference.clear()

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -631,6 +631,12 @@ class BlueFerryApp(App[None]):
         self._update_responsive(self.size.width)
         self._load_data()
 
+    def on_app_focus(self) -> None:
+        self.call_later(self._maybe_mark_selected_read)
+
+    def on_screen_resume(self) -> None:
+        self.call_later(self._maybe_mark_selected_read)
+
     def on_unmount(self) -> None:
         if self._monitor is not None:
             self._monitor.close()
@@ -879,6 +885,11 @@ class BlueFerryApp(App[None]):
             notice.set_classes("")
 
     def _maybe_mark_selected_read(self) -> None:
+        if not self.app_focus or isinstance(self.screen, ModalScreen):
+            return
+        workspace = self.query_one("#workspace")
+        if workspace.has_class("narrow") and not workspace.has_class("chat-open"):
+            return
         thread = self.state.selected
         if thread is None or not thread.unread:
             return
@@ -965,6 +976,7 @@ class BlueFerryApp(App[None]):
         composer = self.query_one("#composer", TextArea)
         if not composer.disabled:
             composer.focus()
+        self._maybe_mark_selected_read()
 
     def action_focus_search(self) -> None:
         self.query_one("#workspace").remove_class("chat-open")

--- a/src/blueferry/ui/conversations.py
+++ b/src/blueferry/ui/conversations.py
@@ -122,6 +122,10 @@ class ConversationsPage(Gtk.Box):
             hexpand=True,
             vexpand=True,
         )
+        self.connect("map", lambda _page: self._mark_selected_read())
+        focus = Gtk.EventControllerFocus()
+        focus.connect("enter", lambda _focus: self._mark_selected_read())
+        self.add_controller(focus)
         self._client = client
         self._toast = toast
         self._state = ConversationState(select_first=False)
@@ -653,6 +657,9 @@ class ConversationsPage(Gtk.Box):
         self._mark_selected_read()
 
     def _mark_selected_read(self) -> None:
+        window = self.get_root()
+        if not self.get_mapped() or window is None or not window.is_active():
+            return
         thread = self._state.selected
         if thread is None or not thread.unread:
             return

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -836,3 +836,37 @@ def test_delete_threads_validates_entire_request_before_erasing(
         operations.delete_threads([key, "address:phone:missing"], True)
 
     assert len(read_events(path=path)) == 1
+
+
+@pytest.mark.parametrize("error", [ValueError("settings full"), OSError("disk full")])
+def test_successful_group_send_is_acknowledged_when_preferences_fail(monkeypatch, error):
+    from concurrent.futures import Future
+
+    from blueferry.obex.worker import ObexWorker
+
+    pending = []
+    recorded = []
+    replies = []
+
+    def remember(*_args):
+        raise error
+
+    def submit(operation, *, on_success, on_error):
+        pending.append((on_success, on_error))
+
+    operations = _operations(
+        submit_obex=submit,
+        confirmed_groups=SimpleNamespace(remember=remember),
+        on_group_sent=lambda *args: recorded.append(args),
+    )
+    thread = _group()
+    _stub_group(operations, thread)
+    operations.send_to_thread(
+        thread["key"], "hello", True, replies.append,
+        lambda error: pytest.fail(str(error)),
+    )
+    result = Future()
+    result.set_result("/transfer/sent")
+    ObexWorker._deliver(result, *pending[0])
+    assert replies == ["/transfer/sent"]
+    assert len(recorded) == 1

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import gi
+import pytest
 
 gi.require_version("Gtk", "4.0")
 
@@ -188,7 +189,8 @@ def test_star_button_toggles_backend_star_state():
     assert starred == [("Bob", False)]
 
 
-def test_selected_unread_thread_is_marked_read():
+@pytest.mark.parametrize("mapped,active", [(True, True), (False, True), (True, False)])
+def test_selected_unread_thread_is_marked_read(mapped, active):
     marked = []
     unread = _thread(
         key="Bob",
@@ -207,6 +209,8 @@ def test_selected_unread_thread_is_marked_read():
     state.apply_snapshot(ConversationSnapshot(None, (unread, _thread())))
     state.selected_key = "Bob"
     page = SimpleNamespace(
+        get_root=lambda: SimpleNamespace(is_active=lambda: active),
+        get_mapped=lambda: mapped,
         _state=state,
         _client=SimpleNamespace(
             mark_thread_read_async=lambda key: marked.append(key)
@@ -214,11 +218,11 @@ def test_selected_unread_thread_is_marked_read():
     )
 
     conversations.ConversationsPage._mark_selected_read(page)
-    assert marked == ["Bob"]
+    assert marked == (["Bob"] if mapped and active else [])
 
     state.selected_key = "Alice"
     conversations.ConversationsPage._mark_selected_read(page)
-    assert marked == ["Bob"]
+    assert marked == (["Bob"] if mapped and active else [])
 
 
 def test_map_refusal_reveals_prominent_message_banner() -> None:

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -30,6 +30,7 @@ def _bare_daemon():
         clear=lambda: None,
     )
     instance.confirmed_groups = SimpleNamespace(
+        migrate=lambda: None,
         matches=lambda *_args, **_kwargs: False,
         remember=lambda *_args, **_kwargs: None,
         forget=lambda *_args, **_kwargs: None,

--- a/tests/test_private_preferences.py
+++ b/tests/test_private_preferences.py
@@ -1,0 +1,137 @@
+"""Preferences use the same encryption and retention policy as message history."""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from blueferry.confirmed_groups import ConfirmedGroupsStore
+from blueferry.settings_store import SettingsStore
+from blueferry.starred_threads import StarredThreadsStore
+from blueferry.storage_security import StorageSecurity, StorageUnavailableError
+
+
+def _stores(path, *, initialize=True):
+    settings = SettingsStore(path)
+    provider = SimpleNamespace(get_or_create=lambda **_kwargs: b'K' * 32)
+    storage = StorageSecurity(settings=settings, key_provider=provider, initialize=initialize)
+    return storage, StarredThreadsStore(path, storage=storage), ConfirmedGroupsStore(
+        path, storage=storage,
+    )
+
+
+def test_encrypted_preferences_hide_identities_and_survive_restart(tmp_path):
+    path = tmp_path / "settings.json"
+    _, stars, groups = _stores(path)
+    key = "group:addresses:email:alice@example.com|phone:15551111111"
+    token = "alice@example.com\n+15551111111"
+    stars.set_starred(key, True)
+    groups.remember(key, token)
+    text = path.read_text()
+    for identity in (key, "alice@example.com", "15551111111", token):
+        assert identity not in text
+    _, stars, groups = _stores(path)
+    assert stars.keys() == [key]
+    assert groups.matches(key, token)
+    assert not groups.matches(key, token + "changed")
+    stars.discard([key])
+    groups.forget([key])
+    assert stars.keys() == []
+    assert not groups.matches(key, token)
+
+
+def test_upgrade_encrypts_legacy_keys_without_losing_preferences(tmp_path):
+    path = tmp_path / "settings.json"
+    key = "address:phone:15551111111"
+    StarredThreadsStore(path).set_starred(key, True)
+    ConfirmedGroupsStore(path).remember(key, "roster")
+    _, stars, groups = _stores(path)
+    assert stars.keys() == [key]
+    groups.migrate()
+    assert groups.matches(key, "roster")
+    assert "15551111111" not in path.read_text()
+
+
+def test_locked_wallet_keeps_ciphertext_and_rejects_writes(tmp_path):
+    path = tmp_path / "settings.json"
+    _, stars, groups = _stores(path)
+    stars.set_starred("one", True)
+    groups.remember("one", "roster")
+    saved = path.read_bytes()
+    storage, stars, groups = _stores(path, initialize=False)
+    assert stars.keys() == []
+    assert not groups.matches("one", "roster")
+    with pytest.raises(StorageUnavailableError):
+        stars.set_starred("two", True)
+    assert path.read_bytes() == saved
+    storage.refresh(allow_prompt=False)
+    assert stars.keys() == ["one"]
+    assert groups.matches("one", "roster")
+
+
+def test_locked_upgrade_scrubs_legacy_plaintext(tmp_path):
+    path = tmp_path / "settings.json"
+    StarredThreadsStore(path).set_starred("address:phone:15551111111", True)
+    ConfirmedGroupsStore(path).remember("group:addresses:phone:15551111111", "roster")
+    _, stars, groups = _stores(path, initialize=False)
+    assert stars.keys() == []
+    groups.migrate()
+    assert "15551111111" not in path.read_text()
+
+
+def test_clear_works_without_wallet_access(tmp_path):
+    path = tmp_path / "settings.json"
+    _, stars, groups = _stores(path)
+    stars.set_starred("one", True)
+    groups.remember("one", "roster")
+    _, stars, groups = _stores(path, initialize=False)
+    stars.clear()
+    groups.clear()
+    _, stars, groups = _stores(path)
+    assert stars.keys() == []
+    assert not groups.matches("one", "roster")
+
+
+@pytest.mark.parametrize("policy", ["none", "plaintext"])
+def test_preferences_follow_retention_policy(tmp_path, policy):
+    path = tmp_path / "settings.json"
+    SettingsStore(path).update(local_data=policy)
+    _, stars, groups = _stores(path)
+    if policy == "none":
+        with pytest.raises(StorageUnavailableError):
+            stars.set_starred("one", True)
+        with pytest.raises(StorageUnavailableError):
+            groups.remember("one", "roster")
+        assert stars.keys() == []
+    else:
+        stars.set_starred("one", True)
+        groups.remember("one", "roster")
+        _, stars, groups = _stores(path)
+        assert stars.keys() == ["one"]
+        assert groups.matches("one", "roster")
+
+
+def test_full_collections_fit_with_encryption_and_long_keys(tmp_path):
+    path = tmp_path / "settings.json"
+    _, stars, groups = _stores(path)
+    keys = [f"group:participants:{i}:" + "é" * 990 for i in range(200)]
+    for key in keys:
+        stars.set_starred(key, True)
+        groups.remember(key, "roster")
+    assert path.stat().st_size > 64 * 1024
+    _, stars, groups = _stores(path)
+    assert stars.keys() == keys
+    assert all(groups.matches(key, "roster") for key in keys)
+
+
+def test_tampering_fails_closed(tmp_path):
+    path = tmp_path / "settings.json"
+    storage, stars, groups = _stores(path)
+    stars.set_starred("one", True)
+    groups.remember("one", "roster")
+    payload = json.loads(path.read_text())
+    # Swapping valid encrypted fields must fail purpose authentication.
+    SettingsStore(path).update(starred_thread_keys=payload["confirmed_group_rosters"])
+    assert stars.keys() == []
+    assert storage.status.state == "error"

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -385,3 +385,50 @@ def test_qt_onboarding_summary_explains_locked_contact_sync(qml_engine) -> None:
     assert "Unlock Local Data, then sync contacts again" in summary.property("text")
     assert "Enable Sync Contacts" not in summary.property("text")
     summary.deleteLater()
+
+
+@pytest.mark.parametrize("relative_path", [
+    "data/quickshell/shell.qml", "src/blueferry/qt/qml/Main.qml",
+])
+def test_read_sync_requires_visible_active_conversation(qml_engine, relative_path):
+    """Execute the shipped handlers with inert windows and backend recorders."""
+    source = (ROOT / relative_path).read_text()
+    functions = []
+    for name in ("threadByKey", "selectedThread", "threadIsUnread", "markSelectedThreadRead"):
+        start = source.index("function " + name + "(")
+        opening = source.index("{", start)
+        depth = 1
+        end = opening + 1
+        while depth:
+            depth += (source[end] == "{") - (source[end] == "}")
+            end += 1
+        functions.append(source[start:end])
+    script = '''(function() {
+        var calls = [];
+        var threads = [{key: "one", unread: true}];
+        var selectedThreadKey = "one";
+        var bridge = {threads: threads, markThreadRead: function(key) { calls.push(key); }};
+        var backendBridge = {request: function(method, args) { calls.push(args.thread_key); }};
+        var window = {visible: true};
+        var applicationSurface = {Window: {active: true}};
+        var phoneSettingsVisible = false;
+        var root = {visible: true, active: true, iphoneSettingsPage: null};
+    ''' + "\n".join(functions) + '''
+        window.visible = root.visible = false;
+        markSelectedThreadRead();
+        window.visible = root.visible = true;
+        applicationSurface.Window.active = root.active = false;
+        markSelectedThreadRead();
+        applicationSurface.Window.active = root.active = true;
+        phoneSettingsVisible = true;
+        root.iphoneSettingsPage = {};
+        markSelectedThreadRead();
+        if (calls.length) throw new Error("Hidden conversation was marked read");
+        phoneSettingsVisible = false;
+        root.iphoneSettingsPage = null;
+        markSelectedThreadRead();
+        return JSON.stringify(calls);
+    })()'''
+    result = qml_engine.evaluate(script)
+    assert not result.isError(), result.toString()
+    assert result.toString() == '["one"]'

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -653,3 +653,31 @@ def test_textual_composer_sends_without_blocking_ui() -> None:
             assert backend.sent == [("one", "A proper terminal reply", False)]
 
     _run_headless(scenario())
+
+
+def test_read_sync_waits_for_narrow_chat_and_pauses_under_dialogs():
+    async def scenario() -> None:
+        backend = _Backend()
+        app = BlueFerryApp(TuiState(backend), monitor_factory=lambda: None)
+        marked = []
+        app._mark_thread_read = marked.append
+        async with app.run_test(size=(70, 30)) as pilot:
+            await _wait_for_threads(app, pilot, 2)
+            selected = app.state.selected
+            assert selected is not None and selected.unread
+            app._maybe_mark_selected_read()
+            assert marked == []
+            app.action_open_thread()
+            assert marked == [selected.key]
+            marked.clear()
+            app.action_help()
+            await pilot.pause()
+            app._maybe_mark_selected_read()
+            assert marked == []
+            app.pop_screen()
+            await pilot.pause()
+            marked.clear()
+            app.app_focus = False
+            app._maybe_mark_selected_read()
+            assert marked == []
+    _run_headless(scenario())


### PR DESCRIPTION
Conversation refreshes could mark messages read while the user was in settings or another window. Saved conversation preferences also exposed contact identities in plaintext, and a settings-size error could swallow a successful group send's response and history entry.

This fixes the three findings from the review of PRs #116, #117, and #119:

- Require an active, visible conversation before automatic read sync in GTK, Qt, and Quickshell. The TUI also pauses read sync under dialogs, in its narrow list view, and when terminal focus reporting says it is inactive.
- Encrypt complete starred-conversation and group-confirmation collections under the existing local-data policy, including their identity-bearing keys. Respect locked wallets and disabled retention, and allow clearing without wallet access.
- Give settings a separate 4 MiB bound for both bounded preference collections and encryption framing, while keeping the local.env limit unchanged. A preference-write failure after a successful send now preserves the sent-history callback and client acknowledgment.

Upgrade behavior: legacy plaintext preferences are encrypted when the wallet is available. If the wallet is locked or retention is disabled, those legacy entries are scrubbed; users may need to star conversations and confirm groups again. Already-encrypted preferences remain intact while the wallet is locked. README and architecture notes document this behavior.

Validation: 882 tests passed on the isolated D-Bus suite. Ruff, mypy, Bandit, QML lint, and git diff checks passed. New regression coverage exercises shipped QML handlers, GTK/TUI visibility, encryption and restart persistence, migration, locked/disabled storage, ciphertext tampering, full collections with long Unicode keys, and successful-send callbacks after persistence failures. No live phone operations were used.
