### PR TITLE
Merge conversations across a contact's phone numbers and emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ download your iCloud Messages archive. Attachments, reactions, typing
 indicators, FaceTime, calls, and complete sent-message history are not
 supported.
 
+Direct conversations combine the phone numbers and email addresses that belong
+unambiguously to one synced contact. Replies use the most recent incoming
+address, shown as **Reply to** above the conversation. Shared addresses and
+contacts that merely have the same name stay separate. Original message
+addresses are retained; editing and syncing contacts updates the grouping.
+
 Group replies are deliberately cautious. Bluetooth does not give BlueFerry a
 reliable group ID or complete roster, so it disables replies when the
 participants are unclear. Named groups may ask you to confirm a local reply

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -408,9 +408,9 @@ ShellRoot {
         if (root.pendingThreadKey !== "") {
           root.selectedThreadKey = root.pendingThreadKey
           if (root.selectedThread() !== null) root.pendingThreadKey = ""
-        } else if (root.selectedThreadKey !== "" && root.selectedThread() === null) {
-          root.selectedThreadKey = ""
         }
+        const selected = root.selectedThread()
+        root.selectedThreadKey = selected ? selected.key : ""
         if (root.pendingMessageHandle !== "")
           root.selectMessage(root.pendingMessageHandle)
         root.warnAboutRosterChanges()
@@ -1047,6 +1047,15 @@ ShellRoot {
                   font.bold: true
                   font.letterSpacing: 1
                 }
+              }
+
+              FerryLabel {
+                Layout.fillWidth: true
+                visible: conversationPane.thread !== null && !conversationPane.thread.is_group
+                text: visible ? "Reply to: " + conversationPane.thread.recipients.join(", ") : ""
+                textFormat: Text.PlainText
+                color: theme.muted
+                elide: Text.ElideRight
               }
 
               Rectangle {

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -62,6 +62,7 @@ from blueferry.threads import (
     ConversationIndex,
     bound_thread_response,
     build_threads,
+    conversation_keys,
     group_confirmation_token,
     sort_threads,
     thread_key,
@@ -183,7 +184,7 @@ class BackendOperations:
         if not stars:
             return threads
         recent = {str(event.get("handle") or "") for event in events[-MAX_CONVERSATION_EVENTS:]}
-        return [thread for thread in threads if thread["key"] in stars or any(
+        return [thread for thread in threads if conversation_keys(thread) & stars or any(
             message["handle"] in recent for message in thread["messages"]
         )]
 
@@ -412,7 +413,10 @@ class BackendOperations:
         if thread is None:
             raise NotFoundError("thread no longer exists in local history")
         try:
-            result = self.dependencies.starred_threads.set_starred(thread_key, bool(starred))
+            store = self.dependencies.starred_threads
+            if not starred:
+                store.discard(list(conversation_keys(thread)))
+            result = store.set_starred(thread["key"], bool(starred))
             self._conversations.invalidate()
             return result
         except ValueError as error:
@@ -603,13 +607,17 @@ class BackendOperations:
             if key not in selected:
                 selected.append(key)
 
-        current_keys = {
-            str(thread["key"]) for thread in self._conversations.threads()
+        by_key = {
+            key: thread for thread in self._conversations.threads()
+            for key in conversation_keys(thread)
         }
-        if not set(selected).issubset(current_keys):
+        if any(key not in by_key for key in selected):
             raise NotFoundError(
                 "a selected thread no longer exists in local history"
             )
+        current = [by_key[key] for key in selected]
+        selected = list(dict.fromkeys(thread["key"] for thread in current))
+        preference_keys = {key for thread in current for key in conversation_keys(thread)}
 
         storage = self.dependencies.storage
         if storage is not None and not storage.status.can_write:
@@ -630,7 +638,7 @@ class BackendOperations:
             anchor_keys: dict[int, str] = {}
             recent_evidence_ids: set[int] = set()
             for event in recent:
-                projected_key = thread_key(event)
+                projected_key = thread_key(event, self.dependencies.contacts)
                 if event.get("kind") not in MESSAGE_KINDS:
                     continue
                 if projected_key is None or projected_key not in selected:
@@ -659,7 +667,7 @@ class BackendOperations:
                 anchored_key = anchor_keys.get(event_id)
                 if anchored_key is None:
                     continue
-                resolved_key = thread_key(event)
+                resolved_key = thread_key(event, self.dependencies.contacts)
                 if (
                     anchored_key.startswith("group:")
                     and resolved_key is not None
@@ -672,7 +680,7 @@ class BackendOperations:
                 if event.get("kind") in MESSAGE_KINDS
                 and (
                     int(event.get(HISTORY_ROW_ID_FIELD, -1)) in anchor_keys
-                    or thread_key(event) in resolved_keys
+                    or thread_key(event, self.dependencies.contacts) in resolved_keys
                 )
             ]
             event_ids = recent_evidence_ids | {
@@ -703,7 +711,7 @@ class BackendOperations:
                 ) or (
                     kind == "sms_seen"
                     and (
-                        thread_key(event) in resolved_keys
+                        thread_key(event, self.dependencies.contacts) in resolved_keys
                         or str(event.get("handle") or "") in selected_handles
                     )
                 )
@@ -726,7 +734,7 @@ class BackendOperations:
 
         self._forget_confirmed_groups(resolved_keys)
         if self.dependencies.starred_threads is not None:
-            self.dependencies.starred_threads.discard(selected)
+            self.dependencies.starred_threads.discard(list(preference_keys))
         self.invalidate_conversations()
         return len(selected)
 

--- a/src/blueferry/contacts.py
+++ b/src/blueferry/contacts.py
@@ -16,7 +16,7 @@ import dbus
 
 from blueferry.bus import obex
 from blueferry.contact_repository import ContactRecord, ContactRepository
-from blueferry.events import is_email_shaped, normalize_phone
+from blueferry.events import canonical_address, is_email_shaped, normalize_phone
 from blueferry.limits import (
     MAX_CONTACT_ADDRESS_CHARS,
     MAX_CONTACT_ADDRESSES_PER_CARD,
@@ -235,6 +235,36 @@ class ContactsResolver:
             if name:
                 for address in (*phones, *emails):
                     self._mem.setdefault(address, set()).add(name)
+
+        self._thread_addresses: dict[str, tuple[str, ...]] = {}
+        # Count record ownership, not names: two people can share a name or number.
+        owners: dict[str, set[int]] = {}
+        for index, (_name, phones, emails) in enumerate(self._records):
+            for address in (*phones, *emails):
+                identity = canonical_address(address)
+                if identity is None:
+                    continue
+                identities = [identity]
+                if identity.startswith("phone:"):
+                    number = identity.removeprefix("phone:")
+                    if len(number) == 10:
+                        identities.append(f"phone:1{number}")
+                    elif len(number) == 11 and number.startswith("1"):
+                        identities.append(f"phone:{number[1:]}")
+                for value in identities:
+                    owners.setdefault(value, set()).add(index)
+        unique: dict[int, list[str]] = {}
+        for identity, records in owners.items():
+            if len(records) == 1:
+                unique.setdefault(next(iter(records)), []).append(identity)
+        for addresses in unique.values():
+            ordered = tuple(sorted(addresses))
+            for identity in ordered:
+                self._thread_addresses[identity] = ordered
+
+    def thread_addresses(self, raw: str | None) -> tuple[str, ...]:
+        """Unambiguous address identities from the same PBAP record."""
+        return self._thread_addresses.get(canonical_address(raw) or "", ())
 
     def refresh(self) -> int:
         """Re-read the SQLite cache into memory. Returns new count."""

--- a/src/blueferry/conversation_state.py
+++ b/src/blueferry/conversation_state.py
@@ -97,7 +97,8 @@ class ConversationState:
         )
 
     def thread(self, key: str) -> Thread | None:
-        return next((thread for thread in self.threads if thread.key == key), None)
+        return next((thread for thread in self.threads
+                     if thread.key == key or key in thread.extra.get("aliases", [])), None)
 
     def apply_snapshot(self, snapshot: ConversationSnapshot) -> None:
         if snapshot.status is not None:
@@ -115,7 +116,8 @@ class ConversationState:
                     self.confirmed_groups[thread.key] = thread.confirmation_token
             keys = {thread.key for thread in self.threads}
             if self.selected_key not in keys:
-                retained = next(
+                alias = self.thread(self.selected_key)
+                retained = alias.key if alias is not None else next(
                     (
                         thread.key
                         for thread in self.threads

--- a/src/blueferry/events.py
+++ b/src/blueferry/events.py
@@ -100,14 +100,13 @@ def parse_map_timestamp(ts: str | None) -> datetime | None:
     """Parse MAP's timestamp format: '20260519T181423' or with timezone suffix."""
     if not ts:
         return None
-    # MAP timestamps: YYYYMMDDTHHMMSS, optionally followed by a TZ offset
-    base = ts[:15]
     try:
-        dt = datetime.strptime(base, "%Y%m%dT%H%M%S")
-    except ValueError:
+        fmt = "%Y%m%dT%H%M%S" + ("%z" if len(ts) > 15 else "")
+        dt = datetime.strptime(ts, fmt)
+        # Offset-free MAP dates use local time on the date of the message.
+        return dt if dt.tzinfo is not None else dt.astimezone()
+    except (ValueError, OverflowError, OSError):
         return None
-    # MAP timestamps are local-time on the iPhone; we'll treat as local
-    return dt.replace(tzinfo=datetime.now().astimezone().tzinfo)
 
 
 # ---- event types --------------------------------------------------------

--- a/src/blueferry/grouping.py
+++ b/src/blueferry/grouping.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import hashlib
 import re
 import unicodedata
-from datetime import datetime
+from datetime import datetime, timezone
 
 from blueferry.ancs.constants import MESSAGES_APP_ID
 from blueferry.events import canonical_address, safe_event_address
@@ -36,8 +36,8 @@ def _seen_at(event: dict) -> datetime | None:
     if not raw:
         return None
     try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except ValueError:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except (ValueError, OverflowError, OSError):
         return None
 
 

--- a/src/blueferry/history.py
+++ b/src/blueferry/history.py
@@ -45,12 +45,9 @@ def _event_datetime(event: EventRecord) -> datetime | None:
     if not raw:
         return None
     try:
-        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except ValueError:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except (ValueError, OverflowError, OSError):
         return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=datetime.now().astimezone().tzinfo)
-    return parsed.astimezone(timezone.utc)
 
 
 def _serialize(event: EventRecord, storage: StorageSecurity | None) -> str:

--- a/src/blueferry/qt/qml/ConversationLogic.qml
+++ b/src/blueferry/qt/qml/ConversationLogic.qml
@@ -7,7 +7,8 @@ QtObject {
 
     function threadByKey(threads, key) {
         for (let index = 0; index < threads.length; ++index) {
-            if (threads[index].key === key) return threads[index]
+            if (threads[index].key === key
+                || (threads[index].aliases || []).indexOf(key) >= 0) return threads[index]
         }
         return null
     }

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -142,9 +142,8 @@ Kirigami.ApplicationWindow {
         }
 
         function onThreadsChanged() {
-            if (root.selectedThreadKey !== "" && root.selectedThread() === null) {
-                root.selectedThreadKey = ""
-            }
+            const selected = root.selectedThread()
+            root.selectedThreadKey = selected ? selected.key : ""
             if (root.pendingMessageHandle !== "")
                 root.selectMessage(root.pendingMessageHandle)
             root.warnAboutRosterChanges()
@@ -758,12 +757,23 @@ Kirigami.ApplicationWindow {
                                     Controls.ToolTip.visible: hovered
                                     onClicked: root.selectedThreadKey = ""
                                 }
-                                Controls.Label {
+                                ColumnLayout {
                                     Layout.fillWidth: true
-                                    text: messagesPage.thread ? messagesPage.thread.name : qsTr("Conversation")
-                                    textFormat: Text.PlainText
-                                    font.bold: true
-                                    elide: Text.ElideRight
+                                    Controls.Label {
+                                        Layout.fillWidth: true
+                                        text: messagesPage.thread ? messagesPage.thread.name : qsTr("Conversation")
+                                        textFormat: Text.PlainText
+                                        font.bold: true
+                                        elide: Text.ElideRight
+                                    }
+                                    Controls.Label {
+                                        Layout.fillWidth: true
+                                        visible: messagesPage.thread !== null && !messagesPage.thread.is_group
+                                        text: visible ? qsTr("Reply to: %1").arg(messagesPage.thread.recipients.join(", ")) : ""
+                                        textFormat: Text.PlainText
+                                        elide: Text.ElideRight
+                                        opacity: 0.7
+                                    }
                                 }
                                 Controls.ToolButton {
                                     visible: messagesPage.thread !== null

--- a/src/blueferry/threads.py
+++ b/src/blueferry/threads.py
@@ -61,7 +61,7 @@ class ConversationIndex:
         return self._threads
 
     def find(self, key: str) -> dict | None:
-        return next((thread for thread in self.threads() if thread["key"] == key), None)
+        return next((thread for thread in self.threads() if key in conversation_keys(thread)), None)
 
 
 def _event_time(event: dict) -> str:
@@ -102,11 +102,22 @@ def group_confirmation_token(
     return "\n".join((str(roster_warning_id or ""), *identities))
 
 
-def thread_key(event: dict) -> str | None:
+def _contact_addresses(resolver, address: str | None) -> tuple[str, ...]:
+    lookup = getattr(resolver, "thread_addresses", None)
+    return lookup(address) if lookup is not None else ()
+
+
+def conversation_keys(thread: dict) -> set[str]:
+    return {thread["key"], *thread.get("aliases", [])}
+
+
+def thread_key(event: dict, resolver=None) -> str | None:
     """Return a stable key that never relies on a contact display name."""
     if event.get("group_key"):
         return str(event["group_key"])
-    identity = canonical_address(safe_event_address(event))
+    address = safe_event_address(event)
+    addresses = _contact_addresses(resolver, address)
+    identity = addresses[0] if addresses else canonical_address(address)
     return f"address:{identity}" if identity else None
 
 
@@ -121,7 +132,7 @@ def build_threads(events: list[dict], resolver=None) -> list[dict]:
     for event in correlated:
         if event.get("kind") not in MESSAGE_KINDS:
             continue
-        key = thread_key(event)
+        key = thread_key(event, resolver)
         if key is None:
             # An untrusted, non-address sender is visible in notification
             # history but can never become a reply target.
@@ -136,6 +147,9 @@ def build_threads(events: list[dict], resolver=None) -> list[dict]:
         if thread is None:
             thread = {
                 "key": key,
+                "aliases": [
+                    f"address:{value}" for value in _contact_addresses(resolver, address)
+                ] if not is_group else [],
                 "name": _thread_name(event, address, resolver),
                 "is_group": is_group,
                 "members": [
@@ -205,6 +219,7 @@ def build_threads(events: list[dict], resolver=None) -> list[dict]:
 
         message = {
             "handle": str(event.get("handle") or ""),
+            "address": address or "",
             "body": str(event.get("body") or ""),
             "timestamp": _event_time(event),
             "outgoing": event.get("kind") == "sms_sent",
@@ -222,6 +237,14 @@ def build_threads(events: list[dict], resolver=None) -> list[dict]:
                 thread["prompt_sender"] = str(event["group_observed_sender"])
 
     for thread in by_key.values():
+        thread["messages"].sort(key=lambda message: message["timestamp"])
+        if not thread["is_group"]:
+            messages = thread["messages"]
+            latest_incoming = next(
+                (message for message in reversed(messages) if not message["outgoing"]),
+                messages[-1],
+            )
+            thread["recipients"] = [latest_incoming["address"]]
         if thread.get("participants_required"):
             thread["reply_ready"] = False
         thread["messages_truncated"] = len(thread["messages"]) > MAX_THREAD_MESSAGES
@@ -244,7 +267,7 @@ def sort_threads(
     decorated: list[dict] = []
     for thread in threads:
         item = dict(thread)
-        item["starred"] = str(item.get("key") or "") in selected
+        item["starred"] = bool(conversation_keys(item) & selected)
         decorated.append(item)
     return sorted(
         decorated,
@@ -260,7 +283,7 @@ def find_thread(events: list[dict], key: str, resolver=None) -> dict | None:
     """Look up one current thread by its opaque backend key."""
     return next(
         (thread for thread in build_threads(events, resolver)
-         if thread["key"] == key),
+         if key in conversation_keys(thread)),
         None,
     )
 

--- a/src/blueferry/threads.py
+++ b/src/blueferry/threads.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Iterable
+from datetime import datetime
 from pathlib import Path
 from typing import TypeAlias
 
@@ -66,6 +67,14 @@ class ConversationIndex:
 
 def _event_time(event: dict) -> str:
     return str(event.get("timestamp") or event.get("seen_at") or "")
+
+
+def _timestamp_order(value: str) -> float:
+    """Compare instants: outgoing local offsets and incoming UTC may differ."""
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except (ValueError, OverflowError, OSError):
+        return float("-inf")
 
 
 def _thread_name(event: dict, address: str | None, resolver) -> str:
@@ -231,13 +240,13 @@ def build_threads(events: list[dict], resolver=None) -> list[dict]:
             "body_truncated": bool(event.get("body_truncated", False)),
         }
         thread["messages"].append(message)
-        if message["timestamp"] >= thread["last_ts"]:
+        if _timestamp_order(str(message["timestamp"])) >= _timestamp_order(thread["last_ts"]):
             thread["last_ts"] = message["timestamp"]
             if event.get("group_observed_sender"):
                 thread["prompt_sender"] = str(event["group_observed_sender"])
 
     for thread in by_key.values():
-        thread["messages"].sort(key=lambda message: message["timestamp"])
+        thread["messages"].sort(key=lambda message: _timestamp_order(message["timestamp"]))
         if not thread["is_group"]:
             messages = thread["messages"]
             latest_incoming = next(
@@ -273,7 +282,7 @@ def sort_threads(
         decorated,
         key=lambda item: (
             bool(item.get("starred")),
-            str(item.get("last_ts") or ""),
+            _timestamp_order(str(item.get("last_ts") or "")),
         ),
         reverse=True,
     )

--- a/src/blueferry/time_display.py
+++ b/src/blueferry/time_display.py
@@ -45,7 +45,8 @@ def format_message_timestamp(
         single_line = raw.replace("\r", " ").replace("\n", " ")
         return terminal_text(single_line)[:32]
 
-    reference = now or datetime.now().astimezone()
+    # A naive local reference lets each message use its own date's DST offset.
+    reference = now or datetime.now()
     local = _in_reference_timezone(parsed, reference)
     if reference.tzinfo is not None:
         reference = reference.replace(tzinfo=None)

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -783,7 +783,9 @@ class BlueFerryApp(App[None]):
         title = thread.name + ("  ·  Group" if thread.is_group else "")
         recipients = ", ".join(thread.recipients)
         title_view.update(Text(_one_line(title)))
-        subtitle_view.update(Text(_one_line(recipients)))
+        subtitle_view.update(Text(_one_line(
+            recipients if thread.is_group else f"Reply to: {recipients}"
+        )))
         unread = _unread_count(thread)
         badge_view.update(
             Text(f"{unread} unread" if unread else "up to date")

--- a/src/blueferry/ui/conversations.py
+++ b/src/blueferry/ui/conversations.py
@@ -238,7 +238,13 @@ class ConversationsPage(Gtk.Box):
             "clicked", self._open_group_roster_dialog
         )
         conversation_header.append(self.back_button)
-        conversation_header.append(self._conversation_title)
+        titles = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, hexpand=True)
+        titles.append(self._conversation_title)
+        self._reply_destination = Gtk.Label(
+            xalign=0, ellipsize=_ELLIPSIZE_END, css_classes=["dim-label"], visible=False,
+        )
+        titles.append(self._reply_destination)
+        conversation_header.append(titles)
         conversation_header.append(self._group_roster_button)
         right.append(conversation_header)
         right.append(Gtk.Separator())
@@ -537,6 +543,7 @@ class ConversationsPage(Gtk.Box):
             self._msg_list.remove_all()
             for message in current.messages:
                 self._append_bubble(message, is_group=current.is_group)
+            self._update_conversation_title(current)
             can_reply = current.reply_ready
             self._entry.set_sensitive(can_reply)
             self._send_btn.set_sensitive(can_reply)
@@ -643,13 +650,20 @@ class ConversationsPage(Gtk.Box):
         self._send_btn.set_sensitive(can_reply)
         self._update_group_roster_banner(thread)
         self._stack.set_visible_child_name("messages")
-        self._conversation_title.set_label(thread.name)
+        self._update_conversation_title(thread)
         self.split_view.set_show_content(True)
         self._msg_list.remove_all()
         for message in thread.messages:
             self._append_bubble(message, is_group=thread.is_group)
         self._scroll_to_bottom()
         self._mark_selected_read()
+
+    def _update_conversation_title(self, thread: Thread) -> None:
+        self._conversation_title.set_label(thread.name)
+        self._reply_destination.set_visible(not thread.is_group)
+        self._reply_destination.set_label(
+            _("Reply to: {address}").format(address=", ".join(thread.recipients))
+        )
 
     def _mark_selected_read(self) -> None:
         window = self.get_root()

--- a/tests/test_contact_threads.py
+++ b/tests/test_contact_threads.py
@@ -1,0 +1,149 @@
+"""PBAP identity grouping and operations on the resulting conversations."""
+from types import SimpleNamespace
+
+import pytest
+
+from blueferry import backend_operations, config
+from blueferry.backend_operations import BackendDependencies, BackendOperations
+from blueferry.contact_repository import ContactRepository
+from blueferry.contacts import ContactsResolver
+from blueferry.conversation_state import ConversationSnapshot, ConversationState
+from blueferry.history import append_event, read_events
+from blueferry.models import Thread
+from blueferry.starred_threads import StarredThreadsStore
+from blueferry.threads import build_threads, conversation_keys
+
+PHONE = "+15551111111"
+OTHER_PHONE = "+15552222222"
+EMAIL = "sarah@example.com"
+
+
+@pytest.fixture
+def contacts(monkeypatch):
+    records = [("Dr. Sarah Bourget", [PHONE[1:], OTHER_PHONE[1:]], [EMAIL])]
+    monkeypatch.setattr(ContactRepository, "load", lambda _self: records)
+    return ContactsResolver(), records
+
+
+def message(address, index, *, outgoing=False, **extra):
+    return {
+        "kind": "sms_sent" if outgoing else "sms_received",
+        "handle": f"message-{index}", "sender_address": address,
+        "body": str(index), "timestamp": f"2026-09-06T10:00:{index:02d}Z",
+        "is_read": False, **extra,
+    }
+
+
+def test_contact_history_is_chronological_and_replies_to_latest_incoming(contacts):
+    resolver, _ = contacts
+    events = [message(PHONE, 3, outgoing=True), message(PHONE, 0),
+              message(EMAIL.upper(), 2), message(OTHER_PHONE, 1)]
+    [thread] = build_threads(events, resolver)
+    assert thread["name"] == "Dr. Sarah Bourget"
+    assert not thread["is_group"]
+    assert thread["recipients"] == [EMAIL.upper()]
+    assert [item["body"] for item in thread["messages"]] == ["0", "1", "2", "3"]
+    assert [item["address"] for item in thread["messages"]] == [
+        PHONE, OTHER_PHONE, EMAIL.upper(), PHONE,
+    ]
+    assert thread["unread"]
+    assert f"address:phone:{PHONE[1:]}" in conversation_keys(thread)
+    assert f"address:email:{EMAIL}" in conversation_keys(thread)
+    assert build_threads(list(reversed(events)), resolver)[0] == thread
+
+
+def test_outgoing_only_contact_uses_latest_destination(contacts):
+    resolver, _ = contacts
+    [thread] = build_threads([message(PHONE, 1, outgoing=True),
+                              message(EMAIL, 2, outgoing=True)], resolver)
+    assert thread["recipients"] == [EMAIL]
+
+
+def test_shared_addresses_and_same_names_do_not_join_people(contacts):
+    resolver, records = contacts
+    records.append(("Dr. Sarah Bourget", ["5551111111"], ["other@example.com"]))
+    resolver.refresh()
+    threads = build_threads([
+        message(PHONE, 0), message(EMAIL, 1), message("other@example.com", 2),
+        message(OTHER_PHONE, 3),
+    ], resolver)
+    assert sorted(len(thread["messages"]) for thread in threads) == [1, 1, 2]
+    shared = next(thread for thread in threads if thread["recipients"] == [PHONE])
+    assert shared["aliases"] == []
+    assert resolver.thread_addresses("5551111111") == ()
+
+
+def test_group_conversation_stays_separate_from_contact(contacts):
+    resolver, _ = contacts
+    threads = build_threads([
+        message(PHONE, 0), message(EMAIL, 1, group_key="group:test", group_name="Family",
+                                   group_recipients=[PHONE, OTHER_PHONE]),
+    ], resolver)
+    assert len(threads) == 2
+    group = next(thread for thread in threads if thread["is_group"])
+    assert group["key"] == "group:test"
+    assert group["aliases"] == []
+
+
+def test_contact_refresh_recomputes_grouping_without_rewriting_messages(contacts):
+    resolver, records = contacts
+    events = [message(PHONE, 0), message(EMAIL, 1)]
+    [original] = build_threads(events, resolver)
+    records.append(("Someone Else", ["15554444444"], []))
+    records[0] = ("Sarah Renamed", list(reversed(records[0][1])), [EMAIL])
+    records.reverse()
+    resolver.refresh()
+    assert build_threads(events, resolver)[0]["key"] == original["key"]
+    records[:] = [("Sarah", [PHONE[1:]], []), ("Sarah", [], [EMAIL])]
+    resolver.refresh()
+    assert len(build_threads(events, resolver)) == 2
+    records.clear()
+    resolver.refresh()
+    assert len(build_threads(events, resolver)) == 2
+    assert "group_key" not in events[0]
+
+
+def test_merged_operations_preserve_stars_read_and_delete_all_addresses(
+    contacts, tmp_path, monkeypatch,
+):
+    resolver, _ = contacts
+    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
+    monkeypatch.setattr(backend_operations, "MAX_CONVERSATION_EVENTS", 2)
+    for event in [message(PHONE, 0), message(OTHER_PHONE, 1), message(EMAIL, 2),
+                  message("+15553333333", 3)]:
+        append_event(event)
+    store = StarredThreadsStore(tmp_path / "settings.json")
+    old_key = f"address:phone:{PHONE[1:]}"
+    store.set_starred(old_key, True)
+    sessions = SimpleNamespace(map=None, map_path="/map")
+    operations = BackendOperations(sessions, BackendDependencies(
+        contacts=resolver, starred_threads=store,
+    ))
+    merged = operations.list_threads(10)[0]
+    assert merged["starred"]
+    assert len(merged["messages"]) == 3
+    assert operations.mark_thread_read(old_key) == 3
+    assert not operations.list_threads(10)[0]["unread"]
+    sent = []
+    monkeypatch.setattr(operations, "_queue_send", lambda *args: sent.append(args[:2]))
+    sessions.map = object()
+    operations.send_to_thread(old_key, "hello", False, lambda _: None, lambda _: None)
+    assert sent == [(EMAIL, "hello")]
+    operations.set_thread_starred(old_key, False)
+    assert store.keys() == []
+    operations.set_thread_starred(merged["key"], True)
+    assert operations.list_threads(10)[0]["starred"]
+    assert operations.delete_threads([old_key, merged["key"]], True) == 1
+    assert [event["sender_address"] for event in read_events()] == ["+15553333333"]
+    assert store.keys() == []
+
+
+def test_selected_address_follows_merge_even_when_old_message_is_not_in_snapshot(contacts):
+    resolver, _ = contacts
+    state = ConversationState()
+    old = Thread.from_dict(build_threads([message(PHONE, 0)])[0])
+    state.apply_snapshot(ConversationSnapshot(None, (old,)))
+    merged = Thread.from_dict(build_threads([message(EMAIL, 1)], resolver)[0])
+    state.apply_snapshot(ConversationSnapshot(None, (merged,)))
+    assert state.selected_key == merged.key
+    assert state.thread(old.key) == merged

--- a/tests/test_contact_threads.py
+++ b/tests/test_contact_threads.py
@@ -147,3 +147,27 @@ def test_selected_address_follows_merge_even_when_old_message_is_not_in_snapshot
     state.apply_snapshot(ConversationSnapshot(None, (merged,)))
     assert state.selected_key == merged.key
     assert state.thread(old.key) == merged
+
+
+def test_local_send_stays_at_tail_of_utc_contact_history(contacts, monkeypatch):
+    from blueferry import threads as threads_module
+
+    resolver, _ = contacts
+    # Limiting the view used to hide the send entirely after string sorting.
+    monkeypatch.setattr(threads_module, "MAX_THREAD_MESSAGES", 2)
+    events = [
+        message(EMAIL, 0, timestamp="2026-09-06T19:05:00+00:00"),
+        message(PHONE, 1, timestamp="2026-09-06T19:06:00+00:00"),
+        message(OTHER_PHONE, 2, outgoing=True, timestamp="2026-09-06T15:53:33-04:00"),
+        message("+15553333333", 3, timestamp="2026-09-06T19:50:00Z"),
+    ]
+    merged, other = build_threads(events, resolver)
+    assert [item["handle"] for item in merged["messages"]] == ["message-1", "message-2"]
+    assert merged["messages"][-1]["outgoing"]
+    assert merged["last_ts"] == "2026-09-06T15:53:33-04:00"
+    assert other["last_ts"] == "2026-09-06T19:50:00Z"
+    assert merged["recipients"] == [PHONE]
+    events.append(message(EMAIL, 4, timestamp="2026-09-06T15:54:00-04:00"))
+    merged = build_threads(events, resolver)[0]
+    assert [item["handle"] for item in merged["messages"]] == ["message-2", "message-4"]
+    assert merged["recipients"] == [EMAIL]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,7 +2,7 @@
 SmsEvent construction from MAP Message1 properties."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 
@@ -54,13 +54,15 @@ class TestParseMapTimestamp:
         assert result.minute == 14
         assert result.second == 23
 
-    def test_with_tz_suffix(self):
-        # iPhone may append a TZ offset; we just take the first 15 chars
-        result = parse_map_timestamp("20260519T181423+0500")
+    @pytest.mark.parametrize(("suffix", "hours"), [("+0500", 5), ("-0400", -4), ("Z", 0)])
+    def test_with_tz_suffix(self, suffix, hours):
+        result = parse_map_timestamp(f"20260519T181423{suffix}")
         assert result is not None
-        assert result.day == 19
+        assert result.hour == 18
+        assert result.utcoffset() == timedelta(hours=hours)
 
-    @pytest.mark.parametrize("bad", ["", None, "not a date", "20260", "abcdef"])
+    @pytest.mark.parametrize("bad", ["", None, "not a date", "20260", "abcdef", "20260519T181423+2500",
+                                     "20260519T181423garbage"])
     def test_invalid_returns_none(self, bad):
         assert parse_map_timestamp(bad) is None
 

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -1,0 +1,68 @@
+"""Cross-season local dates and mixed-offset history regressions."""
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from blueferry import events, history, time_display
+from blueferry.threads import build_threads
+
+
+@pytest.fixture(autouse=True)
+def summer_in_new_york(monkeypatch):
+    import time
+
+    class SummerClock(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            local = cls(2026, 7, 15, 12)
+            return local if tz is None else local.astimezone(tz)
+
+    with monkeypatch.context() as patch:
+        patch.setenv("TZ", "America/New_York")
+        time.tzset()
+        for module in (events, history, time_display):
+            patch.setattr(module, "datetime", SummerClock)
+        try:
+            yield
+        finally:
+            patch.undo()
+            time.tzset()
+
+
+@pytest.mark.parametrize(("month", "offset"), [(1, -5), (7, -4)])
+def test_offset_free_map_date_uses_its_own_season(month, offset):
+    parsed = events.parse_map_timestamp(f"2026{month:02d}15T120000")
+    assert parsed.hour == 12
+    assert parsed.utcoffset() == timedelta(hours=offset)
+
+
+def test_default_display_converts_winter_message_using_winter_offset():
+    assert time_display.format_message_timestamp("2026-01-15T17:00:00Z") == "Jan 15 at 12:00 PM"
+    # Getting the offset wrong can also shift the calendar date.
+    assert time_display.format_message_timestamp("2026-01-16T04:30:00Z") == "Jan 15 at 11:30 PM"
+
+
+def test_retention_boundary_uses_historical_offset_for_timezone_free_rows(tmp_path):
+    path = tmp_path / "events.sqlite"
+    cutoff = datetime(2026, 7, 15, 16, tzinfo=timezone.utc) - timedelta(days=180)
+    for label, minutes in [("expired", -30), ("retained", 30)]:
+        local = (cutoff + timedelta(minutes=minutes)).astimezone(ZoneInfo("America/New_York"))
+        history.append_event({
+            "kind": "sms_received", "body": label,
+            "seen_at": local.replace(tzinfo=None).isoformat(),
+        }, path=path)
+    assert history.prune_events(path=path, retention_days=180) == 1
+    assert [event["body"] for event in history.read_events(path=path)] == ["retained"]
+
+
+def test_group_correlation_accepts_local_timestamp_alongside_utc():
+    threads = build_threads([
+        {"kind": "sms_received", "handle": "message-1", "sender_address": "+15551111111",
+         "contact_name": "Alice", "body": "hi", "seen_at": "2026-01-15T12:00:00"},
+        {"kind": "ancs_notification", "app_id": "com.apple.MobileSMS", "title": "Alice",
+         "subtitle": "Family", "body": "hi", "seen_at": "2026-01-15T17:00:01Z"},
+    ])
+    assert len(threads) == 1
+    assert threads[0]["is_group"]
+    assert threads[0]["name"] == "Family"


### PR DESCRIPTION
Direct messages from one contact's phone numbers and email addresses previously appeared as separate conversations with the same display name. BlueFerry now combines addresses that belong unambiguously to one synced PBAP contact into a chronological conversation.

Replies use the latest incoming address, or the latest outgoing destination when there are no incoming messages. GTK, Qt, Quickshell, and the TUI show a Reply to label. Messages retain their original addresses, and direct replies still send to exactly one destination.

Address ownership is computed across contact records, including the existing North American number variants. Shared addresses, separate contacts with identical names, and group conversations remain separate. Contact refreshes rebuild the grouping without rewriting history. Previous address keys remain aliases for selection, stars, read state, sends, and deletion; deleting a merged conversation removes its retained history across all its addresses.

Timestamp ordering compares actual instants across UTC and local offsets, keeping outgoing messages in their correct position before history truncation. MAP parsing preserves explicit offsets and interprets local dates using their historical daylight-saving offset. Display and retention likewise use the offset on the message date. Group correlation normalizes timezone-free historical timestamps and aware timestamps to UTC before subtraction.

Validation: 907 tests passed in an isolated D-Bus session. Ruff, Bandit, mypy, and QML syntax checks passed. Regression coverage includes explicit MAP offsets, malformed suffixes, cross-season display and retention boundaries, mixed timezone-free/aware group correlation, plus contact grouping, reply routing, ambiguous ownership, group separation, contact refreshes, combined operations, selection across a merge, and mixed-timezone message ordering. A reported missing send was confirmed present in the live backend snapshot; the corrected ordering places it immediately before the subsequent incoming message. The updated build has not been installed for an end-to-end device test.
