### PR TITLE
Share client refresh and conversation logic

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,15 +82,28 @@ model conversion; synchronous and toolkit-specific scheduling remain separate.
 Qt message composition and group confirmation live in standalone QML components
 with an explicit bridge dependency; the window handles navigation.
 GTK and Qt contact searches use `ConversationState` request sequences, and Qt
-retains that state across sends. Qt and TUI share the snapshot loader, which
-keeps failed reads distinct from empty history. Quickshell's transport coalesces
+retains that typed state across refreshes and sends. Qt and TUI share the snapshot
+loader; GTK feeds its independent asynchronous read results into the same state.
+Snapshots distinguish an untouched source, a failed read, and a successful empty
+history. Status and history errors clear only when their own read recovers, and a
+failed status read marks the backend unavailable while retaining the last history.
+The shared reply planner validates the roster token retained by a confirmation
+dialog and provides blocked-reply messages. Qt additionally binds its pending
+dialog to the original conversation and draft. Quickshell's transport coalesces
 contact queries and delivers only the latest request's result or failure.
 
-`ConversationLogic.qml` holds the Qt/Quickshell thread lookup, unread, roster
-warning, and participant parsing helpers. The Quickshell source wrapper imports
+`Thread` derives unread counts, group approval tokens, and roster-warning keys.
+Both Qt and the Quickshell bridge serialize these fields for QML, so JavaScript
+does not recompute them. The token implementation lives in `recipients` and is
+also used by the backend; it preserves the spelling of displayed addresses.
+These presentation fields are computed by the client from existing backend
+fields and require no new D-Bus API generation.
+
+`ConversationLogic.qml` holds Qt/Quickshell thread lookup, warning deduplication,
+and participant parsing helpers. The Quickshell source wrapper imports
 the canonical Qt QML file for development; its package installs that file directly
 so it has no runtime dependency on the Qt client. Python/QML behavior tests cover
-the shared contracts, including group signatures and participant line parsing.
+the shared contracts, including serialized approval tokens and participant line parsing.
 GTK and TUI use the same Python participant parser in `recipients`.
 
 `ListThreads` includes retained starred conversations even when their last event

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,6 +87,8 @@ loader; GTK feeds its independent asynchronous read results into the same state.
 Snapshots distinguish an untouched source, a failed read, and a successful empty
 history. Status and history errors clear only when their own read recovers, and a
 failed status read marks the backend unavailable while retaining the last history.
+Storage is shown as unavailable after failed reads, with the last known policy
+retained; before the first successful read, the policy is unknown.
 The shared reply planner validates the roster token retained by a confirmation
 dialog and provides blocked-reply messages. Qt additionally binds its pending
 dialog to the original conversation and draft. Quickshell's transport coalesces

--- a/TESTING.md
+++ b/TESTING.md
@@ -65,6 +65,10 @@ generations before operations, including after daemon replacement; lifecycle
 tests verify that packaged upgrade recovery runs before compatibility checks.
 Client-model and setup-facade tests use plain mappings and monkeypatched
 operations; they must not probe BlueZ merely to exercise serialization.
+Shared conversation tests exercise partial failures and recovery in either order,
+and reject stale recipient approvals even when the backend remembers the new
+roster. Presentation tests feed the same derived thread metadata through Qt and
+Quickshell and retain adapter coverage for delayed confirmation dialogs.
 Bluetooth compatibility tests feed inert `btmgmt info` text through the parser
 and fake BlueZ's object inventory. They assert capabilities rather than
 controller brands and never execute `btmgmt` against the host.

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -58,7 +58,7 @@ from blueferry.obex.map_query import list_recent_messages
 from blueferry.obex.map_read import set_session_messages_read
 from blueferry.obex.map_send import send_group_message, send_message
 from blueferry.protocol import MESSAGES_API_VERSION
-from blueferry.recipients import InvalidRecipient, validate_recipient
+from blueferry.recipients import InvalidRecipient, group_confirmation_token, validate_recipient
 from blueferry.storage_security import (
     STORAGE_POLICIES,
     CorruptStorageError,
@@ -71,7 +71,6 @@ from blueferry.threads import (
     bound_thread_response,
     build_threads,
     conversation_keys,
-    group_confirmation_token,
     sort_threads,
     thread_key,
 )

--- a/src/blueferry/conversation_state.py
+++ b/src/blueferry/conversation_state.py
@@ -6,14 +6,18 @@ from enum import Enum
 from typing import Protocol
 
 from blueferry.client import BackendError
+from blueferry.i18n import _
 from blueferry.models import BackendStatus, Thread
 
 
 @dataclass(frozen=True, slots=True)
 class ConversationSnapshot:
-    status: BackendStatus | None
-    threads: tuple[Thread, ...] | None
-    failures: tuple[str, ...] = ()
+    """Independent read results; an absent result and error leave that source alone."""
+
+    status: BackendStatus | None = None
+    threads: tuple[Thread, ...] | None = None
+    status_error: str = ""
+    thread_error: str = ""
 
 
 class SnapshotClient(Protocol):
@@ -25,18 +29,18 @@ def fetch_conversation_snapshot(
     client: SnapshotClient, *, limit: int = 1000,
 ) -> ConversationSnapshot:
     """Fetch each independently; None distinguishes failure from an empty result."""
-    failures: list[str] = []
+    status_error = thread_error = ""
     status: BackendStatus | None = None
     threads: tuple[Thread, ...] | None = None
     try:
         status = client.status()
     except BackendError as error:
-        failures.append(str(error))
+        status_error = str(error)
     try:
         threads = tuple(client.threads(limit))
     except BackendError as error:
-        failures.append(str(error))
-    return ConversationSnapshot(status, threads, tuple(failures))
+        thread_error = str(error)
+    return ConversationSnapshot(status, threads, status_error, thread_error)
 
 
 class ReplyDisposition(str, Enum):
@@ -45,6 +49,18 @@ class ReplyDisposition(str, Enum):
     NO_THREAD = "no-thread"
     READ_ONLY = "read-only"
     CONFIRM_GROUP = "confirm-group"
+    STALE_GROUP = "stale-group"
+
+    @property
+    def message(self) -> str:
+        return {
+            ReplyDisposition.NO_THREAD: _("Select a conversation first"),
+            ReplyDisposition.READ_ONLY: _("This conversation is read-only"),
+            ReplyDisposition.CONFIRM_GROUP: _("Group reply requires participant confirmation"),
+            ReplyDisposition.STALE_GROUP: _(
+                "The group changed. Review the recipients and send again."
+            ),
+        }.get(self, "")
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,7 +76,7 @@ class ReplyPlan:
 
     @property
     def expected_group_token(self) -> str:
-        return self.thread.confirmation_token if self.thread and self.thread.is_group else ""
+        return self.thread.confirmation_token if self.thread else ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,6 +94,8 @@ class ConversationState:
         self.status = BackendStatus()
         self.selected_key = ""
         self.error = ""
+        self._status_error = ""
+        self._thread_error = ""
         self.notice = ""
         self.confirmed_groups: dict[str, str] = {}
         self.warned_roster_changes: set[str] = set()
@@ -107,7 +125,14 @@ class ConversationState:
     def apply_snapshot(self, snapshot: ConversationSnapshot) -> None:
         if snapshot.status is not None:
             self.status = snapshot.status
+            self._status_error = ""
+        elif snapshot.status_error:
+            self._status_error = snapshot.status_error
+            self.status = BackendStatus(extra={"error": snapshot.status_error})
+        if snapshot.thread_error:
+            self._thread_error = snapshot.thread_error
         if snapshot.threads is not None:
+            self._thread_error = ""
             previous = self.selected
             previous_handle = (
                 previous.messages[-1].handle
@@ -138,9 +163,9 @@ class ConversationState:
                     if self.select_first and self.threads
                     else ""
                 )
-        self.error = "; ".join(
-            failure for failure in snapshot.failures if failure
-        )
+        self.error = "; ".join(dict.fromkeys(
+            error for error in (self._status_error, self._thread_error) if error
+        ))
 
     def move(self, delta: int) -> None:
         if not self.threads:
@@ -162,6 +187,7 @@ class ConversationState:
         *,
         thread_key: str | None = None,
         confirm_group: bool = False,
+        expected_group_token: str | None = None,
     ) -> ReplyPlan:
         selected = self.thread(thread_key or self.selected_key)
         message = body.strip()
@@ -169,6 +195,8 @@ class ConversationState:
             return ReplyPlan(ReplyDisposition.EMPTY, selected, "")
         if selected is None:
             return ReplyPlan(ReplyDisposition.NO_THREAD, None, message)
+        if expected_group_token is not None and expected_group_token != selected.confirmation_token:
+            return ReplyPlan(ReplyDisposition.STALE_GROUP, selected, message)
         if not selected.reply_ready:
             return ReplyPlan(ReplyDisposition.READ_ONLY, selected, message)
         if (
@@ -211,18 +239,11 @@ class ConversationState:
         self.selected_key = updated.key
         self.confirmed_groups.pop(updated.key, None)
 
-    @staticmethod
-    def roster_warning_id(thread: Thread) -> str:
-        return (
-            thread.roster_warning_id
-            or f"{thread.key}:{thread.unexpected_sender or 'unknown'}"
-        )
-
     def next_roster_warning(self) -> Thread | None:
         for thread in self.threads:
             if not thread.roster_changed:
                 continue
-            warning_id = self.roster_warning_id(thread)
+            warning_id = thread.roster_warning_key
             if warning_id in self.warned_roster_changes:
                 continue
             self.warned_roster_changes.add(warning_id)

--- a/src/blueferry/conversation_state.py
+++ b/src/blueferry/conversation_state.py
@@ -91,7 +91,7 @@ class ConversationState:
     def __init__(self, *, select_first: bool = True) -> None:
         self.select_first = select_first
         self.threads: list[Thread] = []
-        self.status = BackendStatus()
+        self.status = BackendStatus(storage_policy="", storage_state="unavailable")
         self.selected_key = ""
         self.error = ""
         self._status_error = ""
@@ -128,7 +128,11 @@ class ConversationState:
             self._status_error = ""
         elif snapshot.status_error:
             self._status_error = snapshot.status_error
-            self.status = BackendStatus(extra={"error": snapshot.status_error})
+            self.status = BackendStatus(
+                storage_policy=self.status.storage_policy,
+                storage_state="unavailable",
+                extra={"error": snapshot.status_error},
+            )
         if snapshot.thread_error:
             self._thread_error = snapshot.thread_error
         if snapshot.threads is not None:

--- a/src/blueferry/models.py
+++ b/src/blueferry/models.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from blueferry.connectivity import is_map_connection_refused
+from blueferry.recipients import group_confirmation_token
 from blueferry.time_display import format_message_timestamp
 
 
@@ -224,6 +225,9 @@ class Thread:
             "prompt_sender",
             "roster_warning_id",
             "unread",
+            "unread_count",
+            "confirmation_token",
+            "roster_warning_key",
             "starred",
             "group_confirmed",
         }
@@ -256,14 +260,22 @@ class Thread:
 
     @property
     def unread(self) -> bool:
-        return any(
-            not message.outgoing and not message.read for message in self.messages
-        )
+        return self.unread_count > 0
+
+    @property
+    def unread_count(self) -> int:
+        return sum(not message.outgoing and not message.read for message in self.messages)
 
     @property
     def confirmation_token(self) -> str:
-        identities = sorted({str(value) for value in self.recipients if str(value)})
-        return "\n".join((self.roster_warning_id, *identities))
+        return (
+            group_confirmation_token(self.recipients, self.roster_warning_id)
+            if self.is_group else ""
+        )
+
+    @property
+    def roster_warning_key(self) -> str:
+        return self.roster_warning_id or f"{self.key}:{self.unexpected_sender or 'unknown'}"
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -282,6 +294,9 @@ class Thread:
             "prompt_sender": self.prompt_sender,
             "roster_warning_id": self.roster_warning_id,
             "unread": self.unread,
+            "unread_count": self.unread_count,
+            "confirmation_token": self.confirmation_token,
+            "roster_warning_key": self.roster_warning_key,
             "starred": self.starred,
             "group_confirmed": self.group_confirmed,
         }

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -27,7 +27,7 @@ from blueferry.conversation_state import (
     fetch_conversation_snapshot,
 )
 from blueferry.i18n import _
-from blueferry.models import BackendStatus, Thread
+from blueferry.models import BackendStatus
 from blueferry.onboarding import OnboardingState, effective_compatibility
 from blueferry.protocol import BUS_NAME, EVENTS_IFACE, OBJECT_PATH
 from blueferry.qt.tasks import Task
@@ -403,38 +403,28 @@ class BridgeController(QObject):
 
         self._run(lambda: self._setup.compatibility(selected), completed, failed)
 
-    def _snapshot(self) -> dict:
+    def _snapshot(self) -> tuple[ConversationSnapshot, list[dict] | None]:
         snapshot = fetch_conversation_snapshot(self._backend)
-        error = "; ".join(snapshot.failures)
-        return {
-            "threads": [item.to_dict() for item in snapshot.threads]
-                if snapshot.threads is not None else None,
-            "status": snapshot.status.to_dict() if snapshot.status is not None
-                else {"daemon": False, "error": error},
-            "thread_error": error,
-        }
+        # Prepare QML's copy on the worker; keep typed models for shared decisions.
+        threads = (
+            [thread.to_dict() for thread in snapshot.threads]
+            if snapshot.threads is not None else None
+        )
+        return snapshot, threads
 
-    def _apply_snapshot(self, snapshot: object) -> None:
-        value = snapshot if isinstance(snapshot, dict) else {}
-        threads = value.get("threads")
-        if isinstance(threads, list):
-            self._threads = list(threads)
-            self._state.apply_snapshot(ConversationSnapshot(
-                None, tuple(Thread.from_dict(item) for item in threads),
-            ))
+    def _apply_snapshot(self, result: tuple[ConversationSnapshot, list[dict] | None]) -> None:
+        snapshot, threads = result
+        self._state.apply_snapshot(snapshot)
+        if threads is not None:
+            self._threads = threads
             self.threadsChanged.emit()
-        status = value.get("status")
-        if isinstance(status, dict):
-            self._status = dict(status)
+        if snapshot.status is not None or snapshot.status_error:
+            self._status = self._state.status.to_dict()
             self.statusChanged.emit()
             self._maybe_unlock_storage()
         self._update_onboarding_stage()
         self._refresh_pairing_issue_report()
-        thread_error = str(value.get("thread_error") or "")
-        if thread_error:
-            self._set_error(thread_error)
-        elif self._status.get("daemon"):
-            self._set_error("")
+        self._set_error(self._state.error)
 
     @Slot()
     def refresh(self) -> None:
@@ -460,21 +450,24 @@ class BridgeController(QObject):
     def sendThread(self, key: str, body: str, confirm_group: bool) -> None:
         draft = body
         state = self._state
-        state.threads = [Thread.from_dict(value) for value in self._threads]
-        thread = state.thread(key)
-        if confirm_group:
-            expected = (key, body.strip(), thread.confirmation_token) if thread else None
-            if expected is None or self._pending_group != expected:
-                self._pending_group = None
-                self._set_error(_("The group changed. Review the recipients and send again."))
-                return
+        pending = self._pending_group
         self._pending_group = None
-        plan = state.plan_reply(body, thread_key=key, confirm_group=confirm_group)
+        if confirm_group:
+            if pending is None or pending[:2] != (key, body.strip()):
+                self._set_error(ReplyDisposition.STALE_GROUP.message)
+                return
+        plan = state.plan_reply(
+            body, thread_key=key, confirm_group=confirm_group,
+            expected_group_token=pending[2] if confirm_group else None,
+        )
+        thread = plan.thread
         if plan.disposition is ReplyDisposition.CONFIRM_GROUP and thread is not None:
-            self._pending_group = (key, plan.body, thread.confirmation_token)
+            self._pending_group = (key, plan.body, plan.expected_group_token)
             self.groupConfirmationRequested.emit(key, draft, "\n".join(thread.recipients))
             return
         if not plan.ready:
+            if plan.disposition.message:
+                self._set_error(plan.disposition.message)
             return
 
         def completed(_value: object) -> None:

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -322,6 +322,7 @@ class BridgeController(QObject):
             self.setupLoadedChanged.emit()
             if status:
                 self._status = dict(status)
+                self._state.status = BackendStatus.from_dict(self._status)
                 self.statusChanged.emit()
                 self._maybe_unlock_storage()
             self._set_error("")
@@ -622,6 +623,7 @@ class BridgeController(QObject):
     def _storage_updated(self, value: object) -> None:
         if isinstance(value, dict):
             self._status.update(value)
+            self._state.status = BackendStatus.from_dict(self._status)
             self.statusChanged.emit()
         self.refresh()
 

--- a/src/blueferry/qt/qml/ConversationLogic.qml
+++ b/src/blueferry/qt/qml/ConversationLogic.qml
@@ -24,33 +24,18 @@ QtObject {
     }
 
     function threadIsUnread(thread) {
-        if (!thread) return false
-        if (thread.unread === true || thread.unread === false) return thread.unread
-        const messages = thread.messages || []
-        for (let index = 0; index < messages.length; ++index) {
-            if (!messages[index].outgoing && messages[index].read === false) return true
-        }
-        return false
+        return !!thread && thread.unread === true
     }
 
     function groupSignature(thread) {
-        if (!thread || !thread.is_group) return ""
-        const unique = []
-        const recipients = thread.recipients || []
-        for (let index = 0; index < recipients.length; ++index) {
-            const address = String(recipients[index] || "")
-            if (address !== "" && unique.indexOf(address) < 0) unique.push(address)
-        }
-        unique.sort()
-        return [String(thread.roster_warning_id || "")].concat(unique).join("\n")
+        return thread && thread.is_group ? String(thread.confirmation_token || "") : ""
     }
 
     function nextRosterWarning(threads) {
         for (let index = 0; index < threads.length; ++index) {
             const thread = threads[index]
             if (!thread.roster_changed) continue
-            const warningId = thread.roster_warning_id
-                || thread.key + ":" + (thread.unexpected_sender || "unknown")
+            const warningId = thread.roster_warning_key
             if (warnedRosterChanges[warningId] === true) continue
             warnedRosterChanges[warningId] = true
             return thread

--- a/src/blueferry/qt/qml/Main.qml
+++ b/src/blueferry/qt/qml/Main.qml
@@ -91,6 +91,8 @@ Kirigami.ApplicationWindow {
 
     function storageStatusText() {
         const status = bridge.status || ({})
+        if (status.daemon !== true)
+            return qsTr("Unavailable")
         if (status.storage_policy === "none")
             return qsTr("Disabled")
         if (status.storage_state === "ready")

--- a/src/blueferry/recipients.py
+++ b/src/blueferry/recipients.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 
 # Recipients are eventually placed in vCard properties, so accepted forms are
 # deliberately narrower than their full formal grammars. Newlines and other
@@ -64,3 +65,12 @@ def validate_recipient(recipient: str) -> str:
 def participant_lines(value: str) -> list[str]:
     """Parse the roster editor without changing address spelling or order."""
     return list(dict.fromkeys(line.strip() for line in value.splitlines() if line.strip()))
+
+
+def group_confirmation_token(
+    recipients: Iterable[object],
+    roster_warning_id: object = "",
+) -> str:
+    """Bind approval to the displayed roster; preserve address spelling."""
+    identities = sorted({str(value) for value in recipients if str(value)})
+    return "\n".join((str(roster_warning_id or ""), *identities))

--- a/src/blueferry/threads.py
+++ b/src/blueferry/threads.py
@@ -163,15 +163,6 @@ def _message_sender(event: dict, address: str | None, resolver) -> str:
     return address or "(unknown)"
 
 
-def group_confirmation_token(
-    recipients: Iterable[object],
-    roster_warning_id: object = "",
-) -> str:
-    """Stable token for one group roster, used to skip repeat send confirms."""
-    identities = sorted({str(value) for value in recipients if str(value)})
-    return "\n".join((str(roster_warning_id or ""), *identities))
-
-
 def _contact_addresses(resolver, address: str | None) -> tuple[str, ...]:
     lookup = getattr(resolver, "thread_addresses", None)
     return lookup(address) if lookup is not None else ()

--- a/src/blueferry/tui.py
+++ b/src/blueferry/tui.py
@@ -90,10 +90,6 @@ def _initials(name: str) -> str:
     return " ".join(initials)
 
 
-def _unread_count(thread: Thread) -> int:
-    return sum(not message.outgoing and not message.read for message in thread.messages)
-
-
 class TuiState(ConversationState):
     def __init__(self, client: _Client) -> None:
         super().__init__()
@@ -123,20 +119,11 @@ class TuiState(ConversationState):
             body,
             thread_key=thread_key,
             confirm_group=confirm_group,
+            expected_group_token=expected_group_token,
         )
-        if plan.disposition is ReplyDisposition.NO_THREAD:
-            self.error = "Select a conversation first"
-            return False
-        if plan.disposition is ReplyDisposition.READ_ONLY:
-            self.error = "This conversation is read-only"
-            return False
-        if plan.disposition is ReplyDisposition.CONFIRM_GROUP:
-            self.error = "Group reply requires participant confirmation"
-            return False
         if not plan.ready or plan.thread is None:
-            return False
-        if expected_group_token is not None and expected_group_token != plan.expected_group_token:
-            self.error = "The group changed. Review the recipients and send again."
+            if plan.disposition.message:
+                self.error = plan.disposition.message
             return False
         try:
             self.client.send_to_thread(
@@ -244,7 +231,7 @@ class ConversationItem(ListItem):
         self.thread_key = thread.key
         latest = thread.messages[-1] if thread.messages else None
         preview = _one_line(latest.body) if latest else "No messages yet"
-        unread = _unread_count(thread)
+        unread = thread.unread_count
         detail = f"{unread} unread" if unread else ("group" if thread.is_group else "direct")
         avatar = Static(Text(_initials(thread.name), justify="center"), classes="avatar")
         star = "★ " if thread.starred else ""
@@ -796,7 +783,7 @@ class BlueFerryApp(App[None]):
         subtitle_view.update(Text(_one_line(
             recipients if thread.is_group else f"Reply to: {recipients}"
         )))
-        unread = _unread_count(thread)
+        unread = thread.unread_count
         badge_view.update(
             Text(f"{unread} unread" if unread else "up to date")
         )

--- a/src/blueferry/ui/conversations.py
+++ b/src/blueferry/ui/conversations.py
@@ -123,8 +123,6 @@ class ConversationsPage(Gtk.Box):
         self._pending_open_handle: str | None = None
         self._reload_pending = False
         self._reload_again = False
-        self._thread_error = ""
-        self._status_error = ""
         self._backend_error_banner = Adw.Banner(use_markup=False)
         self.append(self._backend_error_banner)
         self._new_destination: str | None = None
@@ -409,13 +407,13 @@ class ConversationsPage(Gtk.Box):
         self._client.list_threads_async(self._apply_threads, self._reload_failed)
 
     def _reload_failed(self, message: str) -> bool:
-        self._thread_error = message
+        self._state.apply_snapshot(ConversationSnapshot(thread_error=message))
         self._update_backend_error_banner()
         self._reload_finished()
         return False
 
     def _update_backend_error_banner(self) -> None:
-        message = self._status_error or self._thread_error
+        message = self._state.error
         self._backend_error_banner.set_title(message)
         self._backend_error_banner.set_revealed(bool(message))
 
@@ -429,16 +427,15 @@ class ConversationsPage(Gtk.Box):
         self._client.get_status_async(self._apply_status, self._status_failed)
 
     def _apply_status(self, status: BackendStatus) -> bool:
-        self._status_error = ""
-        self._update_backend_error_banner()
         self._state.apply_snapshot(ConversationSnapshot(status, None))
+        self._update_backend_error_banner()
         self._map_refused_banner.set_revealed(
             map_connection_refused(status.to_dict())
         )
         return False
 
     def _status_failed(self, message: str) -> bool:
-        self._status_error = message
+        self._state.apply_snapshot(ConversationSnapshot(status_error=message))
         self._update_backend_error_banner()
         self._map_refused_banner.set_revealed(False)
         return False
@@ -546,8 +543,6 @@ class ConversationsPage(Gtk.Box):
         self._client.send_message(recipient, body, done, failed)
 
     def _apply_threads(self, loaded) -> bool:
-        self._thread_error = ""
-        self._update_backend_error_banner()
         previous = self._state.selected
         adjustment = self._msg_scroll.get_vadjustment()
         position = adjustment.get_value()
@@ -558,6 +553,7 @@ class ConversationsPage(Gtk.Box):
             if isinstance(thread, Thread) and thread.key
         )
         self._state.apply_snapshot(ConversationSnapshot(None, threads))
+        self._update_backend_error_banner()
         self._rebuild_thread_list()
         current = self._state.selected
         if current is not None:
@@ -1000,17 +996,16 @@ class ConversationsPage(Gtk.Box):
 
         def responded(_dialog, response: str) -> None:
             if response == "send":
-                current = self._state.thread(thread.key)
-                if current is None or current.confirmation_token != thread.confirmation_token:
-                    self._toast(_("The group changed. Review the recipients and send again."))
-                    return
                 plan = self._state.plan_reply(
                     body,
                     thread_key=thread.key,
                     confirm_group=True,
+                    expected_group_token=thread.confirmation_token,
                 )
                 if plan.ready:
                     self._dispatch_send(plan)
+                elif plan.disposition.message:
+                    self._toast(plan.disposition.message)
 
         dialog.connect("response", responded)
         dialog.present(self.get_root())

--- a/tests/test_backend_operations.py
+++ b/tests/test_backend_operations.py
@@ -24,8 +24,9 @@ from blueferry.limits import (
     MAX_THREAD_BODY_CHARS,
 )
 from blueferry.models import Thread
+from blueferry.recipients import group_confirmation_token
 from blueferry.starred_threads import StarredThreadsStore
-from blueferry.threads import build_threads, group_confirmation_token
+from blueferry.threads import build_threads
 
 
 class _Sessions:

--- a/tests/test_confirmed_groups.py
+++ b/tests/test_confirmed_groups.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from blueferry.confirmed_groups import ConfirmedGroupsStore
-from blueferry.threads import group_confirmation_token
+from blueferry.recipients import group_confirmation_token
 
 
 def test_store_remembers_a_roster_across_instances(tmp_path) -> None:

--- a/tests/test_conversation_state.py
+++ b/tests/test_conversation_state.py
@@ -54,7 +54,7 @@ def test_partial_snapshot_preserves_successful_state_and_selection() -> None:
     state.selected_key = "two"
 
     state.apply_snapshot(
-        ConversationSnapshot(None, None, ("temporary failure",))
+        ConversationSnapshot(thread_error="temporary failure")
     )
 
     assert state.status is original_status
@@ -74,6 +74,37 @@ def test_selection_follows_the_same_message_when_thread_key_changes() -> None:
     )
 
     assert state.selected_key == "new"
+
+
+@pytest.mark.parametrize("recover_status_first", [False, True])
+def test_refresh_errors_clear_only_when_their_own_source_recovers(recover_status_first):
+    state = ConversationState()
+    thread = _thread("kept")
+    state.apply_snapshot(ConversationSnapshot(BackendStatus(daemon=True), (thread,)))
+    state.apply_snapshot(ConversationSnapshot(status_error="status failed"))
+    state.apply_snapshot(ConversationSnapshot(thread_error="history failed"))
+    assert state.error == "status failed; history failed"
+    assert state.status.daemon is False
+    assert state.status.extra["error"] == "status failed"
+    assert state.selected is thread
+
+    status = ConversationSnapshot(status=BackendStatus(daemon=True))
+    threads = ConversationSnapshot(threads=())
+    state.apply_snapshot(status if recover_status_first else threads)
+    assert state.error == ("history failed" if recover_status_first else "status failed")
+    state.apply_snapshot(threads if recover_status_first else status)
+    assert state.error == ""
+    assert state.status.daemon is True
+    assert state.threads == []
+    assert state.selected is None
+
+
+def test_duplicate_backend_errors_are_displayed_once():
+    state = ConversationState()
+    state.apply_snapshot(ConversationSnapshot(status_error="incompatible", thread_error="incompatible"))
+    assert state.error == "incompatible"
+    state.apply_snapshot(ConversationSnapshot(threads=()))
+    assert state.error == "incompatible"
 
 
 def test_presentations_can_leave_the_initial_selection_empty() -> None:
@@ -137,6 +168,40 @@ def test_daemon_remembered_roster_skips_client_confirmation() -> None:
 
     assert state.plan_reply("hello", thread_key="group").ready is True
     assert state.confirmed_groups[group.key] == group.confirmation_token
+
+
+@pytest.mark.parametrize("change", [
+    {"recipients": ("alice@example.com", "carol@example.com")},
+    {"roster_warning_id": "new-warning"},
+    {"is_group": False},
+])
+def test_confirming_a_stale_roster_is_blocked_even_if_backend_approved_it(change):
+    state = ConversationState()
+    original = _thread("group", group=True)
+    state.apply_snapshot(ConversationSnapshot(threads=(original,)))
+    displayed = state.plan_reply(" draft ")
+    assert displayed.disposition is ReplyDisposition.CONFIRM_GROUP
+    state.apply_snapshot(ConversationSnapshot(threads=(
+        replace(original, **change, group_confirmed=True),
+    )))
+    plan = state.plan_reply(
+        displayed.body, thread_key=original.key, confirm_group=True,
+        expected_group_token=displayed.expected_group_token,
+    )
+    assert plan.disposition is ReplyDisposition.STALE_GROUP
+    assert plan.ready is False
+    assert "group changed" in plan.disposition.message
+
+
+def test_reordering_displayed_recipients_does_not_invalidate_approval():
+    state = ConversationState()
+    original = _thread("group", group=True)
+    state.apply_snapshot(ConversationSnapshot(threads=(
+        replace(original, recipients=tuple(reversed(original.recipients))),
+    )))
+    assert state.plan_reply(
+        "draft", confirm_group=True, expected_group_token=original.confirmation_token,
+    ).ready
 
 
 def test_group_update_clears_prior_confirmation() -> None:
@@ -230,7 +295,5 @@ def test_shared_snapshot_loader_distinguishes_empty_history_from_failure(status_
     assert calls == ["status", 17]
     assert (snapshot.status is None) == status_fails
     assert snapshot.threads == (None if threads_fail else ())
-    assert snapshot.failures == tuple(
-        message for failed, message in [(status_fails, "status failed"), (threads_fail, "threads failed")]
-        if failed
-    )
+    assert snapshot.status_error == ("status failed" if status_fails else "")
+    assert snapshot.thread_error == ("threads failed" if threads_fail else "")

--- a/tests/test_conversation_state.py
+++ b/tests/test_conversation_state.py
@@ -107,6 +107,31 @@ def test_duplicate_backend_errors_are_displayed_once():
     assert state.error == "incompatible"
 
 
+@pytest.mark.parametrize("policy,storage_state", [
+    ("encrypted", "ready"), ("encrypted", "locked"),
+    ("plaintext", "ready"), ("none", "disabled"),
+])
+def test_failed_status_preserves_policy_without_claiming_storage_is_locked(policy, storage_state):
+    state = ConversationState()
+    healthy = BackendStatus(
+        daemon=True, map=True, storage_policy=policy, storage_state=storage_state,
+        storage_detail="previous storage detail",
+    )
+    state.apply_snapshot(ConversationSnapshot(status=healthy))
+    for error in ("status timed out", "backend unavailable"):
+        state.apply_snapshot(ConversationSnapshot(status_error=error))
+        state.apply_snapshot(ConversationSnapshot(threads=()))
+        assert state.status.daemon is False
+        assert state.status.map is False
+        assert state.status.storage_policy == policy
+        assert state.status.storage_state == "unavailable"
+        assert state.status.storage_detail == ""
+        assert state.error == error
+    state.apply_snapshot(ConversationSnapshot(status=healthy))
+    assert state.status is healthy
+    assert state.error == ""
+
+
 def test_presentations_can_leave_the_initial_selection_empty() -> None:
     state = ConversationState(select_first=False)
     state.apply_snapshot(

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -273,9 +273,7 @@ def test_backend_error_remains_visible_until_both_refreshes_recover():
     from unittest.mock import Mock
 
     message = backend_compatibility_error({})
-    page = Mock(
-        _state=ConversationState(), _thread_error="", _status_error="",
-    )
+    page = Mock(_state=ConversationState())
     adjustment = page._msg_scroll.get_vadjustment.return_value
     adjustment.get_value.return_value = 0
     adjustment.get_upper.return_value = 0
@@ -364,7 +362,7 @@ def test_roster_warning_fallback_id_is_stable_for_partial_payload() -> None:
         roster_warning_id="",
     )
 
-    assert ConversationState.roster_warning_id(thread) == (
+    assert thread.roster_warning_key == (
         "group:named:crew:Casey"
     )
 

--- a/tests/test_dbus_integration.py
+++ b/tests/test_dbus_integration.py
@@ -29,9 +29,9 @@ from blueferry.protocol import (
     MESSAGES_IFACE,
     OBJECT_PATH,
 )
+from blueferry.recipients import group_confirmation_token
 from blueferry.settings_store import SettingsStore
 from blueferry.storage_security import StorageSecurity
-from blueferry.threads import group_confirmation_token
 
 pytestmark = pytest.mark.private_dbus
 _service_ids = itertools.count()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,7 @@
 
 from blueferry import models as models_module
 from blueferry.models import BackendStatus, EventRecord, Thread
-from blueferry.threads import group_confirmation_token
+from blueferry.recipients import group_confirmation_token
 
 
 def test_status_defaults_missing_fields_and_preserves_new_fields():
@@ -110,6 +110,32 @@ def test_thread_confirmation_token_tracks_recipients_and_roster_warning():
     )
     cleared = Thread.from_dict({**payload, "roster_warning_id": ""})
     assert thread.confirmation_token != cleared.confirmation_token
+
+
+def test_presentation_metadata_is_derived_from_the_current_roster_and_messages():
+    thread = Thread.from_dict({
+        "key": "group:crew", "is_group": True, "unexpected_sender": "Casey",
+        "recipients": ["+1 (555) 222-2222", "Alice@example.com", "Alice@example.com"],
+        "messages": [
+            {"outgoing": True, "read": False},
+            {"outgoing": False, "read": True},
+            {"outgoing": False, "read": False},
+            {"outgoing": False, "read": False},
+        ],
+        "confirmation_token": "stale token", "roster_warning_key": "stale warning",
+        "unread": False, "unread_count": 99,
+    })
+    payload = thread.to_dict()
+    assert thread.unread_count == payload["unread_count"] == 2
+    assert payload["unread"] is True
+    assert payload["confirmation_token"] == "\n+1 (555) 222-2222\nAlice@example.com"
+    assert payload["roster_warning_key"] == "group:crew:Casey"
+    assert Thread.from_dict(payload).to_dict() == payload
+
+
+def test_direct_thread_has_no_group_approval_token():
+    thread = Thread.from_dict({"key": "direct", "recipients": ["alice@example.com"]})
+    assert thread.confirmation_token == thread.to_dict()["confirmation_token"] == ""
 
 
 def test_thread_unread_ignores_outgoing_and_read_incoming():

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -401,6 +401,41 @@ def _qml_functions(source: str, names: tuple[str, ...]) -> str:
     return "\n".join(functions)
 
 
+@pytest.mark.parametrize("policy,storage_state,label", [
+    ("encrypted", "locked", "Locked"), ("plaintext", "ready", "Available"),
+    ("none", "disabled", "Disabled"),
+])
+def test_qt_storage_label_reports_unavailability_after_failed_reads(qml_engine, policy, storage_state, label):
+    import json
+
+    from blueferry.conversation_state import ConversationSnapshot, ConversationState
+    from blueferry.models import BackendStatus
+
+    state = ConversationState()
+    healthy = BackendStatus(daemon=True, storage_policy=policy, storage_state=storage_state)
+    statuses = []
+    for snapshot in (
+        ConversationSnapshot(status=healthy),
+        ConversationSnapshot(status_error="status timed out"),
+        ConversationSnapshot(status=healthy),
+    ):
+        state.apply_snapshot(snapshot)
+        statuses.append(state.status.to_dict())
+    function = _qml_functions((ROOT / "src/blueferry/qt/qml/Main.qml").read_text(), ("storageStatusText",))
+    result = qml_engine.evaluate('''(function() {
+        const statuses = ''' + json.dumps(statuses) + ''';
+        const bridge = {};
+        function qsTr(text) { return text; }
+        ''' + function + '''
+        return JSON.stringify(statuses.map(function(status) {
+            bridge.status = status;
+            return storageStatusText();
+        }));
+    })()''')
+    assert not result.isError(), result.toString()
+    assert json.loads(result.toString()) == [label, "Unavailable", label]
+
+
 @pytest.mark.parametrize("relative_path", [
     "data/quickshell/shell.qml", "src/blueferry/qt/qml/Main.qml",
 ])

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -567,6 +567,7 @@ def test_qml_conversation_decisions_match_python_state(qml_engine):
     }]
     state = ConversationState()
     state.apply_snapshot(ConversationSnapshot(None, tuple(Thread.from_dict(t) for t in threads)))
+    threads = [thread.to_dict() for thread in state.threads]
     thread = state.next_roster_warning()
     assert thread is not None
     result = qml_engine.evaluate('''(function() {

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -149,8 +149,40 @@ def test_incompatible_initial_snapshot_displays_one_error_without_attempting_unl
     controller._apply_snapshot(controller._snapshot())
     assert controller.status["daemon"] is False
     assert controller.status["error"] == controller.errorText == message
+    assert controller.status["storage_policy"] == ""
+    assert controller.status["storage_state"] == "unavailable"
     assert controller.threads == []
     assert unlocks == []
+
+
+def test_failed_status_preserves_the_latest_successful_storage_setting(monkeypatch):
+    controller = BridgeController(
+        backend=_Backend(), setup=object(), subscribe=False, autostart=False,
+    )
+    controller._apply_snapshot(controller._snapshot())
+    monkeypatch.setattr(controller, "refresh", lambda: None)
+    controller._storage_updated({"storage_policy": "none", "storage_state": "disabled"})
+    controller._apply_snapshot((ConversationSnapshot(status_error="status timed out"), None))
+    assert controller.status["storage_policy"] == "none"
+    assert controller.status["storage_state"] == "unavailable"
+    assert controller.errorText == "status timed out"
+
+
+def test_failed_first_refresh_preserves_the_policy_loaded_at_startup(monkeypatch):
+    controller = BridgeController(
+        backend=_Backend(), setup=object(), subscribe=False, autostart=False,
+    )
+    status = BackendStatus(daemon=True, storage_policy="none", storage_state="disabled")
+    monkeypatch.setattr(controller, "_run", lambda _operation, ready, _failed: ready((
+        ConfigurationState(True, "02:00:00:00:00:01", "hci0", ""), status.to_dict(),
+    )))
+    monkeypatch.setattr(controller, "loadSetupState", lambda: None)
+    monkeypatch.setattr(controller, "loadDevices", lambda _scan: None)
+    monkeypatch.setattr(controller, "refresh", lambda: None)
+    controller.start()
+    controller._apply_snapshot((ConversationSnapshot(status_error="status timed out"), None))
+    assert controller.status["storage_policy"] == "none"
+    assert controller.status["storage_state"] == "unavailable"
 
 
 def test_failed_capability_probe_is_loaded_and_pairable(monkeypatch):

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -2,14 +2,23 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 pytest.importorskip("PySide6")
 
 from blueferry.client import BackendError
+from blueferry.conversation_state import ConversationSnapshot
 from blueferry.models import BackendStatus, Thread
 from blueferry.qt.controller import BridgeController
 from blueferry.setup_client import ConfigurationState
+
+
+def _apply_threads(controller, threads):
+    controller._apply_snapshot((
+        ConversationSnapshot(threads=tuple(threads)), [thread.to_dict() for thread in threads],
+    ))
 
 
 class _Backend:
@@ -17,7 +26,7 @@ class _Backend:
         self.sent = []
 
     def status(self):
-        return BackendStatus(daemon=True, map=True, contacts=4)
+        return BackendStatus(daemon=True, map=True, contacts=4, storage_state="ready")
 
     def threads(self, limit=1000):
         return [
@@ -82,9 +91,10 @@ def test_snapshot_converts_typed_client_models_for_qml():
     )
 
     snapshot = controller._snapshot()
+    controller._apply_snapshot(snapshot)
 
-    assert snapshot["status"]["contacts"] == 4
-    assert snapshot["threads"][0]["key"] == "address:email:test@example.com"
+    assert controller.status["contacts"] == 4
+    assert controller.threads[0]["key"] == "address:email:test@example.com"
 
 
 def test_failed_thread_snapshot_preserves_last_successful_projection():
@@ -106,8 +116,10 @@ def test_failed_thread_snapshot_preserves_last_successful_projection():
         subscribe=False,
         autostart=False,
     )
-    previous = [{"key": "address:phone:15551234567", "name": "Kept"}]
-    controller._threads = previous
+    _apply_threads(controller, [Thread.from_dict({
+        "key": "address:phone:15551234567", "name": "Kept",
+    })])
+    previous = controller.threads
 
     snapshot = controller._snapshot()
     controller._apply_snapshot(snapshot)
@@ -115,6 +127,30 @@ def test_failed_thread_snapshot_preserves_last_successful_projection():
     assert controller.threads == previous
     assert controller.status["daemon"] is True
     assert controller.errorText == "thread snapshot unavailable"
+
+
+def test_incompatible_initial_snapshot_displays_one_error_without_attempting_unlock(monkeypatch):
+    from blueferry.protocol import backend_compatibility_error
+
+    message = backend_compatibility_error({})
+
+    class IncompatibleBackend(_Backend):
+        def status(self):
+            raise BackendError(message)
+
+        def threads(self, limit=1000):
+            raise BackendError(message)
+
+    controller = BridgeController(
+        backend=IncompatibleBackend(), setup=object(), subscribe=False, autostart=False,
+    )
+    unlocks = []
+    monkeypatch.setattr(controller, "unlockStorage", lambda: unlocks.append(True))
+    controller._apply_snapshot(controller._snapshot())
+    assert controller.status["daemon"] is False
+    assert controller.status["error"] == controller.errorText == message
+    assert controller.threads == []
+    assert unlocks == []
 
 
 def test_failed_capability_probe_is_loaded_and_pairable(monkeypatch):
@@ -680,10 +716,10 @@ def test_activating_bluetooth_reloads_the_selected_adapter_before_scanning(
 
 def test_group_send_requires_explicit_approval_and_rejects_changed_roster(monkeypatch):
     controller = BridgeController(backend=_Backend(), setup=object(), subscribe=False, autostart=False)
-    controller._threads = [{
+    _apply_threads(controller, [Thread.from_dict({
         "key": "group:test", "name": "Group", "is_group": True, "reply_ready": True,
         "recipients": ["+15551111111", "+15552222222"],
-    }]
+    })])
     queued = []
     prompts = []
     monkeypatch.setattr(controller, "_run", lambda *args, **kwargs: queued.append(args))
@@ -691,7 +727,10 @@ def test_group_send_requires_explicit_approval_and_rejects_changed_roster(monkey
     controller.sendThread("group:test", "draft", False)
     assert not queued
     assert prompts == [("group:test", "draft", "+15551111111\n+15552222222")]
-    controller._threads[0]["recipients"].append("+15553333333")
+    thread = controller._state.threads[0]
+    _apply_threads(controller, [
+        replace(thread, recipients=(*thread.recipients, "+15553333333")),
+    ])
     controller.sendThread("group:test", "draft", True)
     assert not queued
     assert "group changed" in controller.errorText
@@ -703,14 +742,14 @@ def test_group_send_requires_explicit_approval_and_rejects_changed_roster(monkey
 def test_draft_completion_is_emitted_only_after_success(monkeypatch):
     backend = _Backend()
     controller = BridgeController(backend=backend, setup=object(), subscribe=False, autostart=False)
-    controller._threads = [thread.to_dict() for thread in backend.threads()]
+    _apply_threads(controller, backend.threads())
     queued = []
     completed = []
     monkeypatch.setattr(controller, "_run", lambda *args, **kwargs: queued.append(args))
     monkeypatch.setattr(controller, "refresh", lambda: None)
     controller.threadSendSucceeded.connect(lambda *args: completed.append(args))
     controller.messageSendSucceeded.connect(lambda *args: completed.append(args))
-    key = controller._threads[0]["key"]
+    key = controller.threads[0]["key"]
     controller.sendThread(key, " draft ", False)
     controller.sendMessage(" new recipient ", " new draft ")
     assert completed == []
@@ -740,10 +779,10 @@ def test_contact_search_rejects_repeated_query_stale_results_and_errors(monkeypa
 
 def test_successful_group_reply_reuses_confirmation_until_roster_changes(monkeypatch):
     controller = BridgeController(backend=_Backend(), setup=object(), subscribe=False, autostart=False)
-    controller._threads = [{
+    _apply_threads(controller, [Thread.from_dict({
         "key": "group:test", "is_group": True, "reply_ready": True,
         "recipients": ["+15551111111", "+15552222222"],
-    }]
+    })])
     pending = []
     prompts = []
     monkeypatch.setattr(controller, "_run", lambda *args, **_kw: pending.append(args))
@@ -755,7 +794,10 @@ def test_successful_group_reply_reuses_confirmation_until_roster_changes(monkeyp
     controller.sendThread("group:test", "second", False)
     assert len(prompts) == 1
     assert len(pending) == 1
-    controller._threads[0]["recipients"].append("+15553333333")
+    thread = controller._state.threads[0]
+    _apply_threads(controller, [
+        replace(thread, recipients=(*thread.recipients, "+15553333333")),
+    ])
     controller.sendThread("group:test", "third", False)
     assert len(prompts) == 2
     assert len(pending) == 1

--- a/tests/test_quickshell_bridge.py
+++ b/tests/test_quickshell_bridge.py
@@ -5,6 +5,7 @@ import json
 import threading
 from types import SimpleNamespace
 
+from blueferry.models import Thread
 from blueferry.quickshell_bridge import QuickshellBridge, _RequestWorkers
 
 
@@ -107,6 +108,31 @@ def test_bridge_rejects_non_boolean_contacts_only_value() -> None:
         assert str(error) == "enabled must be a boolean"
     else:
         raise AssertionError("non-boolean preference was accepted")
+
+
+def test_bridge_supplies_shared_thread_metadata_and_forwards_displayed_approval():
+    class Client(FakeClient):
+        def threads(self, limit=200):
+            return [Thread.from_dict({
+                "key": "group:crew", "is_group": True, "roster_warning_id": "warning:1",
+                "recipients": ["Bob@example.com", "+1 (555) 222-2222"],
+                "messages": [{"outgoing": False, "read": False}],
+            })]
+
+    client = Client()
+    bridge = QuickshellBridge(client)
+    payload = bridge.dispatch("threads", {})[0]
+    assert payload["confirmation_token"] == "warning:1\n+1 (555) 222-2222\nBob@example.com"
+    assert payload["roster_warning_key"] == "warning:1"
+    assert payload["unread"] is True
+    assert payload["unread_count"] == 1
+    bridge.dispatch("send_to_thread", {
+        "thread_key": payload["key"], "body": "draft", "confirm_group": True,
+        "expected_group_token": payload["confirmation_token"],
+    })
+    assert client.calls == [(
+        "send_to_thread", "group:crew", "draft", True, payload["confirmation_token"],
+    )]
 
 
 def test_bridge_returns_structured_success_and_errors() -> None:

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from blueferry import threads as threads_module
+from blueferry.recipients import group_confirmation_token
 from blueferry.threads import (
     build_threads,
-    group_confirmation_token,
     sort_threads,
     thread_key,
 )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -503,6 +503,32 @@ def test_unchanged_poll_does_not_rebuild_the_terminal_view() -> None:
     _run_headless(scenario())
 
 
+def test_textual_reports_storage_unavailable_during_status_failure() -> None:
+    class Backend(_Backend):
+        fail = False
+
+        def status(self):
+            if self.fail:
+                raise BackendError("status timed out")
+            return BackendStatus(daemon=True, storage_policy="none", storage_state="disabled")
+
+    async def scenario() -> None:
+        backend = Backend()
+        state = TuiState(backend)
+        app = BlueFerryApp(state, monitor_factory=lambda: None)
+        async with app.run_test(size=(120, 36)) as pilot:
+            await _wait_for_threads(app, pilot, 2)
+            backend.fail = True
+            await app._apply_snapshot(state.fetch_snapshot())
+            await _wait_for_static_text(app, pilot, "#storage-status", "STORAGE  UNAVAILABLE")
+            assert state.status.storage_policy == "none"
+            backend.fail = False
+            await app._apply_snapshot(state.fetch_snapshot())
+            await _wait_for_static_text(app, pilot, "#storage-status", "STORAGE  DISABLED")
+
+    _run_headless(scenario())
+
+
 def test_textual_warns_once_when_saved_group_roster_changes() -> None:
     async def scenario() -> None:
         backend = _Backend()


### PR DESCRIPTION
Client adapters repeated refresh-error handling and stale group-approval checks, while Qt reconstructed typed threads from its QML dictionaries before sending. Centralize those decisions in `ConversationState`: GTK, Qt, and TUI now retain each read's error until that source recovers, and use the same reply planner to reject changed recipient approvals. Failed status reads report storage as unavailable while preserving the last known policy, including settings loaded at startup or changed just before the failure.

Qt retains the typed snapshot across refreshes and sends, preparing its QML copy on the worker thread. `Thread` supplies unread counts, approval tokens, and roster-warning keys to both Qt and Quickshell. The backend and client models use one token implementation that preserves the displayed address spelling. These fields are derived locally from existing backend data, so no D-Bus API generation change is needed.

Validation: all CI checks passed, including 968 hermetic tests with first-install and public D-Bus coverage, Ruff, Bandit, mypy (81 files), QML lint, and Ubuntu 24.04 Debian package builds. Local diff checks also passed. Added regression coverage for partial recovery in either order, stale approval despite backend confirmation, derived metadata through Quickshell, an incompatible initial Qt snapshot, and storage failure/recovery in the Qt and terminal presentations.

