### PR TITLE
Polish conversation scrolling, contact search, and Fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ install them with apt:
 sudo apt install ./blueferry-backend_*.deb ./blueferry-gtk_*.deb
 ```
 
-For Fedora, download the `.noarch.rpm` files whose `.fcNN` tag matches your
-Fedora release, then install them with dnf:
+For Fedora 43 or 44, download the `.fc43.noarch.rpm` files. For Fedora 45,
+download the `.fc45.noarch.rpm` files. Fedora 43 and 44 use the same package
+build. Install the backend and your client with dnf:
 
 ```bash
-fedora_release=$(rpm -E %fedora)
-sudo dnf install ./blueferry-backend-*.fc${fedora_release}.noarch.rpm \
-  ./blueferry-gtk-*.fc${fedora_release}.noarch.rpm
+# Fedora 43 and 44; use fc45 below for Fedora 45.
+sudo dnf install ./blueferry-backend-*.fc43.noarch.rpm \
+  ./blueferry-gtk-*.fc43.noarch.rpm
 ```
 
 Replace the GTK package with `blueferry-qt` for KDE Plasma. Arch and CachyOS

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -727,7 +727,11 @@ class BlueFerryApp(App[None]):
         selected: list[Thread] = []
         for thread in self.state.threads:
             preview = thread.messages[-1].body if thread.messages else ""
-            haystack = " ".join((thread.name, *thread.recipients, preview)).casefold()
+            addresses = []
+            for key in thread.extra.get("aliases", []):
+                kind, _, address = str(key).removeprefix("address:").partition(":")
+                addresses.append(f"+{address}" if kind == "phone" else address)
+            haystack = " ".join((thread.name, *thread.recipients, *addresses, preview)).casefold()
             if query in haystack:
                 selected.append(thread)
         return selected

--- a/src/blueferry/ui/conversations.py
+++ b/src/blueferry/ui/conversations.py
@@ -531,6 +531,10 @@ class ConversationsPage(Gtk.Box):
         self._client.send_message(recipient, body, done, failed)
 
     def _apply_threads(self, loaded) -> bool:
+        previous = self._state.selected
+        adjustment = self._msg_scroll.get_vadjustment()
+        position = adjustment.get_value()
+        following = adjustment.get_upper() - adjustment.get_page_size() - position <= 32
         threads = tuple(
             thread
             for thread in loaded
@@ -540,16 +544,20 @@ class ConversationsPage(Gtk.Box):
         self._rebuild_thread_list()
         current = self._state.selected
         if current is not None:
-            self._msg_list.remove_all()
-            for message in current.messages:
-                self._append_bubble(message, is_group=current.is_group)
+            switched = previous is None or previous.key not in {
+                current.key, *current.extra.get("aliases", []),
+            }
+            if switched or previous.messages != current.messages:
+                self._msg_list.remove_all()
+                for message in current.messages:
+                    self._append_bubble(message, is_group=current.is_group)
+                self._scroll_to(None if switched or following else position)
             self._update_conversation_title(current)
             can_reply = current.reply_ready
             self._entry.set_sensitive(can_reply)
             self._send_btn.set_sensitive(can_reply)
             self._update_group_roster_banner(current)
             self._stack.set_visible_child_name("messages")
-            self._scroll_to_bottom()
         else:
             self._entry.set_sensitive(False)
             self._send_btn.set_sensitive(False)
@@ -655,7 +663,7 @@ class ConversationsPage(Gtk.Box):
         self._msg_list.remove_all()
         for message in thread.messages:
             self._append_bubble(message, is_group=thread.is_group)
-        self._scroll_to_bottom()
+        self._scroll_to()
         self._mark_selected_read()
 
     def _update_conversation_title(self, thread: Thread) -> None:
@@ -933,10 +941,14 @@ class ConversationsPage(Gtk.Box):
         row.set_child(outer)
         self._msg_list.append(row)
 
-    def _scroll_to_bottom(self) -> None:
+    def _scroll_to(self, position: float | None = None) -> None:
+        selected = self._state.selected_key
+
         def _scroll() -> bool:
+            if self._state.selected_key != selected:
+                return False
             adj = self._msg_scroll.get_vadjustment()
-            adj.set_value(adj.get_upper())
+            adj.set_value(adj.get_upper() if position is None else position)
             return False
 
         GLib.idle_add(_scroll)

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -330,3 +330,39 @@ def test_roster_warning_fallback_id_is_stable_for_partial_payload() -> None:
     assert ConversationState.roster_warning_id(thread) == (
         "group:named:crew:Casey"
     )
+
+
+@pytest.mark.parametrize(
+    ("position", "changed", "expected"),
+    [(200, True, [200]), (780, True, [None]), (200, False, [])],
+)
+def test_refresh_preserves_reading_position_and_only_follows_from_bottom(position, changed, expected):
+    from unittest.mock import Mock
+
+    before = _thread()
+    state = ConversationState()
+    state.apply_snapshot(ConversationSnapshot(None, (before,)))
+    adjustment = Mock()
+    adjustment.get_value.return_value = position
+    adjustment.get_upper.return_value = 1000
+    adjustment.get_page_size.return_value = 200
+    page = Mock(_state=state)
+    page._msg_scroll.get_vadjustment.return_value = adjustment
+    after = _thread(messages=(*before.messages, before.messages[0])) if changed else before
+
+    conversations.ConversationsPage._apply_threads(page, [after])
+
+    assert [call.args[0] for call in page._scroll_to.call_args_list] == expected
+    assert page._msg_list.remove_all.call_count == int(changed)
+
+
+def test_delayed_scroll_does_not_move_a_different_conversation(monkeypatch):
+    from unittest.mock import Mock
+
+    callbacks = []
+    monkeypatch.setattr(conversations.GLib, "idle_add", lambda callback: callbacks.append(callback))
+    page = Mock(_state=SimpleNamespace(selected_key="Alice"))
+    conversations.ConversationsPage._scroll_to(page, 200)
+    page._state.selected_key = "Bob"
+    assert callbacks[0]() is False
+    page._msg_scroll.get_vadjustment.assert_not_called()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -681,3 +681,21 @@ def test_read_sync_waits_for_narrow_chat_and_pauses_under_dialogs():
             app._maybe_mark_selected_read()
             assert marked == []
     _run_headless(scenario())
+
+
+def test_search_finds_other_addresses_in_a_merged_contact(monkeypatch):
+    from types import SimpleNamespace
+
+    state = TuiState(_Backend())
+    merged = replace(_thread("one", "Alice", "hello"), extra={"aliases": [
+        "address:phone:15559998888", "address:email:alice@example.com",
+    ]})
+    state.threads = [merged, _thread("two", "Bob", "unrelated")]
+    app = BlueFerryApp(state, monitor_factory=lambda: None)
+    search = SimpleNamespace(value="")
+    monkeypatch.setattr(app, "query_one", lambda *_args: search)
+    for query in ["5559998888", "+15559998888", "ALICE@EXAMPLE.COM", "Alice", "hello", "15551111111"]:
+        search.value = query
+        assert merged in app._filtered_threads()
+    search.value = "address:email:"
+    assert app._filtered_threads() == []


### PR DESCRIPTION
GTK conversation refreshes previously jumped to the bottom while a user was reading older messages. Refreshes now preserve the scroll position, follow new messages only when already near the bottom, and avoid rebuilding unchanged message lists. A delayed scroll cannot move a different conversation after selection changes.

TUI conversation search now includes every address in a merged contact, including phone numbers with a leading plus. The README also directs Fedora 44 users to the available fc43 packages instead of nonexistent fc44 artifacts.

Validation: 912 tests passed in an isolated D-Bus session; Ruff, mypy, and Bandit passed. The focused search regression passed again after adding leading-plus matching. Regression coverage checks scroll preservation, following from the bottom, unchanged refreshes, stale scroll callbacks, and alternate contact address searches. GTK scroll behavior was tested with fake widgets, not an interactive desktop session.
