### PR TITLE
Cancel OBEX transfers when size limits or timeouts abort them

### DIFF
--- a/src/blueferry/contacts.py
+++ b/src/blueferry/contacts.py
@@ -142,14 +142,9 @@ def pull_phonebook(
         initial_status = str(initial.get("Status", "queued"))
         log.debug("PBAP transfer %s initial status=%s size=%s",
                   transfer_path, initial_status, initial.get("Size", "unknown"))
-        initial_size = int(initial.get("Size", 0) or 0)
-        if initial_size > MAX_PHONEBOOK_BYTES:
-            raise RuntimeError(
-                f"phonebook exceeds {MAX_PHONEBOOK_BYTES} byte safety limit"
-            )
         def phonebook_size() -> int:
             size = out.stat().st_size if out.exists() else 0
-            if size > MAX_PHONEBOOK_BYTES:
+            if max(size, int(initial.get("Size", 0) or 0)) > MAX_PHONEBOOK_BYTES:
                 raise RuntimeError(
                     f"phonebook exceeds {MAX_PHONEBOOK_BYTES} byte safety limit"
                 )

--- a/src/blueferry/obex/transfer.py
+++ b/src/blueferry/obex/transfer.py
@@ -1,12 +1,15 @@
 """Shared BlueZ OBEX Transfer1 completion handling."""
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Callable
 
 import dbus
 
 from blueferry.bus import obex
+
+log = logging.getLogger(__name__)
 
 _TRANSFER_IFACE = "org.bluez.obex.Transfer1"
 _DISAPPEARED_ERRORS = frozenset({
@@ -50,64 +53,72 @@ def wait_for_transfer(
     restarted whenever its integer value increases. ``overall_timeout_s``
     optionally imposes a hard deadline that progress cannot extend.
     """
-    status = str(initial_status or "queued").casefold()
-    if check_progress is not None:
-        check_progress()
-    status_reader = get_status
-    if status_reader is None and status not in {"complete", "error"}:
-        properties = obex(transfer_path, "org.freedesktop.DBus.Properties")
-
-        def read_status() -> str:
-            kwargs = (
-                {"timeout": property_timeout_s}
-                if property_timeout_s is not None else {}
-            )
-            return str(properties.Get(_TRANSFER_IFACE, "Status", **kwargs))
-
-        status_reader = read_status
-
-    timeout = max(0.0, float(timeout_s))
-    started_at = monotonic()
-    deadline = started_at + timeout
-    overall_deadline = (
-        started_at + max(0.0, float(overall_timeout_s))
-        if overall_timeout_s is not None
-        else None
-    )
-    last_progress = get_progress() if get_progress is not None else None
-    while status not in {"complete", "error"}:
-        if get_progress is not None:
-            progress = get_progress()
-            if last_progress is None or progress > last_progress:
-                last_progress = progress
-                deadline = monotonic() + timeout
-        now = monotonic()
-        if overall_deadline is not None and now >= overall_deadline:
-            raise TimeoutError(
-                f"OBEX transfer {transfer_path} exceeded its "
-                f"{overall_timeout_s:g}s overall limit "
-                f"(last status: {status or 'unknown'})"
-            )
-        if now >= deadline:
-            raise TimeoutError(
-                f"OBEX transfer {transfer_path} timed out after {timeout_s:g}s "
-                f"(last status: {status or 'unknown'})"
-            )
-        if status_reader is None:
-            raise RuntimeError("OBEX transfer has no status reader")
-        try:
-            status = str(status_reader()).casefold()
-        except dbus.exceptions.DBusException as error:
-            if _dbus_error_name(error) in _DISAPPEARED_ERRORS:
-                return "gone"
-            raise RuntimeError(
-                f"could not read OBEX transfer status for {transfer_path}: "
-                f"{_dbus_error_name(error) or error}"
-            ) from error
+    try:
+        status = str(initial_status or "queued").casefold()
         if check_progress is not None:
             check_progress()
-        if status not in {"complete", "error"}:
-            sleep(poll_interval_s)
-    if status == "error":
-        raise TransferFailed(f"OBEX transfer reported error: {transfer_path}")
-    return "complete"
+        status_reader = get_status
+        if status_reader is None and status not in {"complete", "error"}:
+            properties = obex(transfer_path, "org.freedesktop.DBus.Properties")
+
+            def read_status() -> str:
+                kwargs = (
+                    {"timeout": property_timeout_s}
+                    if property_timeout_s is not None else {}
+                )
+                return str(properties.Get(_TRANSFER_IFACE, "Status", **kwargs))
+
+            status_reader = read_status
+
+        timeout = max(0.0, float(timeout_s))
+        started_at = monotonic()
+        deadline = started_at + timeout
+        overall_deadline = (
+            started_at + max(0.0, float(overall_timeout_s))
+            if overall_timeout_s is not None
+            else None
+        )
+        last_progress = get_progress() if get_progress is not None else None
+        while status not in {"complete", "error"}:
+            if get_progress is not None:
+                progress = get_progress()
+                if last_progress is None or progress > last_progress:
+                    last_progress = progress
+                    deadline = monotonic() + timeout
+            now = monotonic()
+            if overall_deadline is not None and now >= overall_deadline:
+                raise TimeoutError(
+                    f"OBEX transfer {transfer_path} exceeded its "
+                    f"{overall_timeout_s:g}s overall limit "
+                    f"(last status: {status or 'unknown'})"
+                )
+            if now >= deadline:
+                raise TimeoutError(
+                    f"OBEX transfer {transfer_path} timed out after {timeout_s:g}s "
+                    f"(last status: {status or 'unknown'})"
+                )
+            if status_reader is None:
+                raise RuntimeError("OBEX transfer has no status reader")
+            try:
+                status = str(status_reader()).casefold()
+            except dbus.exceptions.DBusException as error:
+                if _dbus_error_name(error) in _DISAPPEARED_ERRORS:
+                    return "gone"
+                raise RuntimeError(
+                    f"could not read OBEX transfer status for {transfer_path}: "
+                    f"{_dbus_error_name(error) or error}"
+                ) from error
+            if check_progress is not None:
+                check_progress()
+            if status not in {"complete", "error"}:
+                sleep(poll_interval_s)
+        if status == "error":
+            raise TransferFailed(f"OBEX transfer reported error: {transfer_path}")
+        return "complete"
+    except Exception:
+        # Unlinking a download does not stop obexd writing through its open fd.
+        try:
+            obex(transfer_path, _TRANSFER_IFACE).Cancel(timeout=2.0)
+        except Exception:
+            log.debug("Could not cancel OBEX transfer %s", transfer_path, exc_info=True)
+        raise

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -19,6 +19,7 @@ from blueferry.limits import (
     MAX_CONTACT_ADDRESSES_PER_CARD,
     MAX_CONTACT_NAME_CHARS,
 )
+from blueferry.obex import transfer
 
 
 def test_pbap_filters_use_phonebook_access_names():
@@ -98,6 +99,40 @@ def test_phonebook_transfer_wires_idle_and_overall_timeouts(
     assert captured["timeout_s"] == 60
     assert captured["overall_timeout_s"] == 30 * 60
     assert callable(captured["get_progress"])
+
+
+@pytest.mark.parametrize("advertised_size", [0, 17])
+def test_oversized_phonebook_is_cancelled_before_cleanup(
+    tmp_path, monkeypatch, advertised_size,
+):
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    monkeypatch.setattr(contacts, "MAX_PHONEBOOK_BYTES", 16)
+    target = None
+    cancelled = []
+
+    class _Pbap:
+        def Select(self, *_args, **_kwargs):
+            pass
+
+        def PullAll(self, path, *_args, **_kwargs):
+            nonlocal target
+            target = Path(path)
+            target.write_bytes(b"x" * (1 if advertised_size else 17))
+            return "/transfer/phonebook", {"Status": "active", "Size": advertised_size}
+
+        def Cancel(self, *, timeout):
+            assert target.exists(), "cancel before removing the temporary directory"
+            cancelled.append(timeout)
+
+    interface = _Pbap()
+    monkeypatch.setattr(contacts, "obex", lambda *_args: interface)
+    monkeypatch.setattr(transfer, "obex", lambda *_args: interface)
+
+    with pytest.raises(RuntimeError, match="safety limit"):
+        contacts.pull_phonebook(SimpleNamespace(pbap_path="/pbap"))
+
+    assert cancelled == [2.0]
+    assert not target.parent.exists()
 
 
 def test_single_vcard():

--- a/tests/test_map_events.py
+++ b/tests/test_map_events.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from blueferry.obex import map_events
+from blueferry.obex import map_events, transfer
 
 
 class _Message:
@@ -47,11 +47,19 @@ def test_fetch_rejects_oversized_bmessage_before_parsing(tmp_path, monkeypatch) 
     monkeypatch.setattr(
         map_events, "obex", lambda _path, _interface: _Message(b"x" * 17),
     )
-    monkeypatch.setattr(map_events, "wait_for_transfer", lambda *_args, **_kwargs: "complete")
+    cancelled = []
+
+    class _Transfer:
+        def Cancel(self, *, timeout):
+            assert target.exists(), "cancel before unlinking the output"
+            cancelled.append(timeout)
+
+    monkeypatch.setattr(transfer, "obex", lambda *_args: _Transfer())
 
     with pytest.raises(RuntimeError, match="safety limit"):
         map_events._fetch_bmessage("/message/test", target)
 
+    assert cancelled == [2.0]
     assert not target.exists()
 
 

--- a/tests/test_obex_transfer.py
+++ b/tests/test_obex_transfer.py
@@ -1,10 +1,20 @@
 """Pure transfer-state tests; no BlueZ or OBEX connection is opened."""
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import dbus
 import pytest
 
+from blueferry.obex import transfer
 from blueferry.obex.transfer import TransferFailed, wait_for_transfer
+
+
+@pytest.fixture(autouse=True)
+def cancel(monkeypatch):
+    interface = Mock()
+    monkeypatch.setattr(transfer, "obex", lambda *_args: interface)
+    return interface.Cancel
 
 
 class _Clock:
@@ -18,7 +28,7 @@ class _Clock:
         self.now += seconds
 
 
-def test_wait_requires_terminal_completion() -> None:
+def test_wait_requires_terminal_completion(cancel) -> None:
     statuses = iter(["queued", "active", "complete"])
     clock = _Clock()
 
@@ -26,9 +36,10 @@ def test_wait_requires_terminal_completion() -> None:
         "/transfer/1", timeout_s=5, get_status=lambda: next(statuses),
         monotonic=clock, sleep=clock.sleep,
     ) == "complete"
+    cancel.assert_not_called()
 
 
-def test_nonterminal_status_at_deadline_is_not_success() -> None:
+def test_nonterminal_status_at_deadline_is_not_success(cancel) -> None:
     clock = _Clock()
 
     with pytest.raises(TimeoutError, match="last status: active"):
@@ -36,6 +47,7 @@ def test_nonterminal_status_at_deadline_is_not_success() -> None:
             "/transfer/2", timeout_s=0.2, get_status=lambda: "active",
             monotonic=clock, sleep=clock.sleep,
         )
+    cancel.assert_called_once_with(timeout=2.0)
 
 
 def test_transfer_timeout_restarts_when_progress_advances() -> None:
@@ -72,7 +84,7 @@ def test_progress_regression_does_not_restart_inactivity_timeout() -> None:
         )
 
 
-def test_progress_cannot_extend_overall_timeout() -> None:
+def test_progress_cannot_extend_overall_timeout(cancel) -> None:
     clock = _Clock()
 
     with pytest.raises(TimeoutError, match=r"0\.5s overall limit"):
@@ -85,6 +97,7 @@ def test_progress_cannot_extend_overall_timeout() -> None:
             monotonic=clock,
             sleep=clock.sleep,
         )
+    cancel.assert_called_once_with(timeout=2.0)
 
 
 def test_explicit_transfer_error_fails() -> None:
@@ -94,7 +107,7 @@ def test_explicit_transfer_error_fails() -> None:
         )
 
 
-def test_only_object_disappearance_is_accepted() -> None:
+def test_only_object_disappearance_is_accepted(cancel) -> None:
     def gone():
         raise dbus.exceptions.DBusException(
             "gone", name="org.freedesktop.DBus.Error.UnknownObject",
@@ -103,9 +116,10 @@ def test_only_object_disappearance_is_accepted() -> None:
     assert wait_for_transfer(
         "/transfer/4", timeout_s=1, get_status=gone,
     ) == "gone"
+    cancel.assert_not_called()
 
 
-def test_unrelated_dbus_failure_is_not_treated_as_completion() -> None:
+def test_unrelated_dbus_failure_is_not_treated_as_completion(cancel) -> None:
     def disconnected():
         raise dbus.exceptions.DBusException(
             "lost", name="org.freedesktop.DBus.Error.Disconnected",
@@ -115,3 +129,29 @@ def test_unrelated_dbus_failure_is_not_treated_as_completion() -> None:
         wait_for_transfer(
             "/transfer/5", timeout_s=1, get_status=disconnected,
         )
+    cancel.assert_called_once_with(timeout=2.0)
+
+
+@pytest.mark.parametrize("callback", ["check_progress", "get_progress"])
+@pytest.mark.parametrize("fail_after", [0, 2])
+def test_progress_rejection_survives_failed_cancellation(cancel, callback, fail_after):
+    clock = _Clock()
+    original = RuntimeError("size limit")
+    calls = 0
+    cancel.side_effect = dbus.exceptions.DBusException("transfer already gone")
+
+    def progress():
+        nonlocal calls
+        calls += 1
+        if calls > fail_after:
+            raise original
+        return 0
+
+    with pytest.raises(RuntimeError) as caught:
+        wait_for_transfer(
+            "/transfer/oversized", timeout_s=1, get_status=lambda: "active",
+            monotonic=clock, sleep=clock.sleep, **{callback: progress},
+        )
+
+    assert caught.value is original
+    cancel.assert_called_once_with(timeout=2.0)


### PR DESCRIPTION
Oversized or stalled OBEX downloads previously raised an error and removed their temporary files without stopping BlueZ's transfer. An open writer could continue consuming storage after rejection.

The shared transfer waiter now calls Transfer1.Cancel with a two-second D-Bus method timeout on failure, before callers clean up their files. Cancellation failures preserve the original error. PBAP's advertised-size check now runs inside that handler alongside the local file-size check. The same handler covers message downloads and outgoing transfer waits.

Validation: all 890 tests pass in an isolated D-Bus session; Ruff, Bandit, and mypy pass. Regression coverage checks cancellation before message/phonebook cleanup, advertised and actual size limits, idle and overall timeouts, and preservation of the original error when cancellation fails. Transfer tests use fake interfaces; no physical-device testing was performed.
