### PR TITLE
Remove unused helpers, redundant branches, and low-value tests

### DIFF
--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -603,7 +603,7 @@ class AncsClient:
         self._authorized = False
         self._reset_requests()
 
-    def _stop_bluez_notifications(self) -> bool:
+    def _stop_bluez_notifications(self) -> None:
         """Remove notification ownership created by us while ATT is up."""
         current_paths = tuple(
             path
@@ -613,7 +613,6 @@ class AncsClient:
         remaining_paths = tuple(sorted(
             self._owned_notify_paths.difference(current_paths)
         ))
-        stopped_all = True
         for path in current_paths + remaining_paths:
             try:
                 dbus.Interface(
@@ -627,11 +626,9 @@ class AncsClient:
                     self._owned_notify_paths.discard(path)
                     log.debug("ANCS notification was already stopped: %s", path)
                 else:
-                    stopped_all = False
                     log.debug("could not stop ANCS notification", exc_info=True)
             else:
                 self._owned_notify_paths.discard(path)
-        return stopped_all
 
     def _try_subscribe(self) -> None:
         if self._notify_started:

--- a/src/blueferry/contacts.py
+++ b/src/blueferry/contacts.py
@@ -161,16 +161,13 @@ def pull_phonebook(
 
         # obexd may remove a completed transfer object just before its output
         # becomes visible. Give the local write a bounded grace period.
-        if status in ("complete", "gone"):
-            for _ in range(20):
-                if out.exists() and out.stat().st_size > 0:
-                    break
-                time.sleep(0.1)
+        for _ in range(20):
+            if out.exists() and out.stat().st_size > 0:
+                break
+            time.sleep(0.1)
 
         size = out.stat().st_size if out.exists() else 0
         log.info("transfer status: %s, file size: %d bytes", status, size)
-        if status == "error":
-            raise RuntimeError("PBAP transfer failed")
         if size == 0:
             raise RuntimeError(
                 "iPhone returned an empty phonebook; verify Settings → "

--- a/src/blueferry/grouping.py
+++ b/src/blueferry/grouping.py
@@ -41,18 +41,6 @@ def _seen_at(event: dict) -> datetime | None:
         return None
 
 
-def _safe_address(event: dict) -> str | None:
-    return safe_event_address(event)
-
-
-def _body_matches(map_body: str, ancs_body: str) -> bool:
-    if map_body == ancs_body:
-        return True
-    # ANCS requests at most 256 characters.  A longer MAP body can therefore
-    # match its exact ANCS prefix, but short partial strings never do.
-    return len(ancs_body) == 256 and map_body.startswith(ancs_body)
-
-
 def _unique_names(names: list[str]) -> list[str]:
     by_folded: dict[str, str] = {}
     for raw in names:
@@ -300,7 +288,7 @@ def correlate_group_events(events: list[dict], resolver=None) -> list[dict]:
         if not str(event.get("kind") or "").startswith("sms_"):
             continue
         name = str(event.get("contact_name") or "").strip()
-        address = _safe_address(event)
+        address = safe_event_address(event)
         if name and address:
             addresses_by_name.setdefault(name.casefold(), set()).add(address)
 
@@ -360,7 +348,7 @@ def correlate_group_events(events: list[dict], resolver=None) -> list[dict]:
             sms.setdefault(CORRELATED_ANCS_ROW_IDS_FIELD, []).append(
                 source_row_id
             )
-        sender_address = _safe_address(sms)
+        sender_address = safe_event_address(sms)
         if sender_name_verified and sender_address:
             addresses_by_name.setdefault(sender_title.casefold(), set()).add(
                 sender_address

--- a/src/blueferry/threads.py
+++ b/src/blueferry/threads.py
@@ -288,15 +288,6 @@ def sort_threads(
     )
 
 
-def find_thread(events: list[dict], key: str, resolver=None) -> dict | None:
-    """Look up one current thread by its opaque backend key."""
-    return next(
-        (thread for thread in build_threads(events, resolver)
-         if key in conversation_keys(thread)),
-        None,
-    )
-
-
 def bound_thread_response(
     threads: list[dict], *, max_bytes: int = MAX_DBUS_JSON_BYTES,
 ) -> list[dict]:

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -390,29 +390,6 @@ def test_records_tolerate_a_malformed_stored_row(tmp_path, monkeypatch):
     ]
 
 
-def test_records_are_ordered_once_at_load(tmp_path, monkeypatch):
-    """Paging slices an already-sorted cache rather than re-sorting."""
-    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
-    monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
-    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
-
-    resolver = ContactsResolver.__new__(ContactsResolver)
-    resolver.storage = None
-    resolver._repository = SimpleNamespace(load=lambda: [
-        ("Zoe Last", ["15550000002"], []),
-        ("Alice Example", ["15551234567"], []),
-    ])
-    resolver._mem = {}
-    resolver._records = []
-    resolver._warm()
-
-    assert [record[0] for record in resolver._records] == [
-        "Alice Example", "Zoe Last",
-    ]
-    assert resolver.records(0, 1) is not resolver._records
-    assert resolver.records(0, 1) == [("Alice Example", ["15551234567"], [])]
-
-
 def test_resolver_only_equates_nanp_country_code_variants() -> None:
     resolver = ContactsResolver.__new__(ContactsResolver)
     resolver._mem = {"15551234567": {"Alice"}}

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -302,12 +302,6 @@ def test_gtk_message_composer_placeholder_tracks_empty_buffer() -> None:
     assert resize_requests == [True, True]
 
 
-def test_participant_editor_keeps_unique_nonempty_lines() -> None:
-    assert conversations._participant_lines(
-        " +15551111111 \n\nbeau@example.com\n+15551111111\n"
-    ) == ["+15551111111", "beau@example.com"]
-
-
 def test_roster_banner_keeps_unexpected_sender_after_later_known_sender() -> None:
     title = conversations._group_roster_banner_title(_thread(
         name="Crew",

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -191,32 +191,6 @@ def test_gui_pairing_requires_confirmation_before_replacing_saved_target() -> No
     assert "--replace-saved-mac" in quickshell
 
 
-def test_all_pairing_clients_expose_compatibility_mode() -> None:
-    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
-    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
-    quickshell = _qml_bundle(ROOT / "data/quickshell")
-
-    for client in (gtk, qt, quickshell):
-        assert "Compatibility pairing" in client
-        assert "iOS 18 or earlier" in client
-    assert "compatibility_mode=" in gtk
-    assert "compatibilityMode.checked" in qt
-    assert "text: compatibilityMode.checked" in qt
-    assert '"--compatibility-mode"' in quickshell
-
-
-def test_all_pairing_clients_expose_explicit_pairing_mode() -> None:
-    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
-    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
-    quickshell = _qml_bundle(ROOT / "data/quickshell")
-
-    for client in (gtk, qt, quickshell):
-        assert "Use explicit Bluetooth pairing" in client
-    assert "explicit_pairing=" in gtk
-    assert "explicitPairing.checked" in qt
-    assert '"--explicit-pairing"' in quickshell
-
-
 def test_capability_checks_do_not_disable_pairing_buttons() -> None:
     gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
     qt = (ROOT / "src/blueferry/qt/qml/Main.qml").read_text()
@@ -276,36 +250,6 @@ def test_quickshell_keeps_private_dbus_values_out_of_process_arguments() -> None
         '"/usr/bin/dbus-monitor"',
     ):
         assert cli_adapter not in quickshell
-
-
-def test_all_gui_clients_can_choose_a_bluetooth_controller() -> None:
-    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
-    qt = _qml_bundle(ROOT / "src/blueferry/qt/qml")
-    quickshell = _qml_bundle(ROOT / "data/quickshell")
-
-    assert "_adapter_row" in gtk
-    assert "selectAdapter" in qt
-    assert "Bluetooth Controller" in gtk
-    assert "Controller:" in qt
-    assert "adapterCombo" in quickshell
-    assert "--adapter" in quickshell
-    assert 'pairProcess.command.push("--adapter", root.adapterName)' in quickshell
-    assert 'forgetProcess.command.push("--adapter", root.configuredAdapter)' in quickshell
-    assert '"--interactive-approval"' in quickshell
-    assert "forgetProcess.write(\"yes\\n\")" in quickshell
-    assert "property string configuredAdapter" in quickshell
-    assert (
-        "root.configuredAdapter = root.targetSaved ? (parsed.adapter || \"\") : \"\""
-    ) in quickshell
-    assert "if (root.targetSaved && parsed.adapter)" not in quickshell
-    assert "scanAfterCompatibility" in quickshell
-    assert 'command.push("--scan-seconds", "24")' in quickshell
-    assert "scan_seconds=DISCOVERY_SECONDS if scan else 0" in (
-        ROOT / "src/blueferry/ui/status.py"
-    ).read_text()
-    assert "scan_seconds=DISCOVERY_SECONDS if scan else 0" in (
-        ROOT / "src/blueferry/qt/controller.py"
-    ).read_text()
 
 
 def test_quickshell_package_ships_shared_qml_without_the_qt_client() -> None:


### PR DESCRIPTION
Remove unused find_thread and _body_matches helpers, replace the _safe_address forwarding wrapper with direct calls, and drop unreachable PBAP status branches already handled by wait_for_transfer. Remove the unused success boolean from ANCS notification cleanup while preserving its ownership updates and error handling.

Remove five low-value tests: private contact-cache ordering already covered through public pagination, the GTK alias of the shared participant parser, and three source-string checks for pairing modes and controller selection. Retain behavioral, security, and packaging checks.

Net reduction: 112 lines across seven files. No new abstractions or tests.

Validation: all 909 remaining tests pass in an isolated D-Bus session; Ruff, mypy, and Bandit pass.
