### PR TITLE
Simplify backend compatibility guidance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,9 +49,9 @@ is checked against the dbus-python decorators in the service implementation.
 (currently 2 for roster-bound replies), independently of the package release.
 Additive compatible changes keep that generation. All shared-client operations
 check the advertised generation on the same owner-bound proxy they invoke;
-missing, malformed, or different generations produce an update-and-restart
-error before reads or mutations. Compatibility is rechecked after daemon
-replacement. Lifecycle recovery reads status without this check so it can
+missing, malformed, or different generations prompt users to install the most
+recent version of BlueFerry before reads or mutations. Compatibility is rechecked
+after daemon replacement. Lifecycle recovery reads status without this check so it can
 restart an outdated packaged daemon first, then requires a compatible API.
 Source installs also require compatibility even without package markers.
 

--- a/src/blueferry/protocol.py
+++ b/src/blueferry/protocol.py
@@ -19,7 +19,7 @@ def backend_compatibility_error(status: Mapping[str, object]) -> str | None:
         return None
     return (
         "This BlueFerry client is incompatible with the running backend. "
-        "Update both the client and backend, then restart BlueFerry."
+        "Install the most recent version of BlueFerry."
     )
 
 # Read/control timeouts are part of the client policy rather than toolkit

--- a/tests/test_client_models.py
+++ b/tests/test_client_models.py
@@ -104,7 +104,7 @@ def test_incompatible_backend_is_rejected_before_reads_or_sends(status):
         lambda: client.send_to_thread("address:phone:15551111111", "draft"),
         lambda: client.send("+15551111111", "draft"),
     ):
-        with pytest.raises(BackendError, match=r"incompatible.*Update both"):
+        with pytest.raises(BackendError, match=r"incompatible.*Install the most recent version"):
             action()
     assert operations == []
 


### PR DESCRIPTION
Replace the backend compatibility instructions with: “Install the most recent version of BlueFerry.” Remove the manual restart instruction, since packaged clients already recover stale backend builds automatically.

Validation: all 11 client-model tests passed; Ruff and `git diff --check` passed.
