### PR TITLE
Make preference reads predictable and extract Qt message components

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,6 +69,8 @@ separate short-lived helper protocol because it precedes daemon availability
 and must exchange confirmation prompts with the QML client.
 All Python transports share `client_wire` for response-shape validation and
 model conversion; synchronous and toolkit-specific scheduling remain separate.
+Qt message composition and group confirmation live in standalone QML components
+with an explicit bridge dependency; the window handles navigation.
 `ListThreads` includes retained starred conversations even when their last event
 falls outside the ordinary 2,000-event window. The cached projection scans retained
 history when stars exist, preserving older group correlation evidence. Responses
@@ -202,8 +204,10 @@ managers; distro systemd hooks reload changed user-unit metadata.
 - Starred thread keys and confirmed group rosters are also sensitive: keys
   can contain contact addresses. Each complete collection in `settings.json`
   is encrypted with its own purpose string under the history storage policy.
-  Legacy plaintext collections are encrypted on first access, or scrubbed when
-  the wallet is locked or retention is disabled. Settings have a separate
+  Legacy plaintext collections are encrypted during explicit daemon storage
+  initialization, or scrubbed when the wallet is locked or retention is disabled.
+  Preference reads never rewrite settings; a thread snapshot reads and decrypts
+  the confirmed-roster collection at most once. Settings have a separate
   4 MiB bound for the two 200-entry collections and encryption framing;
   `local.env` retains its 64 KiB bound.
 - Passive daemon startup loads an existing key only from an already unlocked

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import re
 import sqlite3
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol
@@ -126,6 +126,8 @@ class StarredThreads(Protocol):
 
 
 class ConfirmedGroups(Protocol):
+    def matching_rosters(self, rosters: Mapping[str, str]) -> set[str]: ...
+
     def matches(self, thread_key: str, token: str) -> bool: ...
 
     def remember(self, thread_key: str, token: str) -> None: ...
@@ -381,19 +383,24 @@ class BackendOperations:
         if store is not None:
             store.clear()
 
-    def _group_confirmed(self, thread: dict) -> bool:
-        if not thread.get("is_group"):
-            return False
-        token = group_confirmation_token(
-            thread.get("recipients") or [],
-            thread.get("roster_warning_id"),
-        )
-        return self._group_roster_confirmed(str(thread.get("key") or ""), token)
-
     def _present_threads(self, threads: Sequence[dict]) -> list[dict]:
         presented = sort_threads(threads, starred_keys=self._starred_keys())
+        rosters = {
+            str(item["key"]): group_confirmation_token(
+                item.get("recipients") or [], item.get("roster_warning_id"),
+            )
+            for item in presented if item.get("is_group")
+        }
+        confirmed = {
+            key for key, token in rosters.items()
+            if self._confirmed_groups.get(key) == token
+        }
+        pending = {key: token for key, token in rosters.items() if key not in confirmed}
+        store = self.dependencies.confirmed_groups
+        if pending and store is not None:
+            confirmed.update(store.matching_rosters(pending))
         for item in presented:
-            item["group_confirmed"] = self._group_confirmed(item)
+            item["group_confirmed"] = item["key"] in confirmed
         return presented
 
     def set_thread_starred(self, thread_key: str, starred: bool) -> bool:

--- a/src/blueferry/confirmed_groups.py
+++ b/src/blueferry/confirmed_groups.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 from blueferry import config
@@ -62,12 +62,19 @@ class ConfirmedGroupsStore:
         return selected
 
     def migrate(self) -> None:
-        self._preference.read()
+        self._preference.migrate()
 
     def matches(self, thread_key: str, token: str) -> bool:
-        key = _normalized_key(thread_key)
-        digest = _digest(token)
-        return bool(key and digest and self._mapping().get(key) == digest)
+        return thread_key in self.matching_rosters({thread_key: token})
+
+    def matching_rosters(self, rosters: Mapping[str, str]) -> set[str]:
+        """Match a presentation snapshot with one settings read/decryption."""
+        current = self._mapping()
+        return {
+            key for key, token in rosters.items()
+            if _normalized_key(key) and token
+            and current.get(_normalized_key(key)) == _digest(token)
+        }
 
     def remember(self, thread_key: str, token: str) -> None:
         key = _normalized_key(thread_key)

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -254,7 +254,7 @@ class Daemon:
     def _initialize_storage(self) -> None:
         status = self.storage.refresh(allow_prompt=False)
         # Upgrade/scrub legacy preferences even if the wallet is locked.
-        self.starred_threads.keys()
+        self.starred_threads.migrate()
         self.confirmed_groups.migrate()
         if status.policy == NO_STORAGE:
             clear_events()

--- a/src/blueferry/private_preferences.py
+++ b/src/blueferry/private_preferences.py
@@ -30,16 +30,9 @@ class PrivatePreference:
         if storage is None or value is None:
             return value
         if storage.status.policy == NO_STORAGE:
-            self.clear()
             return None
         if not isinstance(value, str):
-            # Upgrade legacy plaintext records while the wallet is available.
-            # If it is locked, scrub them rather than retain exposed identities.
-            if storage.status.can_write:
-                self.write(value)
-                return value
-            self.clear()
-            return None
+            return value if storage.status.can_read else None
         if not storage.status.can_read:
             return None
         try:
@@ -47,6 +40,20 @@ class PrivatePreference:
         except (CorruptStorageError, ValueError):
             storage.fail_closed("Saved conversation preferences could not be authenticated")
             return None
+
+    def migrate(self) -> None:
+        """Upgrade or scrub legacy records during explicit storage initialization."""
+        value = self._settings.read().get(self._key)
+        storage = self._storage
+        if storage is None or value is None:
+            return
+        if storage.status.policy == NO_STORAGE:
+            self.clear()
+        elif not isinstance(value, str):
+            if storage.status.can_write:
+                self.write(value)
+            else:
+                self.clear()
 
     def write(self, value: object) -> None:
         if self._storage is not None:

--- a/src/blueferry/qt/qml/ExpandingMessageComposer.qml
+++ b/src/blueferry/qt/qml/ExpandingMessageComposer.qml
@@ -1,0 +1,56 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls as Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+Controls.ScrollView {
+    id: messageComposer
+
+    property alias text: editor.text
+    property alias placeholderText: editor.placeholderText
+    signal accepted()
+
+    Layout.fillWidth: true
+    Layout.minimumWidth: 0
+    Layout.minimumHeight: Kirigami.Units.gridUnit * 2.5
+    Layout.preferredHeight: Math.min(
+        Math.max(
+            editor.contentHeight + editor.topPadding + editor.bottomPadding + 2,
+            Layout.minimumHeight
+        ),
+        Layout.maximumHeight
+    )
+    Layout.maximumHeight: Kirigami.Units.gridUnit * 8
+    clip: true
+    Controls.ScrollBar.horizontal.policy: Controls.ScrollBar.AlwaysOff
+    Controls.ScrollBar.vertical.policy: Controls.ScrollBar.AsNeeded
+
+    function clear() {
+        editor.clear()
+    }
+
+    function forceActiveFocus() {
+        editor.forceActiveFocus()
+    }
+
+    function submit(event) {
+        if ((event.modifiers & Qt.ShiftModifier) !== 0) {
+            event.accepted = false
+            return
+        }
+        accepted()
+        event.accepted = true
+    }
+
+    Controls.TextArea {
+        id: editor
+        width: messageComposer.availableWidth
+        wrapMode: TextEdit.Wrap
+        selectByMouse: true
+        Accessible.name: messageComposer.Accessible.name
+        Keys.onReturnPressed: event => messageComposer.submit(event)
+        Keys.onEnterPressed: event => messageComposer.submit(event)
+    }
+}

--- a/src/blueferry/qt/qml/GroupConfirmationDialog.qml
+++ b/src/blueferry/qt/qml/GroupConfirmationDialog.qml
@@ -1,0 +1,30 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import org.kde.kirigami as Kirigami
+
+Kirigami.PromptDialog {
+    id: dialog
+    required property var bridge
+    property string threadKey: ""
+    property string draft: ""
+    title: qsTr("Confirm Group Recipients")
+    standardButtons: Kirigami.Dialog.Cancel
+    customFooterActions: [Kirigami.Action {
+        text: qsTr("Send to These Recipients")
+        onTriggered: {
+            dialog.bridge.sendThread(dialog.threadKey, dialog.draft, true)
+            dialog.close()
+        }
+    }]
+    Connections {
+        target: dialog.bridge
+        function onGroupConfirmationRequested(key: string, body: string, roster: string): void {
+            dialog.threadKey = key
+            dialog.draft = body
+            dialog.subtitle = "<span>" + roster.replace(/&/g, "&amp;").replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;").replace(/\n/g, "<br>") + "</span>"
+            dialog.open()
+        }
+    }
+}

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -18,56 +18,6 @@ Kirigami.ApplicationWindow {
     property string pendingMessageHandle: ""
     property var warnedRosterChanges: ({})
 
-    component ExpandingMessageComposer: Controls.ScrollView {
-        id: messageComposer
-
-        property alias text: editor.text
-        property alias placeholderText: editor.placeholderText
-        signal accepted()
-
-        Layout.fillWidth: true
-        Layout.minimumWidth: 0
-        Layout.minimumHeight: Kirigami.Units.gridUnit * 2.5
-        Layout.preferredHeight: Math.min(
-            Math.max(
-                editor.contentHeight + editor.topPadding + editor.bottomPadding + 2,
-                Layout.minimumHeight
-            ),
-            Layout.maximumHeight
-        )
-        Layout.maximumHeight: Kirigami.Units.gridUnit * 8
-        clip: true
-        Controls.ScrollBar.horizontal.policy: Controls.ScrollBar.AlwaysOff
-        Controls.ScrollBar.vertical.policy: Controls.ScrollBar.AsNeeded
-
-        function clear() {
-            editor.clear()
-        }
-
-        function forceActiveFocus() {
-            editor.forceActiveFocus()
-        }
-
-        function submit(event) {
-            if ((event.modifiers & Qt.ShiftModifier) !== 0) {
-                event.accepted = false
-                return
-            }
-            accepted()
-            event.accepted = true
-        }
-
-        Controls.TextArea {
-            id: editor
-            width: messageComposer.availableWidth
-            wrapMode: TextEdit.Wrap
-            selectByMouse: true
-            Accessible.name: messageComposer.Accessible.name
-            Keys.onReturnPressed: event => messageComposer.submit(event)
-            Keys.onEnterPressed: event => messageComposer.submit(event)
-        }
-    }
-
     visible: true
     width: 980
     height: 680
@@ -606,125 +556,14 @@ Kirigami.ApplicationWindow {
         standardButtons: Kirigami.Dialog.Close
     }
 
-    Kirigami.PromptDialog {
+    GroupConfirmationDialog {
         id: confirmGroupDialog
-        property string threadKey: ""
-        property string draft: ""
-        title: qsTr("Confirm Group Recipients")
-        standardButtons: Kirigami.Dialog.Cancel
-        customFooterActions: [Kirigami.Action {
-            text: qsTr("Send to These Recipients")
-            onTriggered: {
-                root.bridge.sendThread(confirmGroupDialog.threadKey, confirmGroupDialog.draft, true)
-                confirmGroupDialog.close()
-            }
-        }]
-        Connections {
-            target: root.bridge
-            function onGroupConfirmationRequested(key: string, body: string, roster: string): void {
-                confirmGroupDialog.threadKey = key
-                confirmGroupDialog.draft = body
-                confirmGroupDialog.subtitle = root.escapedRichText(root.htmlEscape(roster).replace(/\n/g, "<br>"))
-                confirmGroupDialog.open()
-            }
-        }
+        bridge: root.bridge
     }
 
-    Kirigami.Dialog {
+    NewMessageDialog {
         id: newMessageDialog
-        title: qsTr("New Message")
-        preferredWidth: Kirigami.Units.gridUnit * 24
-        standardButtons: Kirigami.Dialog.Cancel
-        customFooterActions: [Kirigami.Action {
-            id: newMessageSendAction
-            text: qsTr("Send")
-            icon.name: "document-send"
-            enabled: newRecipient.text.trim() !== ""
-                && newMessageBody.text.trim() !== "" && !root.bridge.busy
-            onTriggered: {
-                root.bridge.sendMessage(newRecipient.text, newMessageBody.text)
-            }
-        }]
-
-        Connections {
-            target: root.bridge
-            function onMessageSendSucceeded(recipient: string, body: string): void {
-                if (newRecipient.text === recipient && newMessageBody.text === body) {
-                    newRecipient.clear()
-                    newMessageBody.clear()
-                    newMessageDialog.close()
-                }
-            }
-        }
-
-        onOpened: {
-            root.bridge.findContacts("")
-            newRecipient.forceActiveFocus()
-        }
-
-        Timer {
-            id: contactSearchTimer
-            interval: 180
-            onTriggered: root.bridge.findContacts(newRecipient.text)
-        }
-
-        ColumnLayout {
-            spacing: Kirigami.Units.smallSpacing
-
-            Controls.Label {
-                text: qsTr("To")
-                font.bold: true
-            }
-            Controls.TextField {
-                id: newRecipient
-                Layout.fillWidth: true
-                placeholderText: qsTr("Contact, phone number, or email address")
-                Accessible.name: qsTr("Recipient")
-                onTextEdited: contactSearchTimer.restart()
-            }
-            ListView {
-                id: contactResults
-                Layout.fillWidth: true
-                Layout.preferredHeight: count > 0
-                    ? Math.min(contentHeight, Kirigami.Units.gridUnit * 10) : 0
-                visible: count > 0
-                clip: true
-                model: root.bridge.contactResults
-
-                delegate: Controls.ItemDelegate {
-                    id: contactDelegate
-                    required property var modelData
-                    width: contactResults.width
-                    text: modelData.name + "\n" + (
-                        modelData.address.indexOf("@") >= 0
-                            ? modelData.address : "+" + modelData.address
-                    )
-                    contentItem: Controls.Label {
-                        text: contactDelegate.text
-                        textFormat: Text.PlainText
-                        elide: Text.ElideRight
-                    }
-                    onClicked: {
-                        newRecipient.text = modelData.address
-                        root.bridge.findContacts("")
-                        newMessageBody.forceActiveFocus()
-                    }
-                }
-            }
-            Controls.Label {
-                text: qsTr("Message")
-                font.bold: true
-            }
-            ExpandingMessageComposer {
-                id: newMessageBody
-                placeholderText: qsTr("Write a Message")
-                Accessible.name: qsTr("Message Text")
-                onAccepted: {
-                    if (newMessageSendAction.enabled)
-                        newMessageSendAction.trigger()
-                }
-            }
-        }
+        bridge: root.bridge
     }
 
     Kirigami.Page {

--- a/src/blueferry/qt/qml/NewMessageDialog.qml
+++ b/src/blueferry/qt/qml/NewMessageDialog.qml
@@ -1,0 +1,106 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls as Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+Kirigami.Dialog {
+    id: dialog
+    required property var bridge
+    property alias recipient: newRecipient.text
+    property alias body: newMessageBody.text
+    title: qsTr("New Message")
+    preferredWidth: Kirigami.Units.gridUnit * 24
+    standardButtons: Kirigami.Dialog.Cancel
+    customFooterActions: [Kirigami.Action {
+        id: newMessageSendAction
+        text: qsTr("Send")
+        icon.name: "document-send"
+        enabled: newRecipient.text.trim() !== ""
+            && newMessageBody.text.trim() !== "" && !dialog.bridge.busy
+        onTriggered: {
+            dialog.bridge.sendMessage(newRecipient.text, newMessageBody.text)
+        }
+    }]
+
+    Connections {
+        target: dialog.bridge
+        function onMessageSendSucceeded(recipient: string, body: string): void {
+            if (newRecipient.text === recipient && newMessageBody.text === body) {
+                newRecipient.clear()
+                newMessageBody.clear()
+                dialog.close()
+            }
+        }
+    }
+
+    onOpened: {
+        dialog.bridge.findContacts("")
+        newRecipient.forceActiveFocus()
+    }
+
+    Timer {
+        id: contactSearchTimer
+        interval: 180
+        onTriggered: dialog.bridge.findContacts(newRecipient.text)
+    }
+
+    ColumnLayout {
+        spacing: Kirigami.Units.smallSpacing
+
+        Controls.Label {
+            text: qsTr("To")
+            font.bold: true
+        }
+        Controls.TextField {
+            id: newRecipient
+            Layout.fillWidth: true
+            placeholderText: qsTr("Contact, phone number, or email address")
+            Accessible.name: qsTr("Recipient")
+            onTextEdited: contactSearchTimer.restart()
+        }
+        ListView {
+            id: contactResults
+            Layout.fillWidth: true
+            Layout.preferredHeight: count > 0
+                ? Math.min(contentHeight, Kirigami.Units.gridUnit * 10) : 0
+            visible: count > 0
+            clip: true
+            model: dialog.bridge.contactResults
+
+            delegate: Controls.ItemDelegate {
+                id: contactDelegate
+                required property var modelData
+                width: contactResults.width
+                text: modelData.name + "\n" + (
+                    modelData.address.indexOf("@") >= 0
+                        ? modelData.address : "+" + modelData.address
+                )
+                contentItem: Controls.Label {
+                    text: contactDelegate.text
+                    textFormat: Text.PlainText
+                    elide: Text.ElideRight
+                }
+                onClicked: {
+                    newRecipient.text = modelData.address
+                    dialog.bridge.findContacts("")
+                    newMessageBody.forceActiveFocus()
+                }
+            }
+        }
+        Controls.Label {
+            text: qsTr("Message")
+            font.bold: true
+        }
+        ExpandingMessageComposer {
+            id: newMessageBody
+            placeholderText: qsTr("Write a Message")
+            Accessible.name: qsTr("Message Text")
+            onAccepted: {
+                if (newMessageSendAction.enabled)
+                    newMessageSendAction.trigger()
+            }
+        }
+    }
+}

--- a/src/blueferry/starred_threads.py
+++ b/src/blueferry/starred_threads.py
@@ -29,6 +29,9 @@ class StarredThreadsStore:
             path or config.SETTINGS_JSON, _SETTINGS_KEY, storage,
         )
 
+    def migrate(self) -> None:
+        self._preference.migrate()
+
     def keys(self) -> list[str]:
         raw = self._preference.read()
         if not isinstance(raw, list):

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -915,3 +915,22 @@ def test_large_thread_response_fits_wire_limit_without_changing_cached_history()
     assert result[0]["messages"][-1]["handle"] == "259"
     assert result[0]["recipients"] == thread["recipients"]
     assert len(thread["messages"]) == 260
+
+
+def test_thread_snapshot_reads_confirmed_rosters_once(tmp_path, monkeypatch):
+    store = ConfirmedGroupsStore(tmp_path / "settings.json")
+    threads = [{**_group(), "key": f"group:{i}"} for i in range(20)]
+    token = group_confirmation_token(threads[0]["recipients"], None)
+    for thread in threads:
+        store.remember(thread["key"], token)
+    threads[-1]["recipients"] = ["+15553333333", "+15554444444"]
+    operations = _operations(confirmed_groups=store)
+    operations._conversations.threads = lambda: threads
+    reads = []
+    read = store._preference.read
+    monkeypatch.setattr(store._preference, "read", lambda: reads.append(True) or read())
+    result = operations.list_threads(100)
+    assert reads == [True]
+    by_key = {thread["key"]: thread["group_confirmed"] for thread in result}
+    assert all(by_key[f"group:{i}"] for i in range(19))
+    assert by_key["group:19"] is False

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -25,6 +25,7 @@ def _bare_daemon():
     )
     instance.starred_threads = SimpleNamespace(
         keys=lambda: [],
+        migrate=lambda: None,
         set_starred=lambda *_args, **_kwargs: False,
         discard=lambda *_args, **_kwargs: None,
         clear=lambda: None,
@@ -32,6 +33,7 @@ def _bare_daemon():
     instance.confirmed_groups = SimpleNamespace(
         migrate=lambda: None,
         matches=lambda *_args, **_kwargs: False,
+        matching_rosters=lambda _rosters: set(),
         remember=lambda *_args, **_kwargs: None,
         forget=lambda *_args, **_kwargs: None,
         clear=lambda: None,
@@ -149,6 +151,8 @@ def test_no_storage_policy_reasserts_empty_local_data(monkeypatch):
         refresh=lambda **_kwargs: status,
     )
     cleared = []
+    instance.starred_threads.migrate = lambda: cleared.append("stars")
+    instance.confirmed_groups.migrate = lambda: cleared.append("groups")
     monkeypatch.setattr(
         daemon_mod, "clear_events", lambda: cleared.append("events")
     )
@@ -158,7 +162,7 @@ def test_no_storage_policy_reasserts_empty_local_data(monkeypatch):
 
     instance._initialize_storage()
 
-    assert cleared == ["events", "contacts"]
+    assert cleared == ["stars", "groups", "events", "contacts"]
 
 
 def test_successful_empty_phonebook_verifies_contact_permission():

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -523,7 +523,7 @@ def test_all_gui_clients_offer_contacts_aware_new_messages() -> None:
 
 def test_all_clients_expand_and_scroll_long_message_drafts() -> None:
     gtk = (ROOT / "src/blueferry/ui/conversations.py").read_text()
-    qt = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
+    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
     quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
     tui_styles = (ROOT / "src/blueferry/tui.tcss").read_text()
 
@@ -748,13 +748,13 @@ def test_quickshell_package_ships_its_quattro_theme_adapter() -> None:
 
 
 def test_remote_qml_text_is_rendered_as_plain_text() -> None:
-    qt_qml = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
+    qt_qml = _qml_bundle(ROOT / "src/blueferry/qt/qml")
     quickshell = (ROOT / "data/quickshell/shell.qml").read_text()
 
     assert (
         "text: contactDelegate.text\n"
-        "                        textFormat: Text.PlainText"
-    ) in qt_qml
+        "textFormat: Text.PlainText"
+    ) in "\n".join(line.strip() for line in qt_qml.splitlines())
     assert "text: deviceCombo.displayText" not in qt_qml
     assert (
         "text: deviceOption.modelData.display_name\n"

--- a/tests/test_private_preferences.py
+++ b/tests/test_private_preferences.py
@@ -48,6 +48,7 @@ def test_upgrade_encrypts_legacy_keys_without_losing_preferences(tmp_path):
     ConfirmedGroupsStore(path).remember(key, "roster")
     _, stars, groups = _stores(path)
     assert stars.keys() == [key]
+    stars.migrate()
     groups.migrate()
     assert groups.matches(key, "roster")
     assert "15551111111" not in path.read_text()
@@ -76,6 +77,7 @@ def test_locked_upgrade_scrubs_legacy_plaintext(tmp_path):
     ConfirmedGroupsStore(path).remember("group:addresses:phone:15551111111", "roster")
     _, stars, groups = _stores(path, initialize=False)
     assert stars.keys() == []
+    stars.migrate()
     groups.migrate()
     assert "15551111111" not in path.read_text()
 
@@ -135,3 +137,25 @@ def test_tampering_fails_closed(tmp_path):
     SettingsStore(path).update(starred_thread_keys=payload["confirmed_group_rosters"])
     assert stars.keys() == []
     assert storage.status.state == "error"
+
+
+@pytest.mark.parametrize("policy", ["encrypted", "none"])
+@pytest.mark.parametrize("initialize", [True, False])
+def test_preference_reads_do_not_migrate_or_scrub_settings(tmp_path, policy, initialize):
+    path = tmp_path / "settings.json"
+    SettingsStore(path).update(local_data=policy)
+    StarredThreadsStore(path).set_starred("private-identity", True)
+    ConfirmedGroupsStore(path).remember("private-identity", "roster")
+    _, stars, groups = _stores(path, initialize=initialize)
+    saved = path.read_bytes()
+    stars.keys()
+    groups.matches("private-identity", "roster")
+    groups.matching_rosters({"private-identity": "roster"})
+    assert path.read_bytes() == saved
+    stars.migrate()
+    groups.migrate()
+    assert "private-identity" not in path.read_text()
+    migrated = path.read_bytes()
+    stars.migrate()
+    groups.migrate()
+    assert path.read_bytes() == migrated

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -432,3 +432,51 @@ def test_read_sync_requires_visible_active_conversation(qml_engine, relative_pat
     result = qml_engine.evaluate(script)
     assert not result.isError(), result.toString()
     assert result.toString() == '["one"]'
+
+
+class _MessageDialogBridge(QObject):
+    from PySide6.QtCore import Signal
+
+    messageSendSucceeded = Signal(str, str)
+    groupConfirmationRequested = Signal(str, str, str)
+
+    @Property(bool, constant=True)
+    def busy(self):
+        return False
+
+    @Property("QVariantList", constant=True)
+    def contactResults(self):
+        return []
+
+    @Slot(str)
+    def findContacts(self, _query):
+        pass
+
+
+def test_new_message_dialog_retains_edited_draft_after_earlier_send(qml_engine):
+    bridge = _MessageDialogBridge()
+    component = _component(qml_engine, "src/blueferry/qt/qml/NewMessageDialog.qml")
+    dialog = component.createWithInitialProperties({
+        "bridge": bridge, "recipient": "alice@example.com", "body": "original draft",
+    })
+    assert dialog is not None
+    dialog.setProperty("body", "new draft")
+    bridge.messageSendSucceeded.emit("alice@example.com", "original draft")
+    assert dialog.property("body") == "new draft"
+    assert dialog.property("recipient") == "alice@example.com"
+    bridge.messageSendSucceeded.emit("alice@example.com", "new draft")
+    assert dialog.property("body") == ""
+    assert dialog.property("recipient") == ""
+    dialog.deleteLater()
+
+
+def test_group_confirmation_component_shows_literal_recipients(qml_engine):
+    bridge = _MessageDialogBridge()
+    component = _component(qml_engine, "src/blueferry/qt/qml/GroupConfirmationDialog.qml")
+    dialog = component.createWithInitialProperties({"bridge": bridge})
+    assert dialog is not None
+    bridge.groupConfirmationRequested.emit("group:test", "draft", "<alice>\nbob@example.com")
+    assert dialog.property("threadKey") == "group:test"
+    assert dialog.property("draft") == "draft"
+    assert dialog.property("subtitle") == "<span>&lt;alice&gt;<br>bob@example.com</span>"
+    dialog.deleteLater()


### PR DESCRIPTION
Preference reads previously rewrote settings to migrate or scrub legacy data, and presenting multiple groups repeatedly read and decrypted the entire confirmed-roster collection. Migration now runs explicitly during daemon storage initialization, while each thread snapshot loads saved confirmations at most once.

The Qt new-message dialog, group-confirmation dialog, and expanding composer are standalone components with explicit dependencies. This removes 161 net lines from the main window and makes draft completion and recipient rendering directly testable.

- Preserve encrypted, plaintext, locked-wallet, and no-retention migration behavior, including idempotence.
- Share single-roster and batched matching through the same normalization and digest checks.
- Add runtime QML coverage for preserving edited drafts and escaping recipient text; update existing component-location assumptions in tests.

Validation: 901 tests passed in the isolated D-Bus suite, with final affected preference/backend tests also passing. Ruff, mypy, Bandit, qmllint, and diff checks pass.

Stacked on #121; merge the bug fixes first. This is the first maintainability pass. Broader decomposition of the remaining frontend screens and further consolidation of client conversation state remain follow-up work.
