### PR TITLE
Consolidate shared conversation behavior across clients

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,6 +71,18 @@ All Python transports share `client_wire` for response-shape validation and
 model conversion; synchronous and toolkit-specific scheduling remain separate.
 Qt message composition and group confirmation live in standalone QML components
 with an explicit bridge dependency; the window handles navigation.
+GTK and Qt contact searches use `ConversationState` request sequences, and Qt
+retains that state across sends. Qt and TUI share the snapshot loader, which
+keeps failed reads distinct from empty history. Quickshell's transport coalesces
+contact queries and delivers only the latest request's result or failure.
+
+`ConversationLogic.qml` holds the Qt/Quickshell thread lookup, unread, roster
+warning, and participant parsing helpers. The Quickshell source wrapper imports
+the canonical Qt QML file for development; its package installs that file directly
+so it has no runtime dependency on the Qt client. Python/QML behavior tests cover
+the shared contracts, including group signatures and participant line parsing.
+GTK and TUI use the same Python participant parser in `recipients`.
+
 `ListThreads` includes retained starred conversations even when their last event
 falls outside the ordinary 2,000-event window. The cached projection scans retained
 history when stars exist, preserving older group correlation evidence. Responses

--- a/data/quickshell/BackendBridge.qml
+++ b/data/quickshell/BackendBridge.qml
@@ -10,6 +10,8 @@ Item {
   property int nextRequestId: 1
   property bool ready: false
   property var queuedRequests: []
+  property var latestRequests: ({})
+  property var latestMethods: ({})
 
   signal response(string method, int requestId, var result)
   signal failure(string method, int requestId, string message)
@@ -30,18 +32,51 @@ Item {
     return requestId
   }
 
+  // Coalesce repeated reads and suppress superseded results, even when a
+  // query changes A → B → A while the first A is still in flight.
+  function requestLatest(method, args) {
+    latestMethods[method] = true
+    const active = latestRequests[method]
+    if (active) {
+      active.queued = args
+      active.cancelled = false
+    } else {
+      latestRequests[method] = {id: request(method, args), cancelled: false}
+    }
+  }
+
+  function cancelLatest(method) {
+    const active = latestRequests[method]
+    if (active) {
+      active.queued = undefined
+      active.cancelled = true
+    }
+  }
+
   function handleLine(line) {
     try {
       var payload = JSON.parse(line)
+      const active = latestRequests[payload.method]
+      if (latestMethods[payload.method] && (!active || active.id !== payload.id)) return
+      if (active && active.id === payload.id) {
+        delete latestRequests[payload.method]
+        if (active.queued !== undefined) {
+          requestLatest(payload.method, active.queued)
+          return
+        }
+        if (active.cancelled) return
+      }
       if (typeof payload.event === "string") {
         eventReceived(payload.event, payload.data)
       } else if (payload.ok === true) {
         response(payload.method || "", payload.id || 0, payload.result)
       } else {
+        if (!payload.method) latestRequests = ({})
         failure(payload.method || "", payload.id || 0,
                 payload.error || "BlueFerry request failed")
       }
     } catch (error) {
+      latestRequests = ({})
       failure("", 0, "BlueFerry bridge returned invalid data")
     }
   }
@@ -64,6 +99,7 @@ Item {
     onExited: function(code) {
       bridge.ready = false
       bridge.queuedRequests = []
+      bridge.latestRequests = ({})
       bridge.failure("", 0, code === 0
         ? "BlueFerry bridge stopped"
         : "BlueFerry bridge is unavailable")

--- a/data/quickshell/ConversationLogic.qml
+++ b/data/quickshell/ConversationLogic.qml
@@ -1,0 +1,4 @@
+// Development wrapper. Packaging installs the shared implementation directly.
+import "../../src/blueferry/qt/qml" as Shared
+
+Shared.ConversationLogic {}

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -10,15 +10,12 @@ ShellRoot {
   id: root
   property var threads: []
   property var contactResults: []
-  property string contactQuery: ""
-  property string contactsRequestedQuery: ""
   property string selectedThreadKey: ""
   property string pendingThreadKey: ""
   property string pendingMessageHandle: ""
   property var confirmedGroupSignatures: ({})
   property var groupParticipantsThread: null
   property var rosterChangedThread: null
-  property var warnedRosterChanges: ({})
   property string errorText: ""
   property bool phoneSettingsVisible: false
   property var pairingDevices: []
@@ -69,6 +66,8 @@ ShellRoot {
   property bool storagePolicyBusy: false
   property bool storageUnlockBusy: false
 
+  ConversationLogic { id: conversationLogic }
+
   Theme { id: theme }
   OnboardingState {
     id: onboarding
@@ -98,19 +97,11 @@ ShellRoot {
   }
 
   function searchContacts(query) {
-    contactQuery = query.trim()
-    if (contactQuery === "") {
-      contactResults = []
-      return
-    }
-    if (!contactsBusy) startContactSearch()
-  }
-
-  function startContactSearch() {
-    if (contactQuery === "" || contactsBusy) return
-    contactsRequestedQuery = contactQuery
-    contactsBusy = true
-    backendBridge.request("contacts", {query: contactsRequestedQuery})
+    contactResults = []
+    const selected = query.trim()
+    contactsBusy = selected !== ""
+    if (contactsBusy) backendBridge.requestLatest("contacts", {query: selected})
+    else backendBridge.cancelLatest("contacts")
   }
 
   function maybeUnlockStorage() {
@@ -123,10 +114,7 @@ ShellRoot {
   }
 
   function threadByKey(key) {
-    for (var index = 0; index < threads.length; ++index) {
-      if (threads[index].key === key) return threads[index]
-    }
-    return null
+    return conversationLogic.threadByKey(threads, key)
   }
 
   function selectedThread() {
@@ -142,14 +130,7 @@ ShellRoot {
   }
 
   function threadIsUnread(thread) {
-    if (!thread) return false
-    if (thread.unread === true) return true
-    if (thread.unread === false) return false
-    var messages = thread.messages || []
-    for (var index = 0; index < messages.length; ++index) {
-      if (!messages[index].outgoing && messages[index].read === false) return true
-    }
-    return false
+    return conversationLogic.threadIsUnread(thread)
   }
 
   function ancsLimited() {
@@ -185,18 +166,12 @@ ShellRoot {
   onPhoneSettingsVisibleChanged: root.markSelectedThreadRead()
 
   function selectMessage(handle) {
-    for (var threadIndex = 0; threadIndex < threads.length; ++threadIndex) {
-      var thread = threads[threadIndex]
-      for (var messageIndex = 0; messageIndex < thread.messages.length; ++messageIndex) {
-        if (thread.messages[messageIndex].handle === handle) {
-          selectedThreadKey = thread.key
-          pendingMessageHandle = ""
-          phoneSettingsVisible = false
-          return true
-        }
-      }
-    }
-    return false
+    const thread = conversationLogic.threadForMessage(threads, handle)
+    if (!thread) return false
+    selectedThreadKey = thread.key
+    pendingMessageHandle = ""
+    phoneSettingsVisible = false
+    return true
   }
 
   function presentWindow() {
@@ -218,15 +193,7 @@ ShellRoot {
   }
 
   function groupSignature(thread) {
-    if (!thread || !thread.is_group) return ""
-    var unique = []
-    var recipients = thread.recipients || []
-    for (var index = 0; index < recipients.length; ++index) {
-      var address = String(recipients[index] || "")
-      if (address !== "" && unique.indexOf(address) < 0) unique.push(address)
-    }
-    unique.sort()
-    return [String(thread.roster_warning_id || "")].concat(unique).join("\n")
+    return conversationLogic.groupSignature(thread)
   }
 
   function groupIsConfirmed(thread) {
@@ -251,27 +218,14 @@ ShellRoot {
   }
 
   function participantLines(value) {
-    var result = []
-    var lines = value.split(/\r?\n/)
-    for (var index = 0; index < lines.length; ++index) {
-      var address = lines[index].trim()
-      if (address !== "" && result.indexOf(address) < 0) result.push(address)
-    }
-    return result
+    return conversationLogic.participantLines(value)
   }
 
   function warnAboutRosterChanges() {
-    for (var index = 0; index < threads.length; ++index) {
-      var thread = threads[index]
-      if (!thread.roster_changed) continue
-      var warningId = thread.roster_warning_id
-        || thread.key + ":" + (thread.unexpected_sender || "unknown")
-      if (warnedRosterChanges[warningId] === true) continue
-      warnedRosterChanges[warningId] = true
-      rosterChangedThread = thread
-      rosterChangedPopup.open()
-      return
-    }
+    const thread = conversationLogic.nextRosterWarning(threads)
+    if (!thread) return
+    rosterChangedThread = thread
+    rosterChangedPopup.open()
   }
 
   function loadCompatibility(adapter) {
@@ -464,9 +418,7 @@ ShellRoot {
         root.errorText = ""
       } else if (method === "contacts") {
         root.contactsBusy = false
-        if (root.contactsRequestedQuery === root.contactQuery)
-          root.contactResults = Array.isArray(result) ? result : []
-        else Qt.callLater(root.startContactSearch)
+        root.contactResults = Array.isArray(result) ? result : []
       } else if (method === "send_to_thread") {
         root.sendBusy = false
         composer.text = ""
@@ -527,8 +479,6 @@ ShellRoot {
       } else if (method === "contacts") {
         root.contactsBusy = false
         root.errorText = message || "Contact search failed"
-        if (root.contactsRequestedQuery !== root.contactQuery)
-          Qt.callLater(root.startContactSearch)
       } else if (method === "send_to_thread") {
         root.sendBusy = false
         root.errorText = message

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -214,6 +214,8 @@ package_blueferry-quickshell() {
     "$pkgdir/usr/bin/blueferry-quickshell"
   install -Dm644 data/quickshell/*.qml \
     -t "$pkgdir/usr/share/blueferry/quickshell"
+  install -Dm644 src/blueferry/qt/qml/ConversationLogic.qml \
+    "$pkgdir/usr/share/blueferry/quickshell/ConversationLogic.qml"
   install -Dm644 data/io.weirdware.BlueFerry.Quickshell.desktop \
     "$pkgdir/usr/share/applications/io.weirdware.BlueFerry.Quickshell.desktop"
   install -Dm644 data/io.weirdware.BlueFerry.Quickshell.metainfo.xml \

--- a/src/blueferry/conversation_state.py
+++ b/src/blueferry/conversation_state.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Protocol
 
+from blueferry.client import BackendError
 from blueferry.models import BackendStatus, Thread
 
 
@@ -12,6 +14,29 @@ class ConversationSnapshot:
     status: BackendStatus | None
     threads: tuple[Thread, ...] | None
     failures: tuple[str, ...] = ()
+
+
+class SnapshotClient(Protocol):
+    def status(self) -> BackendStatus: ...
+    def threads(self, limit: int = 1000) -> list[Thread]: ...
+
+
+def fetch_conversation_snapshot(
+    client: SnapshotClient, *, limit: int = 1000,
+) -> ConversationSnapshot:
+    """Fetch each independently; None distinguishes failure from an empty result."""
+    failures: list[str] = []
+    status: BackendStatus | None = None
+    threads: tuple[Thread, ...] | None = None
+    try:
+        status = client.status()
+    except BackendError as error:
+        failures.append(str(error))
+    try:
+        threads = tuple(client.threads(limit))
+    except BackendError as error:
+        failures.append(str(error))
+    return ConversationSnapshot(status, threads, tuple(failures))
 
 
 class ReplyDisposition(str, Enum):

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -19,8 +19,13 @@ from PySide6.QtDBus import QDBusConnection
 from blueferry import __version__
 from blueferry.backend_lifecycle import ensure_backend_current, restart_backend
 from blueferry.bluetooth_devices import iphone_candidates
-from blueferry.client import BackendClient, BackendError
-from blueferry.conversation_state import ConversationState, ReplyDisposition
+from blueferry.client import BackendClient
+from blueferry.conversation_state import (
+    ConversationSnapshot,
+    ConversationState,
+    ReplyDisposition,
+    fetch_conversation_snapshot,
+)
 from blueferry.i18n import _
 from blueferry.models import BackendStatus, Thread
 from blueferry.onboarding import OnboardingState, effective_compatibility
@@ -74,7 +79,7 @@ class BridgeController(QObject):
         self._threads: list[dict] = []
         self._pending_group: tuple[str, str, str] | None = None
         self._contact_results: list[dict] = []
-        self._contact_query = ""
+        self._state = ConversationState(select_first=False)
         self._status: dict = {}
         self._devices: list[dict] = []
         self._bluetooth_active = False
@@ -399,25 +404,14 @@ class BridgeController(QObject):
         self._run(lambda: self._setup.compatibility(selected), completed, failed)
 
     def _snapshot(self) -> dict:
-        status: dict
-        try:
-            status = self._backend.status().to_dict()
-        except BackendError as error:
-            status = {"daemon": False, "error": str(error)}
-        threads: list[dict] | None
-        thread_error = ""
-        try:
-            threads = [item.to_dict() for item in self._backend.threads()]
-        except BackendError as error:
-            # A failed snapshot is not evidence that history is empty. Keep
-            # the last successful projection visible and report the transient
-            # failure separately.
-            threads = None
-            thread_error = str(error)
+        snapshot = fetch_conversation_snapshot(self._backend)
+        error = "; ".join(snapshot.failures)
         return {
-            "threads": threads,
-            "status": status,
-            "thread_error": thread_error,
+            "threads": [item.to_dict() for item in snapshot.threads]
+                if snapshot.threads is not None else None,
+            "status": snapshot.status.to_dict() if snapshot.status is not None
+                else {"daemon": False, "error": error},
+            "thread_error": error,
         }
 
     def _apply_snapshot(self, snapshot: object) -> None:
@@ -425,6 +419,9 @@ class BridgeController(QObject):
         threads = value.get("threads")
         if isinstance(threads, list):
             self._threads = list(threads)
+            self._state.apply_snapshot(ConversationSnapshot(
+                None, tuple(Thread.from_dict(item) for item in threads),
+            ))
             self.threadsChanged.emit()
         status = value.get("status")
         if isinstance(status, dict):
@@ -468,7 +465,7 @@ class BridgeController(QObject):
     @Slot(str, str, bool)
     def sendThread(self, key: str, body: str, confirm_group: bool) -> None:
         draft = body
-        state = ConversationState()
+        state = self._state
         state.threads = [Thread.from_dict(value) for value in self._threads]
         thread = state.thread(key)
         if confirm_group:
@@ -487,6 +484,7 @@ class BridgeController(QObject):
             return
 
         def completed(_value: object) -> None:
+            state.reply_sent(plan, preserve_selection=True)
             self.threadSendSucceeded.emit(key, draft)
             self.refresh()
 
@@ -507,27 +505,29 @@ class BridgeController(QObject):
 
     @Slot(str)
     def findContacts(self, query: str) -> None:
-        selected = query.strip()
-        self._contact_query = selected
-        if not selected:
-            self._contact_results = []
-            self.contactResultsChanged.emit()
+        request = self._state.begin_contact_search(query)
+        self._contact_results = []
+        self.contactResultsChanged.emit()
+        if request is None:
             return
 
         def completed(value: object) -> None:
-            if self._contact_query != selected:
-                return
             matches = list(value) if isinstance(value, list) else []
+            if not self._state.apply_contact_results(request, matches):
+                return
             self._contact_results = [
                 {"name": str(name), "address": str(address)}
-                for name, address in matches
+                for name, address in self._state.contact_results
             ]
             self.contactResultsChanged.emit()
 
+        def failed(message: str) -> None:
+            if self._state.apply_contact_results(request, []):
+                self._set_error(message)
+
         self._run(
-            lambda: self._backend.find_contacts(selected),
-            completed,
-            busy=False,
+            lambda: self._backend.find_contacts(request.query),
+            completed, failed, busy=False,
         )
 
     @Slot(str, str)
@@ -841,6 +841,10 @@ class BridgeController(QObject):
             self._configuration = ConfigurationState(False, "", "", "")
             self._status = {}
             self._threads = []
+            self._state = ConversationState(select_first=False)
+            self._pending_group = None
+            self._contact_results = []
+            self.contactResultsChanged.emit()
             self.configuredChanged.emit()
             self.compatibilityChanged.emit()
             self.statusChanged.emit()

--- a/src/blueferry/qt/qml/ConversationLogic.qml
+++ b/src/blueferry/qt/qml/ConversationLogic.qml
@@ -1,0 +1,70 @@
+import QtQuick
+
+// Shared by the Qt and Quickshell adapters. Window visibility, navigation,
+// transport calls, and dialogs stay with their respective UI.
+QtObject {
+    property var warnedRosterChanges: ({})
+
+    function threadByKey(threads, key) {
+        for (let index = 0; index < threads.length; ++index) {
+            if (threads[index].key === key) return threads[index]
+        }
+        return null
+    }
+
+    function threadForMessage(threads, handle) {
+        for (let index = 0; index < threads.length; ++index) {
+            const messages = threads[index].messages || []
+            for (let messageIndex = 0; messageIndex < messages.length; ++messageIndex) {
+                if (messages[messageIndex].handle === handle) return threads[index]
+            }
+        }
+        return null
+    }
+
+    function threadIsUnread(thread) {
+        if (!thread) return false
+        if (thread.unread === true || thread.unread === false) return thread.unread
+        const messages = thread.messages || []
+        for (let index = 0; index < messages.length; ++index) {
+            if (!messages[index].outgoing && messages[index].read === false) return true
+        }
+        return false
+    }
+
+    function groupSignature(thread) {
+        if (!thread || !thread.is_group) return ""
+        const unique = []
+        const recipients = thread.recipients || []
+        for (let index = 0; index < recipients.length; ++index) {
+            const address = String(recipients[index] || "")
+            if (address !== "" && unique.indexOf(address) < 0) unique.push(address)
+        }
+        unique.sort()
+        return [String(thread.roster_warning_id || "")].concat(unique).join("\n")
+    }
+
+    function nextRosterWarning(threads) {
+        for (let index = 0; index < threads.length; ++index) {
+            const thread = threads[index]
+            if (!thread.roster_changed) continue
+            const warningId = thread.roster_warning_id
+                || thread.key + ":" + (thread.unexpected_sender || "unknown")
+            if (warnedRosterChanges[warningId] === true) continue
+            warnedRosterChanges[warningId] = true
+            return thread
+        }
+        return null
+    }
+
+    function participantLines(value) {
+        const result = []
+        // Match Python str.splitlines(), used by the GTK and terminal editors.
+        const lines = value.split(/\r\n|[\n\r\v\f\u001c-\u001e\u0085\u2028\u2029]/)
+        for (let index = 0; index < lines.length; ++index) {
+            const address = lines[index].trim()
+            if (address !== "" && result.indexOf(address) < 0) result.push(address)
+        }
+        return result
+    }
+}

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -8,6 +8,8 @@ import org.kde.kirigami as Kirigami
 Kirigami.ApplicationWindow {
     id: root
 
+    ConversationLogic { id: conversationLogic }
+
     required property var bridge
     property string selectedThreadKey: ""
     onSelectedThreadKeyChanged: root.markSelectedThreadRead()
@@ -16,7 +18,6 @@ Kirigami.ApplicationWindow {
     property bool firstRunRedirected: false
     property var iphoneSettingsPage: null
     property string pendingMessageHandle: ""
-    property var warnedRosterChanges: ({})
 
     visible: true
     width: 980
@@ -26,12 +27,7 @@ Kirigami.ApplicationWindow {
     title: qsTr("BlueFerry")
 
     function threadByKey(key) {
-        for (let index = 0; index < bridge.threads.length; ++index) {
-            if (bridge.threads[index].key === key) {
-                return bridge.threads[index]
-            }
-        }
-        return null
+        return conversationLogic.threadByKey(bridge.threads, key)
     }
 
     function selectedThread() {
@@ -39,18 +35,7 @@ Kirigami.ApplicationWindow {
     }
 
     function threadIsUnread(thread) {
-        if (!thread)
-            return false
-        if (thread.unread === true)
-            return true
-        if (thread.unread === false)
-            return false
-        const messages = thread.messages || []
-        for (let index = 0; index < messages.length; ++index) {
-            if (!messages[index].outgoing && messages[index].read === false)
-                return true
-        }
-        return false
+        return conversationLogic.threadIsUnread(thread)
     }
 
     function markSelectedThreadRead() {
@@ -62,19 +47,13 @@ Kirigami.ApplicationWindow {
     }
 
     function selectMessage(handle) {
-        for (let threadIndex = 0; threadIndex < bridge.threads.length; ++threadIndex) {
-            const thread = bridge.threads[threadIndex]
-            for (let messageIndex = 0; messageIndex < thread.messages.length; ++messageIndex) {
-                if (thread.messages[messageIndex].handle === handle) {
-                    closePhoneSettings()
-                    pageStack.currentIndex = 0
-                    selectedThreadKey = thread.key
-                    pendingMessageHandle = ""
-                    return true
-                }
-            }
-        }
-        return false
+        const thread = conversationLogic.threadForMessage(bridge.threads, handle)
+        if (!thread) return false
+        closePhoneSettings()
+        pageStack.currentIndex = 0
+        selectedThreadKey = thread.key
+        pendingMessageHandle = ""
+        return true
     }
 
     function htmlEscape(value) {
@@ -148,19 +127,10 @@ Kirigami.ApplicationWindow {
     }
 
     function warnAboutRosterChanges() {
-        for (let index = 0; index < bridge.threads.length; ++index) {
-            const thread = bridge.threads[index]
-            if (!thread.roster_changed)
-                continue
-            const warningId = thread.roster_warning_id
-                || thread.key + ":" + (thread.unexpected_sender || "unknown")
-            if (warnedRosterChanges[warningId] === true)
-                continue
-            warnedRosterChanges[warningId] = true
-            rosterChangedDialog.thread = thread
-            rosterChangedDialog.open()
-            return
-        }
+        const thread = conversationLogic.nextRosterWarning(bridge.threads)
+        if (!thread) return
+        rosterChangedDialog.thread = thread
+        rosterChangedDialog.open()
     }
 
     Connections {
@@ -273,14 +243,7 @@ Kirigami.ApplicationWindow {
         standardButtons: Kirigami.Dialog.Cancel
 
         function recipients() {
-            const result = []
-            const lines = groupParticipantEditor.text.split(/\r?\n/)
-            for (let index = 0; index < lines.length; ++index) {
-                const address = lines[index].trim()
-                if (address !== "" && result.indexOf(address) < 0)
-                    result.push(address)
-            }
-            return result
+            return conversationLogic.participantLines(groupParticipantEditor.text)
         }
 
         customFooterActions: [Kirigami.Action {

--- a/src/blueferry/recipients.py
+++ b/src/blueferry/recipients.py
@@ -59,3 +59,8 @@ def validate_recipient(recipient: str) -> str:
     raise InvalidRecipient(
         f"not a valid phone number or email address: {candidate!r}"
     )
+
+
+def participant_lines(value: str) -> list[str]:
+    """Parse the roster editor without changing address spelling or order."""
+    return list(dict.fromkeys(line.strip() for line in value.splitlines() if line.strip()))

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -26,10 +26,12 @@ from blueferry.conversation_state import (
     ConversationSnapshot,
     ConversationState,
     ReplyDisposition,
+    fetch_conversation_snapshot,
 )
 from blueferry.models import BackendStatus, Thread, ThreadMessage
 from blueferry.onboarding import ancs_unavailable_detail
 from blueferry.protocol import BUS_NAME, EVENTS_IFACE, OBJECT_PATH
+from blueferry.recipients import participant_lines
 from blueferry.text_safety import terminal_text
 from blueferry.time_display import format_message_timestamp
 
@@ -97,18 +99,7 @@ class TuiState(ConversationState):
         self.client = client
 
     def fetch_snapshot(self) -> ConversationSnapshot:
-        failures: list[str] = []
-        status: BackendStatus | None = None
-        threads: tuple[Thread, ...] | None = None
-        try:
-            status = self.client.status()
-        except BackendError as error:
-            failures.append(str(error))
-        try:
-            threads = tuple(self.client.threads(200))
-        except BackendError as error:
-            failures.append(str(error))
-        return ConversationSnapshot(status, threads, tuple(failures))
+        return fetch_conversation_snapshot(self.client, limit=200)
 
     def refresh(self) -> None:
         self.apply_snapshot(self.fetch_snapshot())
@@ -441,11 +432,7 @@ class RosterChangedScreen(ModalScreen[tuple[str, ...] | None]):
 
     @on(Button.Pressed, "#roster-changed-save")
     def save_button(self) -> None:
-        recipients: list[str] = []
-        for line in self.query_one("#roster-participants", TextArea).text.splitlines():
-            address = line.strip()
-            if address and address not in recipients:
-                recipients.append(address)
+        recipients = participant_lines(self.query_one("#roster-participants", TextArea).text)
         if not 2 <= len(recipients) <= 20:
             self.notify(
                 "Enter 2 to 20 participants, one per line",

--- a/src/blueferry/ui/conversations.py
+++ b/src/blueferry/ui/conversations.py
@@ -16,6 +16,7 @@ from blueferry.conversation_state import (
 )
 from blueferry.i18n import _
 from blueferry.models import BackendStatus, Thread, ThreadMessage
+from blueferry.recipients import participant_lines as _participant_lines
 from blueferry.ui.status_presenter import (
     map_connection_refused,
     map_connection_refused_message,
@@ -86,16 +87,6 @@ class MessageComposer(Gtk.ScrolledWindow):
 
     def grab_focus(self) -> bool:
         return self._view.grab_focus()
-
-
-def _participant_lines(value: str) -> list[str]:
-    """Return unique non-empty addresses from the one-per-line editor."""
-    result: list[str] = []
-    for line in value.splitlines():
-        address = line.strip()
-        if address and address not in result:
-            result.append(address)
-    return result
 
 
 def _group_roster_banner_title(thread: Thread) -> str:

--- a/tests/test_conversation_state.py
+++ b/tests/test_conversation_state.py
@@ -204,3 +204,33 @@ def test_reply_sent_rejects_blocked_plan() -> None:
     state = ConversationState()
     with pytest.raises(ValueError, match="blocked"):
         state.reply_sent(state.plan_reply("hello"))
+
+
+@pytest.mark.parametrize("status_fails,threads_fail", [(False, False), (True, False), (False, True), (True, True)])
+def test_shared_snapshot_loader_distinguishes_empty_history_from_failure(status_fails, threads_fail):
+    from blueferry.client import BackendError
+    from blueferry.conversation_state import fetch_conversation_snapshot
+
+    calls = []
+
+    class Client:
+        def status(self):
+            calls.append("status")
+            if status_fails:
+                raise BackendError("status failed")
+            return BackendStatus(daemon=True)
+
+        def threads(self, limit=1000):
+            calls.append(limit)
+            if threads_fail:
+                raise BackendError("threads failed")
+            return []
+
+    snapshot = fetch_conversation_snapshot(Client(), limit=17)
+    assert calls == ["status", 17]
+    assert (snapshot.status is None) == status_fails
+    assert snapshot.threads == (None if threads_fail else ())
+    assert snapshot.failures == tuple(
+        message for failed, message in [(status_fails, "status failed"), (threads_fail, "threads failed")]
+        if failed
+    )

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -404,7 +404,7 @@ def test_group_message_bubbles_show_the_individual_sender() -> None:
 
 def test_quickshell_remembers_group_confirmation_until_roster_changes() -> None:
     qml = (ROOT / "data" / "quickshell" / "shell.qml").read_text()
-    signature = qml.split("function groupSignature(thread)", 1)[1]
+    signature = (ROOT / "src/blueferry/qt/qml/ConversationLogic.qml").read_text()
 
     assert "property var confirmedGroupSignatures" in qml
     assert "function groupIsConfirmed(thread)" in qml
@@ -518,7 +518,7 @@ def test_all_gui_clients_offer_contacts_aware_new_messages() -> None:
     assert "def findContacts" in qt_controller
     assert 'text: qsTr("New Message")' in qt_qml
     assert 'Accessible.name: "New message"' in quickshell
-    assert 'backendBridge.request("contacts"' in quickshell
+    assert 'backendBridge.requestLatest("contacts"' in quickshell
 
 
 def test_all_clients_expand_and_scroll_long_message_drafts() -> None:

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -387,14 +387,9 @@ def test_qt_onboarding_summary_explains_locked_contact_sync(qml_engine) -> None:
     summary.deleteLater()
 
 
-@pytest.mark.parametrize("relative_path", [
-    "data/quickshell/shell.qml", "src/blueferry/qt/qml/Main.qml",
-])
-def test_read_sync_requires_visible_active_conversation(qml_engine, relative_path):
-    """Execute the shipped handlers with inert windows and backend recorders."""
-    source = (ROOT / relative_path).read_text()
+def _qml_functions(source: str, names: tuple[str, ...]) -> str:
     functions = []
-    for name in ("threadByKey", "selectedThread", "threadIsUnread", "markSelectedThreadRead"):
+    for name in names:
         start = source.index("function " + name + "(")
         opening = source.index("{", start)
         depth = 1
@@ -403,6 +398,22 @@ def test_read_sync_requires_visible_active_conversation(qml_engine, relative_pat
             depth += (source[end] == "{") - (source[end] == "}")
             end += 1
         functions.append(source[start:end])
+    return "\n".join(functions)
+
+
+@pytest.mark.parametrize("relative_path", [
+    "data/quickshell/shell.qml", "src/blueferry/qt/qml/Main.qml",
+])
+def test_read_sync_requires_visible_active_conversation(qml_engine, relative_path):
+    """Execute the shipped handlers with inert windows and backend recorders."""
+    component = _component(qml_engine, "src/blueferry/qt/qml/ConversationLogic.qml")
+    logic = component.create()
+    assert logic is not None
+    qml_engine.globalObject().setProperty("conversationLogic", qml_engine.newQObject(logic))
+    source = (ROOT / relative_path).read_text()
+    functions = _qml_functions(source, (
+        "threadByKey", "selectedThread", "threadIsUnread", "markSelectedThreadRead",
+    ))
     script = '''(function() {
         var calls = [];
         var threads = [{key: "one", unread: true}];
@@ -413,7 +424,7 @@ def test_read_sync_requires_visible_active_conversation(qml_engine, relative_pat
         var applicationSurface = {Window: {active: true}};
         var phoneSettingsVisible = false;
         var root = {visible: true, active: true, iphoneSettingsPage: null};
-    ''' + "\n".join(functions) + '''
+    ''' + functions + '''
         window.visible = root.visible = false;
         markSelectedThreadRead();
         window.visible = root.visible = true;
@@ -432,6 +443,7 @@ def test_read_sync_requires_visible_active_conversation(qml_engine, relative_pat
     result = qml_engine.evaluate(script)
     assert not result.isError(), result.toString()
     assert result.toString() == '["one"]'
+    logic.deleteLater()
 
 
 class _MessageDialogBridge(QObject):
@@ -480,3 +492,97 @@ def test_group_confirmation_component_shows_literal_recipients(qml_engine):
     assert dialog.property("draft") == "draft"
     assert dialog.property("subtitle") == "<span>&lt;alice&gt;<br>bob@example.com</span>"
     dialog.deleteLater()
+
+
+def test_quickshell_search_coalesces_queries_and_ignores_superseded_replies(qml_engine):
+    source = (ROOT / "data/quickshell/BackendBridge.qml").read_text()
+    functions = _qml_functions(source, ("requestLatest", "cancelLatest", "handleLine"))
+    result = qml_engine.evaluate('''(function() {
+        var latestRequests = {}, latestMethods = {}, sent = [], replies = [], errors = [];
+        var nextId = 1;
+        function request(method, args) { sent.push(args.query); return nextId++; }
+        function response(method, id, result) { replies.push(result); }
+        function failure(method, id, error) { errors.push(error); }
+        function eventReceived() {}
+    ''' + functions + '''
+        requestLatest("contacts", {query: "A"});
+        requestLatest("contacts", {query: "B"});
+        requestLatest("contacts", {query: "A"});
+        handleLine(JSON.stringify({method: "contacts", id: 1, ok: false, error: "old failure"}));
+        if (replies.length || errors.length || sent.join() !== "A,A") throw new Error("stale search");
+        handleLine(JSON.stringify({method: "contacts", id: 2, ok: true, result: "latest A"}));
+        requestLatest("contacts", {query: "B"});
+        cancelLatest("contacts");
+        handleLine(JSON.stringify({method: "contacts", id: 3, ok: true, result: "cancelled"}));
+        requestLatest("contacts", {query: "C"});
+        handleLine(JSON.stringify({method: "", id: 0, ok: false, error: "bridge failed"}));
+        handleLine(JSON.stringify({method: "contacts", id: 4, ok: true, result: "before failure"}));
+        requestLatest("contacts", {query: "D"});
+        handleLine(JSON.stringify({method: "contacts", id: 5, ok: true, result: "recovered"}));
+        return JSON.stringify({replies: replies, errors: errors, sent: sent});
+    })()''')
+    assert not result.isError(), result.toString()
+    import json
+
+    assert json.loads(result.toString()) == {
+        "replies": ["latest A", "recovered"], "errors": ["bridge failed"],
+        "sent": ["A", "A", "B", "C", "D"],
+    }
+
+
+@pytest.mark.parametrize("text", [
+    "  alice@example.com\n\n+15551111111\nalice@example.com  ",
+    "alice\rbob\r\nalice\u2028carol\u0085dave\v\ffrank",
+    "", " \n\t ",
+])
+def test_roster_parsing_matches_between_python_and_qml(qml_engine, text):
+    import json
+
+    from blueferry.recipients import participant_lines
+
+    component = _component(qml_engine, "src/blueferry/qt/qml/ConversationLogic.qml")
+    logic = component.create()
+    assert logic is not None
+    qml_engine.globalObject().setProperty("logic", qml_engine.newQObject(logic))
+    result = qml_engine.evaluate("JSON.stringify(logic.participantLines(" + json.dumps(text) + "))")
+    assert not result.isError(), result.toString()
+    assert json.loads(result.toString()) == participant_lines(text)
+    logic.deleteLater()
+
+
+def test_qml_conversation_decisions_match_python_state(qml_engine):
+    import json
+
+    from blueferry.conversation_state import ConversationSnapshot, ConversationState
+    from blueferry.models import Thread
+
+    component = _component(qml_engine, "src/blueferry/qt/qml/ConversationLogic.qml")
+    logic = component.create()
+    assert logic is not None
+    qml_engine.globalObject().setProperty("logic", qml_engine.newQObject(logic))
+    threads = [{
+        "key": "group:one", "is_group": True, "roster_changed": True,
+        "unexpected_sender": "Alice", "recipients": ["b@example.com", "a@example.com", "b@example.com"],
+        "messages": [{"handle": "message", "outgoing": False, "read": False}],
+    }]
+    state = ConversationState()
+    state.apply_snapshot(ConversationSnapshot(None, tuple(Thread.from_dict(t) for t in threads)))
+    thread = state.next_roster_warning()
+    assert thread is not None
+    result = qml_engine.evaluate('''(function() {
+        const threads = ''' + json.dumps(threads) + ''';
+        return JSON.stringify([
+            logic.threadByKey(threads, "group:one").key,
+            logic.threadForMessage(threads, "message").key,
+            logic.threadIsUnread(threads[0]),
+            logic.groupSignature(threads[0]),
+            logic.nextRosterWarning(threads).key,
+            logic.nextRosterWarning(threads)
+        ]);
+    })()''')
+    assert not result.isError(), result.toString()
+    assert json.loads(result.toString()) == [
+        thread.key, thread.key, thread.unread, thread.confirmation_token, thread.key, None,
+    ]
+    assert state.next_roster_warning() is None
+    logic.deleteLater()

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -19,7 +19,7 @@ class _Backend:
     def status(self):
         return BackendStatus(daemon=True, map=True, contacts=4)
 
-    def threads(self):
+    def threads(self, limit=1000):
         return [
             Thread(
                 key="address:email:test@example.com",
@@ -97,7 +97,7 @@ def test_failed_thread_snapshot_preserves_last_successful_projection():
                 storage_state="ready",
             )
 
-        def threads(self):
+        def threads(self, limit=1000):
             raise BackendError("thread snapshot unavailable")
 
     controller = BridgeController(
@@ -718,3 +718,44 @@ def test_draft_completion_is_emitted_only_after_success(monkeypatch):
     assert completed == [(key, " draft ")]
     queued[1][1]("sent")
     assert completed[-1] == (" new recipient ", " new draft ")
+
+
+def test_contact_search_rejects_repeated_query_stale_results_and_errors(monkeypatch):
+    controller = BridgeController(backend=_Backend(), setup=object(), subscribe=False, autostart=False)
+    pending = []
+    monkeypatch.setattr(controller, "_run", lambda *args, **_kw: pending.append(args))
+    controller.findContacts("Ali")
+    controller.findContacts("Bob")
+    controller.findContacts("Ali")
+    pending[0][1]([("Old Alice", "old@example.com")])
+    pending[1][2]("stale failure")
+    assert controller.contactResults == []
+    assert controller.errorText == ""
+    pending[2][1]([("Alice", "alice@example.com")])
+    assert controller.contactResults == [{"name": "Alice", "address": "alice@example.com"}]
+    controller.findContacts("")
+    pending[2][1]([("Late Alice", "late@example.com")])
+    assert controller.contactResults == []
+
+
+def test_successful_group_reply_reuses_confirmation_until_roster_changes(monkeypatch):
+    controller = BridgeController(backend=_Backend(), setup=object(), subscribe=False, autostart=False)
+    controller._threads = [{
+        "key": "group:test", "is_group": True, "reply_ready": True,
+        "recipients": ["+15551111111", "+15552222222"],
+    }]
+    pending = []
+    prompts = []
+    monkeypatch.setattr(controller, "_run", lambda *args, **_kw: pending.append(args))
+    monkeypatch.setattr(controller, "refresh", lambda: None)
+    controller.groupConfirmationRequested.connect(lambda *args: prompts.append(args))
+    controller.sendThread("group:test", "first", False)
+    controller.sendThread("group:test", "first", True)
+    pending.pop()[1]("sent")
+    controller.sendThread("group:test", "second", False)
+    assert len(prompts) == 1
+    assert len(pending) == 1
+    controller._threads[0]["recipients"].append("+15553333333")
+    controller.sendThread("group:test", "third", False)
+    assert len(prompts) == 2
+    assert len(pending) == 1


### PR DESCRIPTION
The clients repeated conversation lookup, unread detection, roster warning, participant parsing, and snapshot handling. Qt also tracked contact searches by query text, allowing an earlier response to appear after an A → B → A query change.

- Share the Qt/Quickshell conversation helpers in one `ConversationLogic.qml` implementation. Window focus, navigation, and dialog rendering remain in their toolkit adapters.
- Keep a persistent `ConversationState` in Qt for contact request sequences and successful group confirmations. Ignore superseded contact results and failures.
- Move Quickshell contact-request coalescing into its transport adapter using request IDs, including cancellation and recovery after bridge errors.
- Use one snapshot loader for Qt and TUI, preserving the distinction between failed reads and empty history.
- Share participant parsing between GTK and TUI; cover its contract and conversation decisions with Python/QML behavior tests.

The Quickshell development wrapper imports the canonical QML source. Arch packaging installs that implementation directly, without a Qt-client runtime dependency.

Validation: 913 tests pass in the isolated D-Bus suite. Ruff, mypy, Bandit, qmllint, and diff checks pass. Built the Qt wheel, staged the Quickshell package using its actual packaging function, verified both contain identical standalone helper code, and linted the staged QML.
