### PR TITLE
Fix seven audited conversation and transport bugs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,6 +69,14 @@ separate short-lived helper protocol because it precedes daemon availability
 and must exchange confirmation prompts with the QML client.
 All Python transports share `client_wire` for response-shape validation and
 model conversion; synchronous and toolkit-specific scheduling remain separate.
+`ListThreads` includes retained starred conversations even when their last event
+falls outside the ordinary 2,000-event window. The cached projection scans retained
+history when stars exist, preserving older group correlation evidence. Responses
+fit the 8 MiB JSON budget by retaining contiguous newest-message tails fairly
+across threads. `messages_truncated` tells clients to show a history notice; this
+also covers the existing 500-message per-thread display cap. These limits never
+delete stored events or change reply recipients.
+
 Group-thread messages include a display-only sender label derived from the
 resolved MAP contact or the correlated Messages notification. It never
 participates in thread identity or reply routing; outgoing labels are localized

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -1105,6 +1105,15 @@ ShellRoot {
                 color: theme.divider
               }
 
+              Label {
+                Layout.fillWidth: true
+                visible: conversationPane.thread !== null
+                  && conversationPane.thread.messages_truncated === true
+                text: "Showing recent messages. Older messages remain in local history."
+                wrapMode: Text.Wrap
+                color: theme.windowText
+              }
+
               ListView {
                 id: messageList
                 property bool stickToBottom: true

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -60,6 +60,7 @@ from blueferry.storage_security import STORAGE_POLICIES, StorageSecurity
 from blueferry.threads import (
     MESSAGE_KINDS,
     ConversationIndex,
+    bound_thread_response,
     build_threads,
     group_confirmation_token,
     sort_threads,
@@ -166,13 +167,23 @@ class BackendOperations:
         self._confirmed_groups: dict[str, str] = {}
         self._conversations = ConversationIndex(
             lambda: read_events(
-                limit=MAX_CONVERSATION_EVENTS,
+                limit=None if self._starred_keys() else MAX_CONVERSATION_EVENTS,
                 max_body_chars=MAX_THREAD_BODY_CHARS,
                 storage=self.dependencies.storage,
             ),
-            lambda events: build_threads(events, self.dependencies.contacts),
+            self._build_conversations,
             revision=lambda: history_revision(storage=self.dependencies.storage),
         )
+
+    def _build_conversations(self, events: list[dict]) -> list[dict]:
+        threads = build_threads(events, self.dependencies.contacts)
+        stars = self._starred_keys()
+        if not stars:
+            return threads
+        recent = {str(event.get("handle") or "") for event in events[-MAX_CONVERSATION_EVENTS:]}
+        return [thread for thread in threads if thread["key"] in stars or any(
+            message["handle"] in recent for message in thread["messages"]
+        )]
 
     def _require_map(self) -> None:
         if self.sessions.map is None:
@@ -332,7 +343,7 @@ class BackendOperations:
 
     def list_threads(self, limit: int) -> list[dict]:
         bounded = max(1, min(int(limit), MAX_THREAD_QUERY_LIMIT))
-        return self._present_threads(self._conversations.threads())[:bounded]
+        return bound_thread_response(self._present_threads(self._conversations.threads())[:bounded])
 
     def _starred_keys(self) -> set[str]:
         store = self.dependencies.starred_threads
@@ -394,9 +405,9 @@ class BackendOperations:
         if thread is None:
             raise NotFoundError("thread no longer exists in local history")
         try:
-            return self.dependencies.starred_threads.set_starred(
-                thread_key, bool(starred)
-            )
+            result = self.dependencies.starred_threads.set_starred(thread_key, bool(starred))
+            self._conversations.invalidate()
+            return result
         except ValueError as error:
             raise InvalidArgumentsError(str(error)) from error
 

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -29,6 +29,7 @@ from blueferry.event_dispatcher import EventDispatcher
 from blueferry.history import (
     clear_events,
     history_count,
+    mark_event_handles_read,
     minimize_ancs_history,
     prune_events,
     read_events,
@@ -440,10 +441,16 @@ class Daemon:
             self.listener = MapEventListener(
                 sessions=self.sessions,
                 on_sms=self.events.message,
+                on_read=self._message_read,
                 resolve_contact=lambda raw: self.contacts.resolve(raw),
                 submit_obex=self.obex_worker.submit,
             )
             self.listener.start()
+
+    def _message_read(self, handle: str) -> None:
+        if mark_event_handles_read([handle], storage=self.storage):
+            if self._dbus_service is not None:
+                self._dbus_service.emit_history_changed()
 
     def _post_sessions_setup(self) -> None:
         """Finish setup once both MAP and PBAP are live."""

--- a/src/blueferry/obex/map_events.py
+++ b/src/blueferry/obex/map_events.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from collections import OrderedDict
 from collections.abc import Callable
 from pathlib import Path
 
@@ -82,10 +83,14 @@ class MapEventListener:
         on_sms: EventCallback,
         *,
         submit_obex: SubmitObex,
+        on_read: Callable[[str], None] | None = None,
         resolve_contact: Callable[[str | None], str | None] = lambda _: None,
     ) -> None:
         self.sessions = sessions
         self.on_sms = on_sms
+        self.on_read = on_read
+        self._read_handles: OrderedDict[str, None] = OrderedDict()
+        self._read_match = None
         self.submit_obex = submit_obex
         self.resolve_contact = resolve_contact
         self._signal_match = None
@@ -99,12 +104,23 @@ class MapEventListener:
         self._signal_match = manager.connect_to_signal(
             "InterfacesAdded", self._on_interfaces_added
         )
+        self._read_match = get_session_bus().add_signal_receiver(
+            self._on_message_properties,
+            signal_name="PropertiesChanged",
+            dbus_interface="org.freedesktop.DBus.Properties",
+            bus_name="org.bluez.obex",
+            path_keyword="path",
+        )
         self._running = True
         log.info("MAP MNS listener started (filtering on %s)",
                  self.sessions.map_path)
 
     def stop(self) -> None:
         self._running = False
+        self._read_handles.clear()
+        if self._read_match is not None:
+            self._read_match.remove()
+            self._read_match = None
         if self._signal_match is not None:
             try:
                 self._signal_match.remove()
@@ -112,6 +128,24 @@ class MapEventListener:
                 log.debug("could not remove MAP event watch", exc_info=True)
             self._signal_match = None
         log.info("MAP MNS listener stopped")
+
+    def _on_message_properties(self, interface, changed, _invalidated, *, path) -> None:
+        session = self.sessions.map
+        if (not self._running or session is None
+                or interface != "org.bluez.obex.Message1"
+                or not str(path).startswith(f"{session.path}/")
+                or not changed.get("Read")):
+            return
+        handle = str(path).rsplit("/", 1)[-1]
+        self._read_handles[handle] = None
+        self._read_handles.move_to_end(handle)
+        if len(self._read_handles) > 2048:
+            self._read_handles.popitem(last=False)
+        if self.on_read is not None:
+            try:
+                self.on_read(handle)
+            except Exception:
+                log.exception("could not persist phone read state")
 
     def _on_interfaces_added(self, path, ifaces) -> None:
         path_s = str(path)
@@ -155,7 +189,8 @@ class MapEventListener:
             contact_name=contact,
             body=parsed.body,
             timestamp=parse_map_timestamp(props.get("Timestamp")),
-            is_read=str(parsed.status or "").upper() == "READ",
+            is_read=(str(parsed.status or "").upper() == "READ"
+                     or handle in self._read_handles),
             message_path=message_path,
         )
         log.info("sms_received (%d-char body)", len(event.body or ""))

--- a/src/blueferry/profile_supervisor.py
+++ b/src/blueferry/profile_supervisor.py
@@ -114,11 +114,17 @@ class ProfileSupervisor:
         generation = self._generation
         self.connectivity.connecting()
         self._on_status()
-        self.worker.submit(
-            self.sessions.open_all,
-            on_success=lambda result: self._opened(generation, result),
-            on_error=lambda error: self._open_failed(generation, error),
-        )
+        try:
+            self.worker.submit(
+                self.sessions.open_all,
+                on_success=lambda result: self._opened(generation, result),
+                on_error=lambda error: self._open_failed(generation, error),
+            )
+        except RuntimeError as error:
+            self._opening = False
+            delay = self.connectivity.failed(error, retry_delay_seconds=self._poll_seconds)
+            self._on_status()
+            self._schedule_retry(delay)
 
     def reconnect(self, reason: str, *, remove_remote_sessions: bool = True) -> None:
         """Discard current consumers and sessions, then reconnect shortly."""
@@ -141,11 +147,29 @@ class ProfileSupervisor:
         close = self.sessions.close_all
         if not remove_remote_sessions:
             close = partial(self.sessions.close_all, remove_remote=False)
-        self.worker.submit(
-            close,
-            on_success=lambda _result: self._closed(generation),
-            on_error=lambda error: self._close_failed(generation, error),
-        )
+        if self._retry_id is not None:
+            self._cancel(self._retry_id)
+            self._retry_id = None
+        self._submit_close(generation, close)
+
+    def _submit_close(self, generation: int, close: Callable[[], None]) -> None:
+        if self._stopping or generation != self._generation:
+            return
+        try:
+            self.worker.submit(
+                close,
+                on_success=lambda _result: self._closed(generation),
+                on_error=lambda error: self._close_failed(generation, error),
+            )
+        except RuntimeError:
+            log.warning("OBEX queue full; retrying session cleanup")
+
+            def retry_close() -> bool:
+                self._retry_id = None
+                self._submit_close(generation, close)
+                return False
+
+            self._retry_id = self._schedule(self._poll_seconds, retry_close)
 
     def session_lost(self, reason: str) -> None:
         # The transport is already failing. Keep cleanup serialized behind any

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -20,8 +20,9 @@ from blueferry import __version__
 from blueferry.backend_lifecycle import ensure_backend_current, restart_backend
 from blueferry.bluetooth_devices import iphone_candidates
 from blueferry.client import BackendClient, BackendError
+from blueferry.conversation_state import ConversationState, ReplyDisposition
 from blueferry.i18n import _
-from blueferry.models import BackendStatus
+from blueferry.models import BackendStatus, Thread
 from blueferry.onboarding import OnboardingState, effective_compatibility
 from blueferry.protocol import BUS_NAME, EVENTS_IFACE, OBJECT_PATH
 from blueferry.qt.tasks import Task
@@ -48,6 +49,9 @@ class BridgeController(QObject):
     pairingConfirmationRequested = Signal(str)
     pairingIssueReportChanged = Signal()
     messageOpenRequested = Signal(str)
+    groupConfirmationRequested = Signal(str, str, str)
+    threadSendSucceeded = Signal(str, str)
+    messageSendSucceeded = Signal(str, str)
 
     def __init__(
         self,
@@ -68,6 +72,7 @@ class BridgeController(QObject):
         self._pool.setExpiryTimeout(-1)
         self._tasks: set[Task] = set()
         self._threads: list[dict] = []
+        self._pending_group: tuple[str, str, str] | None = None
         self._contact_results: list[dict] = []
         self._contact_query = ""
         self._status: dict = {}
@@ -462,15 +467,31 @@ class BridgeController(QObject):
 
     @Slot(str, str, bool)
     def sendThread(self, key: str, body: str, confirm_group: bool) -> None:
-        body = body.strip()
-        if not key or not body:
+        draft = body
+        state = ConversationState()
+        state.threads = [Thread.from_dict(value) for value in self._threads]
+        thread = state.thread(key)
+        if confirm_group:
+            expected = (key, body.strip(), thread.confirmation_token) if thread else None
+            if expected is None or self._pending_group != expected:
+                self._pending_group = None
+                self._set_error(_("The group changed. Review the recipients and send again."))
+                return
+        self._pending_group = None
+        plan = state.plan_reply(body, thread_key=key, confirm_group=confirm_group)
+        if plan.disposition is ReplyDisposition.CONFIRM_GROUP and thread is not None:
+            self._pending_group = (key, plan.body, thread.confirmation_token)
+            self.groupConfirmationRequested.emit(key, draft, "\n".join(thread.recipients))
+            return
+        if not plan.ready:
             return
 
         def completed(_value: object) -> None:
+            self.threadSendSucceeded.emit(key, draft)
             self.refresh()
 
         self._run(
-            lambda: self._backend.send_to_thread(key, body, confirm_group=confirm_group),
+            lambda: self._backend.send_to_thread(key, plan.body, confirm_group=plan.confirm_group),
             completed,
         )
 
@@ -511,14 +532,16 @@ class BridgeController(QObject):
 
     @Slot(str, str)
     def sendMessage(self, recipient: str, body: str) -> None:
-        recipient = recipient.strip()
-        body = body.strip()
-        if not recipient or not body:
+        if not recipient.strip() or not body.strip():
             return
 
+        def completed(_value: object) -> None:
+            self.messageSendSucceeded.emit(recipient, body)
+            self.refresh()
+
         self._run(
-            lambda: self._backend.send(recipient, body),
-            lambda _value: self.refresh(),
+            lambda: self._backend.send(recipient.strip(), body.strip()),
+            completed,
         )
 
     @Slot()

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -606,6 +606,30 @@ Kirigami.ApplicationWindow {
         standardButtons: Kirigami.Dialog.Close
     }
 
+    Kirigami.PromptDialog {
+        id: confirmGroupDialog
+        property string threadKey: ""
+        property string draft: ""
+        title: qsTr("Confirm Group Recipients")
+        standardButtons: Kirigami.Dialog.Cancel
+        customFooterActions: [Kirigami.Action {
+            text: qsTr("Send to These Recipients")
+            onTriggered: {
+                root.bridge.sendThread(confirmGroupDialog.threadKey, confirmGroupDialog.draft, true)
+                confirmGroupDialog.close()
+            }
+        }]
+        Connections {
+            target: root.bridge
+            function onGroupConfirmationRequested(key: string, body: string, roster: string): void {
+                confirmGroupDialog.threadKey = key
+                confirmGroupDialog.draft = body
+                confirmGroupDialog.subtitle = root.escapedRichText(root.htmlEscape(roster).replace(/\n/g, "<br>"))
+                confirmGroupDialog.open()
+            }
+        }
+    }
+
     Kirigami.Dialog {
         id: newMessageDialog
         title: qsTr("New Message")
@@ -619,13 +643,21 @@ Kirigami.ApplicationWindow {
                 && newMessageBody.text.trim() !== "" && !root.bridge.busy
             onTriggered: {
                 root.bridge.sendMessage(newRecipient.text, newMessageBody.text)
-                newMessageDialog.close()
             }
         }]
 
+        Connections {
+            target: root.bridge
+            function onMessageSendSucceeded(recipient: string, body: string): void {
+                if (newRecipient.text === recipient && newMessageBody.text === body) {
+                    newRecipient.clear()
+                    newMessageBody.clear()
+                    newMessageDialog.close()
+                }
+            }
+        }
+
         onOpened: {
-            newRecipient.clear()
-            newMessageBody.clear()
             root.bridge.findContacts("")
             newRecipient.forceActiveFocus()
         }
@@ -957,6 +989,14 @@ Kirigami.ApplicationWindow {
                             }
                         }
 
+                        Controls.Label {
+                            Layout.fillWidth: true
+                            visible: messagesPage.thread !== null
+                                && messagesPage.thread.messages_truncated === true
+                            text: qsTr("Showing recent messages. Older messages remain in local history.")
+                            wrapMode: Text.Wrap
+                        }
+
                         ListView {
                             id: messageList
                             Layout.fillWidth: true
@@ -1031,6 +1071,14 @@ Kirigami.ApplicationWindow {
 
                             ExpandingMessageComposer {
                                 id: composer
+                                Connections {
+                                    target: root.bridge
+                                    function onThreadSendSucceeded(key: string, body: string): void {
+                                        if (messagesPage.thread && messagesPage.thread.key === key
+                                                && composer.text === body)
+                                            composer.clear()
+                                    }
+                                }
                                 placeholderText: qsTr("Write a Message")
                                 enabled: messagesPage.thread !== null
                                     && messagesPage.thread.reply_ready && !root.bridge.busy
@@ -1048,9 +1096,8 @@ Kirigami.ApplicationWindow {
                                     root.bridge.sendThread(
                                         messagesPage.thread.key,
                                         composer.text,
-                                        messagesPage.thread.is_group
+                                        false
                                     )
-                                    composer.clear()
                                 }
                             }
                         }

--- a/src/blueferry/quickshell_bridge.py
+++ b/src/blueferry/quickshell_bridge.py
@@ -204,6 +204,20 @@ def _install_signal_receivers(bridge: QuickshellBridge) -> list[object]:
     ]
 
 
+def _read_requests(stream: TextIO, submit: Callable[[str], None]) -> None:
+    while True:
+        line = stream.readline(MAX_REQUEST_CHARS + 2)
+        if not line:
+            return
+        if len(line) > MAX_REQUEST_CHARS:
+            # Report one oversized request, then discard its remaining chunks.
+            submit(line)
+            while line and not line.endswith("\n"):
+                line = stream.readline(MAX_REQUEST_CHARS + 2)
+            continue
+        submit(line)
+
+
 def main() -> int:
     from dbus.mainloop.glib import DBusGMainLoop
     from gi.repository import GLib
@@ -214,22 +228,13 @@ def main() -> int:
     signal_matches = _install_signal_receivers(bridge)
     loop = GLib.MainLoop()
 
-    def read_request(_source: object, condition: int) -> bool:
-        if condition & (GLib.IO_HUP | GLib.IO_ERR):
-            loop.quit()
-            return False
-        line = sys.stdin.readline()
-        if not line:
-            loop.quit()
-            return False
-        workers.submit(line)
-        return True
+    # A dedicated reader drains TextIO's prefetched lines and keeps a partial
+    # request from blocking GLib's D-Bus signal dispatch.
+    def read_requests() -> None:
+        _read_requests(sys.stdin, workers.submit)
+        GLib.idle_add(loop.quit)
 
-    GLib.io_add_watch(
-        sys.stdin.fileno(),
-        GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR,
-        read_request,
-    )
+    threading.Thread(target=read_requests, name="blueferry-stdin", daemon=True).start()
     try:
         loop.run()
     finally:

--- a/src/blueferry/threads.py
+++ b/src/blueferry/threads.py
@@ -1,6 +1,7 @@
 """Backend-owned conversation model and reply routing metadata."""
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import TypeAlias
@@ -12,7 +13,7 @@ from blueferry.events import (
 )
 from blueferry.grouping import correlate_group_events
 from blueferry.history import history_revision
-from blueferry.limits import MAX_THREAD_MESSAGES
+from blueferry.limits import MAX_DBUS_JSON_BYTES, MAX_THREAD_MESSAGES
 
 MESSAGE_KINDS = {"sms_received", "sms_sent"}
 CacheKey: TypeAlias = tuple[int, ...]
@@ -223,7 +224,8 @@ def build_threads(events: list[dict], resolver=None) -> list[dict]:
     for thread in by_key.values():
         if thread.get("participants_required"):
             thread["reply_ready"] = False
-        if len(thread["messages"]) > MAX_THREAD_MESSAGES:
+        thread["messages_truncated"] = len(thread["messages"]) > MAX_THREAD_MESSAGES
+        if thread["messages_truncated"]:
             thread["messages"] = thread["messages"][-MAX_THREAD_MESSAGES:]
         thread["unread"] = any(
             not message.get("outgoing") and not message.get("read")
@@ -261,3 +263,45 @@ def find_thread(events: list[dict], key: str, resolver=None) -> dict | None:
          if thread["key"] == key),
         None,
     )
+
+
+def bound_thread_response(
+    threads: list[dict], *, max_bytes: int = MAX_DBUS_JSON_BYTES,
+) -> list[dict]:
+    """Fit newest message tails fairly within the wire budget, without mutating history."""
+    def size(value: object) -> int:
+        return len(json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+
+    result: list[dict] = []
+    remaining = max_bytes - 2  # outer list
+    for thread in threads:
+        item = {**thread, "messages": [], "messages_truncated": False}
+        cost = size(item) + bool(result)
+        if cost > remaining:
+            break
+        remaining -= cost
+        result.append(item)
+
+    # One message per conversation per round prevents a large thread from
+    # consuming the entire response. Each retained history remains contiguous.
+    pending = list(range(len(result)))
+    while pending:
+        next_round = []
+        for index in pending:
+            messages = threads[index].get("messages", [])
+            kept = result[index]["messages"]
+            if len(kept) == len(messages):
+                continue
+            message = messages[-len(kept) - 1]
+            cost = size(message) + bool(kept)
+            if cost <= remaining:
+                remaining -= cost
+                kept.append(message)
+                next_round.append(index)
+        pending = next_round
+    for original, item in zip(threads, result, strict=False):
+        item["messages"].reverse()
+        item["messages_truncated"] = bool(original.get("messages_truncated")) or (
+            len(item["messages"]) < len(original.get("messages", []))
+        )
+    return result

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -807,6 +807,10 @@ class BlueFerryApp(App[None]):
         )
 
         widgets: list[Static | MessageRow] = []
+        if thread.extra.get("messages_truncated"):
+            widgets.append(Static(
+                "Showing recent messages. Older messages remain in local history."
+            ))
         previous_day = ""
         for message in thread.messages:
             timestamp = format_message_timestamp(message.timestamp)

--- a/src/blueferry/ui/conversations.py
+++ b/src/blueferry/ui/conversations.py
@@ -258,6 +258,10 @@ class ConversationsPage(Gtk.Box):
             "button-clicked", self._open_group_roster_dialog
         )
         right.append(self._group_roster_banner)
+        self._history_banner = Adw.Banner(
+            title=_("Showing recent messages. Older messages remain in local history.")
+        )
+        right.append(self._history_banner)
         right.append(self._stack)
 
         compose = Gtk.Box(
@@ -764,6 +768,7 @@ class ConversationsPage(Gtk.Box):
         dialog.present(self.get_root())
 
     def _update_group_roster_banner(self, thread: Thread | None) -> None:
+        self._history_banner.set_revealed(bool(thread and thread.extra.get("messages_truncated")))
         required = bool(thread and thread.participants_required)
         self._group_roster_button.set_visible(
             bool(thread and thread.group_origin == "named")

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -870,3 +870,48 @@ def test_successful_group_send_is_acknowledged_when_preferences_fail(monkeypatch
     ObexWorker._deliver(result, *pending[0])
     assert replies == ["/transfer/sent"]
     assert len(recorded) == 1
+
+
+def test_starred_thread_survives_recent_event_window(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
+    monkeypatch.setattr(backend_operations, "MAX_CONVERSATION_EVENTS", 3)
+    append_event({
+        "kind": "sms_received", "handle": "favorite", "sender_address": "+15551111111",
+        "body": "keep me", "seen_at": "2026-08-01T00:00:00Z",
+    })
+    store = StarredThreadsStore(tmp_path / "settings.json")
+    operations = _operations(starred_threads=store)
+    key = operations.list_threads(10)[0]["key"]
+    operations.set_thread_starred(key, True)
+    for index in range(4):
+        append_event({
+            "kind": "sms_received", "handle": f"new-{index}",
+            "sender_address": "+15552222222", "body": "new",
+            "seen_at": f"2026-08-02T00:00:0{index}Z",
+        })
+    for instance in [operations, _operations(starred_threads=store)]:
+        favorite = instance.list_threads(10)[0]
+        assert favorite["key"] == key
+        assert favorite["starred"] is True
+        assert favorite["messages"][0]["body"] == "keep me"
+    operations.set_thread_starred(key, False)
+    assert key not in {thread["key"] for thread in operations.list_threads(10)}
+
+
+def test_large_thread_response_fits_wire_limit_without_changing_cached_history():
+    import json
+
+    from blueferry.limits import MAX_DBUS_JSON_BYTES
+
+    operations = _operations()
+    messages = [{"handle": str(i), "body": "😀" * 32768} for i in range(260)]
+    thread = {**_group(), "messages": messages}
+    _stub_group(operations, thread)
+    result = operations.list_threads(1)
+    assert len(json.dumps(result, ensure_ascii=False, separators=(",", ":")).encode()) <= (
+        MAX_DBUS_JSON_BYTES
+    )
+    assert result[0]["messages_truncated"] is True
+    assert result[0]["messages"][-1]["handle"] == "259"
+    assert result[0]["recipients"] == thread["recipients"]
+    assert len(thread["messages"]) == 260

--- a/tests/test_map_events.py
+++ b/tests/test_map_events.py
@@ -108,3 +108,72 @@ def test_failed_body_fetch_does_not_persist_an_unusable_event() -> None:
     listener._fetch_failed("message42", RuntimeError("transfer failed"))
 
     assert received == []
+
+
+def test_phone_read_updates_persist_without_notification_and_survive_fetch_race(
+    monkeypatch, tmp_path,
+):
+    from types import SimpleNamespace
+
+    from blueferry import config, daemon
+    from blueferry.history import append_event, read_events
+
+    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "history.sqlite")
+    append_event({"kind": "sms_received", "handle": "message1", "is_read": False})
+    changed = []
+    service = daemon.Daemon.__new__(daemon.Daemon)
+    service.storage = None
+    service._dbus_service = SimpleNamespace(emit_history_changed=lambda: changed.append(True))
+    received = []
+    listener = map_events.MapEventListener(
+        SimpleNamespace(map=SimpleNamespace(path="/session1")), received.append,
+        submit_obex=lambda *_a, **_k: None, on_read=service._message_read,
+    )
+    listener._running = True
+    for interface, props, path in [
+        ("org.bluez.obex.Message1", {"Read": True}, "/session10/message1"),
+        ("org.bluez.obex.Transfer1", {"Read": True}, "/session1/message1"),
+        ("org.bluez.obex.Message1", {"Read": False}, "/session1/message1"),
+    ]:
+        listener._on_message_properties(interface, props, [], path=path)
+    assert changed == []
+    listener._on_message_properties(
+        "org.bluez.obex.Message1", {"Read": True}, [], path="/session1/message1",
+    )
+    assert read_events()[0]["is_read"] is True
+    assert changed == [True]
+    listener._fetched("message1", "/session1/message1", {}, SimpleNamespace(
+        sender_address="+15551234567", body="hello", status="UNREAD",
+    ))
+    assert received[0].is_read is True
+    listener.stop()
+    listener._on_message_properties(
+        "org.bluez.obex.Message1", {"Read": True}, [], path="/session1/message1",
+    )
+    assert changed == [True]
+
+
+def test_listener_subscribes_to_read_updates_for_its_entire_lifetime(monkeypatch):
+    from types import SimpleNamespace
+
+    subscriptions = []
+    removed = []
+
+    def subscribe(*args, **kwargs):
+        subscriptions.append((args, kwargs))
+        return SimpleNamespace(remove=lambda: removed.append(True))
+
+    bus = SimpleNamespace(get_object=lambda *_a: object(), add_signal_receiver=subscribe)
+    monkeypatch.setattr(map_events, "get_session_bus", lambda: bus)
+    monkeypatch.setattr(map_events.dbus, "Interface", lambda *_a: SimpleNamespace(
+        connect_to_signal=subscribe,
+    ))
+    listener = map_events.MapEventListener(
+        SimpleNamespace(map_path="/map"), lambda _e: None,
+        submit_obex=lambda *_a, **_k: None,
+    )
+    listener.start()
+    assert subscriptions[1][1]["signal_name"] == "PropertiesChanged"
+    assert subscriptions[1][1]["path_keyword"] == "path"
+    listener.stop()
+    assert removed == [True, True]

--- a/tests/test_profile_supervisor.py
+++ b/tests/test_profile_supervisor.py
@@ -303,3 +303,57 @@ def test_loss_during_open_cannot_publish_stale_readiness() -> None:
     # operation before a retry can begin.
     worker.succeed()
     assert sessions.map is None and sessions.pbap is None
+
+
+def test_full_queue_retries_open_without_completing_an_attempt(monkeypatch):
+    completed = []
+    supervisor, sessions, worker, scheduled, *_ = make_supervisor(
+        first_attempt=lambda: completed.append(True),
+    )
+    submit = worker.submit
+    monkeypatch.setattr(worker, "submit", lambda *_a, **_k: (_ for _ in ()).throw(
+        RuntimeError("queue full")
+    ))
+    supervisor.start()
+    assert not supervisor.opening
+    assert not completed
+    monkeypatch.setattr(worker, "submit", submit)
+    scheduled.pop()[1]()
+    worker.succeed()
+    assert supervisor.ready
+    assert sessions.opens == 1
+    assert completed == [True]
+
+
+def test_full_queue_retries_cleanup_before_reopening(monkeypatch):
+    supervisor, sessions, worker, scheduled, *_ = make_supervisor()
+    supervisor.start()
+    worker.succeed()
+    submit = worker.submit
+    monkeypatch.setattr(worker, "submit", lambda *_a, **_k: (_ for _ in ()).throw(
+        RuntimeError("queue full")
+    ))
+    supervisor.session_lost("disconnected")
+    supervisor.open()
+    assert not worker.jobs
+    monkeypatch.setattr(worker, "submit", submit)
+    scheduled.pop()[1]()
+    worker.succeed()
+    assert sessions.remote_closes == [False]
+    assert sessions.opens == 1
+    scheduled.pop()[1]()
+    worker.succeed()
+    assert sessions.opens == 2
+    assert supervisor.ready
+
+
+def test_stop_cancels_rejected_cleanup_retry(monkeypatch):
+    supervisor, _sessions, worker, scheduled, *_ = make_supervisor()
+    monkeypatch.setattr(worker, "submit", lambda *_a, **_k: (_ for _ in ()).throw(
+        RuntimeError("queue full")
+    ))
+    supervisor.reconnect("disconnected")
+    supervisor.stop()
+    scheduled.pop()[1]()
+    assert not scheduled
+    assert not worker.jobs

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -676,3 +676,45 @@ def test_activating_bluetooth_reloads_the_selected_adapter_before_scanning(
     assert calls == ["activate", ("compatibility", "hci1")]
     assert controller.compatibility["adapter"] == "hci1"
     assert loaded == [True]
+
+
+def test_group_send_requires_explicit_approval_and_rejects_changed_roster(monkeypatch):
+    controller = BridgeController(backend=_Backend(), setup=object(), subscribe=False, autostart=False)
+    controller._threads = [{
+        "key": "group:test", "name": "Group", "is_group": True, "reply_ready": True,
+        "recipients": ["+15551111111", "+15552222222"],
+    }]
+    queued = []
+    prompts = []
+    monkeypatch.setattr(controller, "_run", lambda *args, **kwargs: queued.append(args))
+    controller.groupConfirmationRequested.connect(lambda *args: prompts.append(args))
+    controller.sendThread("group:test", "draft", False)
+    assert not queued
+    assert prompts == [("group:test", "draft", "+15551111111\n+15552222222")]
+    controller._threads[0]["recipients"].append("+15553333333")
+    controller.sendThread("group:test", "draft", True)
+    assert not queued
+    assert "group changed" in controller.errorText
+    controller.sendThread("group:test", "draft", False)
+    controller.sendThread("group:test", "draft", True)
+    assert len(queued) == 1
+
+
+def test_draft_completion_is_emitted_only_after_success(monkeypatch):
+    backend = _Backend()
+    controller = BridgeController(backend=backend, setup=object(), subscribe=False, autostart=False)
+    controller._threads = [thread.to_dict() for thread in backend.threads()]
+    queued = []
+    completed = []
+    monkeypatch.setattr(controller, "_run", lambda *args, **kwargs: queued.append(args))
+    monkeypatch.setattr(controller, "refresh", lambda: None)
+    controller.threadSendSucceeded.connect(lambda *args: completed.append(args))
+    controller.messageSendSucceeded.connect(lambda *args: completed.append(args))
+    key = controller._threads[0]["key"]
+    controller.sendThread(key, " draft ", False)
+    controller.sendMessage(" new recipient ", " new draft ")
+    assert completed == []
+    queued[0][1]("sent")
+    assert completed == [(key, " draft ")]
+    queued[1][1]("sent")
+    assert completed[-1] == (" new recipient ", " new draft ")

--- a/tests/test_quickshell_bridge.py
+++ b/tests/test_quickshell_bridge.py
@@ -151,3 +151,41 @@ def test_slow_send_does_not_block_status_requests() -> None:
     workers.submit('{"id":2,"method":"status","args":{}}')
     assert status_called.wait(1)
     release_send.set()
+
+
+def test_stdin_reader_drains_batched_lines_without_another_write():
+    import os
+
+    from blueferry.quickshell_bridge import _read_requests
+
+    read_fd, write_fd = os.pipe()
+    received = []
+    completed = threading.Event()
+
+    def submit(line):
+        received.append(line)
+        if len(received) == 3:
+            completed.set()
+
+    with os.fdopen(read_fd) as stream:
+        reader = threading.Thread(target=_read_requests, args=(stream, submit), daemon=True)
+        reader.start()
+        try:
+            os.write(write_fd, b"one\ntwo\nthree\n")
+            assert completed.wait(2), received
+            assert received == ["one\n", "two\n", "three\n"]
+        finally:
+            os.close(write_fd)
+            reader.join(2)
+        assert not reader.is_alive()
+
+
+def test_stdin_reader_discards_oversized_line_and_recovers(monkeypatch):
+    from blueferry import quickshell_bridge
+
+    monkeypatch.setattr(quickshell_bridge, "MAX_REQUEST_CHARS", 8)
+    received = []
+    quickshell_bridge._read_requests(io.StringIO("x" * 40 + "\nnext\n"), received.append)
+    assert len(received) == 2
+    assert len(received[0]) > 8
+    assert received[1] == "next\n"

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -157,3 +157,23 @@ def test_group_messages_identify_incoming_senders_and_outgoing_author() -> None:
     assert messages[0]["sender"] == "Alice"
     # Clients localize the outgoing label as "You".
     assert messages[1]["sender"] == ""
+
+
+def test_response_budget_shares_space_and_keeps_contiguous_tails():
+    import json
+
+    from blueferry.threads import bound_thread_response
+
+    original = [
+        {"key": str(i), "messages": [{"body": "x" * 100, "handle": str(n)} for n in range(10)]}
+        for i in range(3)
+    ]
+    result = bound_thread_response(original, max_bytes=1200)
+    assert len(json.dumps(result, ensure_ascii=False, separators=(",", ":")).encode()) <= 1200
+    assert len(result) == 3
+    for thread in result:
+        count = len(thread["messages"])
+        assert 0 < count < 10
+        assert [m["handle"] for m in thread["messages"]] == [str(n) for n in range(10-count, 10)]
+        assert thread["messages_truncated"] is True
+    assert all(len(thread["messages"]) == 10 for thread in original)


### PR DESCRIPTION
Fix seven failures found in the codebase audit:

- Qt requires explicit approval of the displayed group roster and rejects stale approvals. Reply and new-message drafts are cleared only after successful sends.
- The Quickshell stdin reader drains batched requests without waiting for another write and keeps partial input off the GLib event loop.
- Large conversation snapshots retain recent message tails within the 8 MiB response budget. All four clients show when history is truncated; stored messages and recipient metadata remain intact.
- Backend-owned MAP read watches persist phone read updates independently of notification settings or popup expiry, including updates racing body retrieval.
- Starred conversations remain visible beyond the recent 2,000-event window.
- Full OBEX queues retry opens and session cleanup without wedging lifecycle flags or reopening before cleanup.

Validation: full isolated D-Bus suite passed (893 tests), followed by an additional passing response-budget fairness regression. Ruff, mypy, Bandit, qmllint, and diff checks pass. Bluetooth hardware behavior was not exercised.

The starred-history projection scans retained history when stars exist. Large threads still use bounded display tails; this change does not add message pagination.
