### PR TITLE
Separate named-group identities and preserve safe legacy routes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -237,8 +237,18 @@ managers; distro systemd hooks reload changed user-unit metadata.
   retain a user-supplied route, and it requires all observed senders to remain
   in that route. A sender outside an established route produces a distinct
   roster-change warning and disables replies. Routes are local metadata and do
-  not modify iPhone groups; named groups with the same name necessarily share
-  one key because ANCS provides no conversation identifier.
+  not modify iPhone groups; named groups with exactly the same name still share
+  one key because ANCS provides no conversation identifier. The named-group
+  routing module preserves spelling in versioned keys (NFC with surrounding
+  whitespace trimmed), so case, internal whitespace, and compatibility
+  characters no longer cause additional collisions.
+- Retained named-group history is re-keyed in the conversation projection;
+  reading it never rewrites the database. Old name-folded keys remain aliases
+  for stars and operations only when the projected history identifies a single
+  spelling. Multiple spellings disable both that alias and any old shared
+  roster until participants are supplied for each conversation. New roster
+  records use the versioned key, and old send approvals require a fresh
+  confirmation. A roster edit does not change the conversation key.
 - Message history and the contact cache are user-private (`0700` directories,
   `0600` SQLite files). Their sensitive records are authenticated and encrypted
   with AES-256-GCM under one random application key held by the desktop Secret

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -222,7 +222,8 @@ Messages ANCS notification supplies the missing display information:
   shaped like `To you & participant` (with further names separated by commas
   or ampersands).
 - For the observed named group, the title is the sender and the subtitle is the
-  group name. This identifies the conversation but contains no member roster.
+  group name. This is display metadata, not a unique conversation identifier,
+  and contains no member roster.
 
 BlueFerry correlates these records only within a bounded time window, refuses
 ambiguous repeated-body matches, and requires every name to resolve to exactly
@@ -232,10 +233,13 @@ when a previously unseen sender appears, but iOS provides no event when a
 silent member is added or removed, so the user must maintain that roster. This
 local roster affects only BlueFerry's reply routing and never modifies the
 Messages group itself. Because iOS supplies a group name but no conversation
-identifier, distinct named groups with the same normalized name cannot be
-distinguished and are projected as one local thread. This is a conservative
-observation-based heuristic, not a general iMessage group protocol;
-alternative iOS notification formats remain uncharacterized.
+identifier, distinct named groups with exactly the same name cannot be
+distinguished and are projected as one local thread. Local keys preserve case,
+internal whitespace, and compatibility characters: `Family` and `FAMILY` are
+separate conversations. Only canonical Unicode equivalence (NFC) and surrounding
+whitespace are normalized. This is an observation-based heuristic, not a general
+iMessage group protocol; alternative iOS notification formats remain
+uncharacterized.
 
 ## PBAP behavior
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -58,6 +58,11 @@ Private D-Bus tests deliberately hold fake wallet and conversation-projection
 work open while fetching status, and verify that history changes invalidate
 an in-flight projection. Wallet tests cover cancellation and late key results;
 group tests bind confirmation to the displayed roster across client refreshes.
+Named-group upgrade tests separate previously colliding spellings and exercise
+legacy rosters, stars, read state, reply confirmation, and deletion against
+temporary history. Ambiguous old keys must fail without sending or deleting
+another conversation; replaying projected history must not enable an old
+ambiguous route.
 Fresh-profile integration coverage starts with locked storage and missing
 databases, unlocks a fake wallet, and reads the first retained message through
 the compatibility-checking client. Client tests reject incompatible API

--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -54,6 +54,7 @@ from blueferry.limits import (
     MAX_THREAD_KEY_CHARS,
     MAX_THREAD_QUERY_LIMIT,
 )
+from blueferry.named_groups import stored_named_group_key
 from blueferry.obex.map_query import list_recent_messages
 from blueferry.obex.map_read import set_session_messages_read
 from blueferry.obex.map_send import send_group_message, send_message
@@ -326,6 +327,7 @@ class BackendOperations:
         thread = self._conversations.find(thread_key)
         if thread is None:
             raise NotFoundError("thread no longer exists in local history")
+        thread_key = str(thread["key"])
         if not thread["reply_ready"] or not thread["recipients"]:
             raise NotReadyError("thread has no unambiguous reply destination")
         self._require_map()
@@ -564,6 +566,7 @@ class BackendOperations:
         thread = self._conversations.find(thread_key)
         if thread is None:
             raise NotFoundError("thread no longer exists in local history")
+        thread_key = str(thread["key"])
         if not thread.get("is_group") or thread.get("group_origin") != "named":
             raise InvalidArgumentsError(
                 "participants can only be supplied for a named group"
@@ -619,7 +622,7 @@ class BackendOperations:
             raise NotReadyError(
                 "could not retain the group participant list"
             ) from error
-        self._forget_confirmed_groups([thread_key])
+        self._forget_confirmed_groups(conversation_keys(thread))
         self.invalidate_conversations()
         updated = self._conversations.find(thread_key)
         if updated is None:
@@ -777,7 +780,10 @@ class BackendOperations:
                 kind = str(event.get("kind") or "")
                 belongs = (
                     kind == "group_route"
-                    and str(event.get("group_key") or "") in resolved_keys
+                    and (
+                        str(event.get("group_key") or "") in resolved_keys
+                        or stored_named_group_key(event) in resolved_keys
+                    )
                 ) or (
                     kind == "sms_seen"
                     and (
@@ -802,7 +808,7 @@ class BackendOperations:
             log.error("could not delete conversations: %s", error)
             raise NotReadyError("could not delete local conversations") from error
 
-        self._forget_confirmed_groups(resolved_keys)
+        self._forget_confirmed_groups(resolved_keys | preference_keys)
         if self.dependencies.starred_threads is not None:
             self.dependencies.starred_threads.discard(list(preference_keys))
         self.invalidate_conversations()

--- a/src/blueferry/grouping.py
+++ b/src/blueferry/grouping.py
@@ -13,14 +13,14 @@ updates can replay the same deterministic correlation.
 """
 from __future__ import annotations
 
-import hashlib
 import re
-import unicodedata
 from bisect import bisect_left, bisect_right
 from datetime import datetime, timezone
 
 from blueferry.ancs.constants import MESSAGES_APP_ID
 from blueferry.events import canonical_address, safe_event_address
+from blueferry.named_groups import NamedGroupRoutes
+from blueferry.named_groups import named_group_key as named_group_key
 
 CORRELATION_WINDOW_SECONDS = 60
 
@@ -113,8 +113,8 @@ def named_group_from_ancs(event: dict) -> str | None:
     """Return the group name carried by the named-group ANCS layout.
 
     Named Messages groups use the sender as the title and the group name as
-    the subtitle. Unlike the unnamed ``To ... & ...`` layout, this proves the
-    conversation identity but does not disclose a safe reply roster.
+    the subtitle. Unlike the unnamed ``To ... & ...`` layout, this supplies a
+    display name, not a unique conversation ID or a safe reply roster.
     """
     if event.get("app_id") != MESSAGES_APP_ID:
         return None
@@ -123,41 +123,6 @@ def named_group_from_ancs(event: dict) -> str | None:
     if not title or not subtitle or group_members_from_ancs(event):
         return None
     return subtitle
-
-
-def named_group_key(name: str) -> str:
-    """Build an opaque stable key from the normalized iOS group name."""
-    normalized = " ".join(
-        unicodedata.normalize("NFKC", name).strip().casefold().split()
-    )
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
-    return f"group:named:{digest}"
-
-
-def _named_group_routes(events: list[dict]) -> dict[str, dict]:
-    """Load the newest structurally valid user-confirmed route per group."""
-    routes: dict[str, dict] = {}
-    for event in events:
-        if event.get("kind") != "group_route":
-            continue
-        key = str(event.get("group_key") or "")
-        name = str(event.get("group_name") or "").strip()
-        recipients = [
-            str(value).strip()
-            for value in event.get("group_recipients", [])
-            if str(value).strip()
-        ]
-        identities = [canonical_address(value) for value in recipients]
-        if (
-            not name
-            or key != named_group_key(name)
-            or not 2 <= len(recipients) <= 20
-            or any(identity is None for identity in identities)
-            or len(set(identities)) != len(identities)
-        ):
-            continue
-        routes[key] = event
-    return routes
 
 
 def _group_identity(
@@ -225,7 +190,7 @@ def _reconcile_group_identities(
     for event in events:
         if not str(event.get("kind") or "").startswith("sms_"):
             continue
-        # Named groups use their normalized iOS name as the persistent lookup
+        # Named groups use their iOS name spelling as the persistent lookup
         # key. Rewriting it after a roster is saved would invalidate the UI
         # thread the user just configured.
         if event.get("group_origin") == "named":
@@ -289,31 +254,11 @@ def correlate_group_events(events: list[dict], resolver=None) -> list[dict]:
         if event.get("kind") == "sms_received"
     ]
     matched: set[int] = set()
-    named_routes = _named_group_routes(out)
-    # A later roster edit is authoritative for locally recorded replies too;
-    # otherwise an old outgoing event could silently re-add a removed member
-    # when the thread projection unions its historical recipients.
+    named_routes = NamedGroupRoutes(out, (
+        name for event in out if (name := named_group_from_ancs(event))
+    ))
     for stored in out:
-        key = str(stored.get("group_key") or "")
-        if not str(stored.get("kind") or "").startswith("sms_"):
-            continue
-        if not key.startswith("group:named:"):
-            continue
-        stored["group_origin"] = "named"
-        route = named_routes.get(key)
-        if route is None:
-            continue
-        stored.update({
-            "group_name": str(route.get("group_name") or ""),
-            "group_members": [
-                str(value) for value in route.get("group_members", [])
-            ],
-            "group_recipients": [
-                str(value) for value in route.get("group_recipients", [])
-            ],
-            "group_reply_ready": True,
-            "group_participants_required": False,
-        })
+        named_routes.annotate_stored(stored)
     addresses_by_name: dict[str, set[str]] = {}
     message_candidates = _MessageCandidates(out, sms_indexes)
 
@@ -377,59 +322,7 @@ def correlate_group_events(events: list[dict], resolver=None) -> list[dict]:
             )
 
         if named_group:
-            key = named_group_key(named_group)
-            route = named_routes.get(key)
-            named_recipients = [sender_address] if sender_address else []
-            named_member_names = [sender_title] if sender_title else []
-            reply_ready = False
-            participants_required = True
-            roster_changed = False
-            roster_warning_id = ""
-            if route is not None:
-                routed_recipients = [
-                    str(value)
-                    for value in route.get("group_recipients", [])
-                ]
-                routed_identities = {
-                    canonical_address(value) for value in routed_recipients
-                }
-                sender_identity = canonical_address(sender_address)
-                # A previously unseen sender is evidence that the saved
-                # membership changed. Fail closed until the user reviews it.
-                if sender_identity is not None and sender_identity in routed_identities:
-                    named_recipients = routed_recipients
-                    named_member_names = [
-                        str(value)
-                        for value in route.get("group_members", [])
-                    ]
-                    reply_ready = True
-                    participants_required = False
-                else:
-                    named_recipients = list(routed_recipients)
-                    named_member_names = [
-                        str(value)
-                        for value in route.get("group_members", [])
-                    ]
-                    if sender_address and sender_address not in named_recipients:
-                        named_recipients.append(sender_address)
-                    if sender_identity is not None:
-                        roster_changed = True
-                        route_version = str(route.get("seen_at") or key)
-                        roster_warning_id = f"{route_version}:{sender_identity}"
-            sms.update({
-                "group_key": key,
-                "group_name": named_group,
-                "group_members": named_member_names,
-                "group_recipients": named_recipients,
-                "group_reply_ready": reply_ready,
-                "group_origin": "named",
-                "group_participants_required": participants_required,
-                "group_observed_recipient": sender_address or "",
-                "group_observed_sender": sender_title,
-                "group_roster_changed": roster_changed,
-                "group_unexpected_sender": sender_title if roster_changed else "",
-                "group_roster_warning_id": roster_warning_id,
-            })
+            sms.update(named_routes.received(named_group, sender_title, sender_address))
             continue
 
         if members is None:  # Defensive: named groups return above.

--- a/src/blueferry/named_groups.py
+++ b/src/blueferry/named_groups.py
@@ -1,0 +1,150 @@
+"""Named-group identity and saved reply routes, independent of event matching."""
+from __future__ import annotations
+
+import hashlib
+import unicodedata
+from collections.abc import Iterable
+
+from blueferry.events import canonical_address
+
+
+def _name(value: str) -> str:
+    return unicodedata.normalize("NFC", value).strip()
+
+
+def named_group_key(name: str) -> str:
+    """Preserve distinct spelling; canonical Unicode forms denote the same name."""
+    digest = hashlib.sha256(_name(name).encode("utf-8")).hexdigest()
+    return f"group:named:v2:{digest}"
+
+
+def legacy_named_group_key(name: str) -> str:
+    """The old name-folding key, used only to interpret retained records."""
+    normalized = " ".join(unicodedata.normalize("NFKC", name).strip().casefold().split())
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return f"group:named:{digest}"
+
+
+def _stored_name(event: dict) -> str:
+    name = _name(str(event.get("group_name") or ""))
+    key = str(event.get("group_key") or "")
+    if name and key in {named_group_key(name), legacy_named_group_key(name)}:
+        return name
+    return ""
+
+
+def stored_named_group_key(event: dict) -> str:
+    """Resolve a retained key using its recorded name, without rewriting it."""
+    name = _stored_name(event)
+    return named_group_key(name) if name else ""
+
+
+class NamedGroupRoutes:
+    """Resolve legacy metadata only when one spelling owns its old key.
+
+    The iPhone exposes no conversation ID. Even the new key cannot distinguish
+    two groups with exactly the same name; it only avoids *additional* collisions
+    from case folding, compatibility characters, and collapsed whitespace.
+    """
+
+    def __init__(self, events: list[dict], observed_names: Iterable[str]) -> None:
+        self._names: dict[str, set[str]] = {}
+        for name in (*observed_names, *(_stored_name(event) for event in events)):
+            if name:
+                self._names.setdefault(legacy_named_group_key(name), set()).add(_name(name))
+        self._routes: dict[str, dict] = {}
+        for event in events:
+            if event.get("kind") != "group_route":
+                continue
+            name = _stored_name(event)
+            if not name:
+                continue
+            key = named_group_key(name)
+            if event["group_key"] != key and not self.aliases(name):
+                # A roster saved for the previously merged thread cannot be
+                # assigned to either new conversation without user review.
+                continue
+            raw_recipients = event.get("group_recipients")
+            if not isinstance(raw_recipients, list | tuple):
+                continue
+            recipients = [str(value).strip() for value in raw_recipients if str(value).strip()]
+            identities = [canonical_address(value) for value in recipients]
+            if (
+                not 2 <= len(recipients) <= 20
+                or any(identity is None for identity in identities)
+                or len(set(identities)) != len(identities)
+            ):
+                continue
+            self._routes[key] = dict(event)
+
+    def aliases(self, name: str) -> list[str]:
+        legacy = legacy_named_group_key(name)
+        return [legacy] if self._names.get(legacy) == {_name(name)} else []
+
+    def annotate_stored(self, event: dict) -> None:
+        """Re-key a projection copy, preserving the original history on disk."""
+        kind = str(event.get("kind") or "")
+        if not kind.startswith("sms_"):
+            return
+        name = _stored_name(event)
+        if not name:
+            return
+        key = named_group_key(name)
+        was_legacy = event["group_key"] != key
+        event["group_key"] = key
+        event["group_aliases"] = self.aliases(name)
+        event["group_origin"] = "named"
+        route = self._routes.get(key)
+        if route is not None:
+            # A roster edit also replaces historical outgoing routing metadata;
+            # otherwise old sends could re-add a participant the user removed.
+            event.update({
+                "group_name": str(route.get("group_name") or ""),
+                "group_members": list(route.get("group_members") or []),
+                "group_recipients": list(route["group_recipients"]),
+                "group_reply_ready": True,
+                "group_participants_required": False,
+            })
+        elif was_legacy and not self.aliases(name):
+            event["group_reply_ready"] = False
+            event["group_participants_required"] = True
+
+    def received(self, name: str, sender_title: str, sender_address: str | None) -> dict:
+        """Apply a saved roster only when the observed sender belongs to it."""
+        key = named_group_key(name)
+        route = self._routes.get(key)
+        recipients = [sender_address] if sender_address else []
+        members = [sender_title] if sender_title else []
+        reply_ready = False
+        roster_changed = False
+        warning_id = ""
+        if route is not None:
+            recipients = [str(value) for value in route["group_recipients"]]
+            members = [str(value) for value in route.get("group_members", [])]
+            sender_identity = canonical_address(sender_address)
+            if sender_identity is not None and sender_identity in {
+                canonical_address(value) for value in recipients
+            }:
+                reply_ready = True
+            else:
+                if sender_address and sender_address not in recipients:
+                    recipients.append(sender_address)
+                if sender_identity is not None:
+                    roster_changed = True
+                    route_version = str(route.get("seen_at") or key)
+                    warning_id = f"{route_version}:{sender_identity}"
+        return {
+            "group_key": key,
+            "group_aliases": self.aliases(name),
+            "group_name": name,
+            "group_members": members,
+            "group_recipients": recipients,
+            "group_reply_ready": reply_ready,
+            "group_origin": "named",
+            "group_participants_required": not reply_ready,
+            "group_observed_recipient": sender_address or "",
+            "group_observed_sender": sender_title,
+            "group_roster_changed": roster_changed,
+            "group_unexpected_sender": sender_title if roster_changed else "",
+            "group_roster_warning_id": warning_id,
+        }

--- a/src/blueferry/threads.py
+++ b/src/blueferry/threads.py
@@ -208,9 +208,9 @@ def build_threads(events: list[dict], resolver=None) -> list[dict]:
         if thread is None:
             thread = {
                 "key": key,
-                "aliases": [
+                "aliases": list(event.get("group_aliases", [])) if is_group else [
                     f"address:{value}" for value in _contact_addresses(resolver, address)
-                ] if not is_group else [],
+                ],
                 "name": _thread_name(event, address, resolver),
                 "is_group": is_group,
                 "members": [

--- a/tests/test_named_groups.py
+++ b/tests/test_named_groups.py
@@ -1,0 +1,252 @@
+"""Distinct display names never inherit each other's history or reply route."""
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from blueferry import backend_operations, config
+from blueferry.backend_operations import BackendDependencies, BackendOperations
+from blueferry.confirmed_groups import ConfirmedGroupsStore
+from blueferry.errors import ConfirmationRequiredError, NotFoundError
+from blueferry.grouping import correlate_group_events
+from blueferry.history import append_event, read_events
+from blueferry.named_groups import legacy_named_group_key, named_group_key
+from blueferry.recipients import group_confirmation_token
+from blueferry.starred_threads import StarredThreadsStore
+from blueferry.threads import ConversationIndex, build_threads
+
+ALICE = "alice@example.com"
+BOB = "bob@example.com"
+CAROL = "carol@example.com"
+
+
+def messages(name, index, sender=ALICE):
+    stamp = f"2026-09-01T10:{index:02}:00Z"
+    body = f"message {index}"
+    return [{
+        "kind": "sms_received", "handle": f"message-{index}", "body": body,
+        "sender_address": sender, "contact_name": "Sender", "seen_at": stamp,
+        "is_read": False,
+    }, {
+        "kind": "ancs_notification", "app_id": "com.apple.MobileSMS",
+        "title": "Sender", "subtitle": name, "body": body, "seen_at": stamp,
+    }]
+
+
+def route(name, recipients, *, legacy=False):
+    return {
+        "kind": "group_route", "group_name": name,
+        "group_key": legacy_named_group_key(name) if legacy else named_group_key(name),
+        "group_recipients": recipients, "group_members": recipients,
+        "seen_at": "2026-09-01T09:00:00Z",
+    }
+
+
+@pytest.mark.parametrize("first,second", [
+    ("Family", "FAMILY"), ("Family", "\uff26amily"),
+    ("Our Family", "Our  Family"), ("Straße", "Strasse"),
+])
+def test_names_that_used_to_collide_have_separate_history_and_routes(first, second):
+    assert legacy_named_group_key(first) == legacy_named_group_key(second)
+    assert named_group_key(first) != named_group_key(second)
+    events = [route(first, [ALICE, BOB]), route(second, [ALICE, CAROL]),
+              *messages(first, 1), *messages(second, 2)]
+    threads = {thread["name"]: thread for thread in build_threads(events)}
+    assert set(threads) == {first, second}
+    for name, recipient, handle in [(first, BOB, "message-1"), (second, CAROL, "message-2")]:
+        assert threads[name]["recipients"] == [ALICE, recipient]
+        assert threads[name]["reply_ready"] is True
+        assert threads[name]["aliases"] == []
+        assert [message["handle"] for message in threads[name]["messages"]] == [handle]
+
+
+def test_canonical_unicode_equivalents_still_refer_to_one_name():
+    composed, decomposed = "Café", "Cafe\u0301"
+    assert named_group_key(composed) == named_group_key(decomposed)
+    threads = build_threads([route(composed, [ALICE, BOB]),
+                             *messages(composed, 1), *messages(decomposed, 2)])
+    assert len(threads) == 1
+    assert threads[0]["recipients"] == [ALICE, BOB]
+    assert len(threads[0]["messages"]) == 2
+
+
+def test_unambiguous_legacy_history_and_route_migrate_without_disk_rewrites():
+    old_key = legacy_named_group_key("Family")
+    outgoing = {
+        "kind": "sms_sent", "handle": "sent-1", "body": "old reply",
+        "group_key": old_key, "group_name": "Family", "group_reply_ready": True,
+        "group_recipients": [ALICE, BOB, CAROL], "seen_at": "2026-09-01T08:00:00Z",
+    }
+    events = [outgoing, route("Family", [ALICE, BOB], legacy=True), *messages("Family", 1)]
+    original = deepcopy(events)
+    index = ConversationIndex(lambda: events, build_threads)
+    thread = index.find(old_key)
+    assert thread is not None
+    assert thread["key"] == named_group_key("Family")
+    assert thread["aliases"] == [old_key]
+    assert thread["recipients"] == [ALICE, BOB]
+    assert thread["reply_ready"] is True
+    assert [message["handle"] for message in thread["messages"]] == ["sent-1", "message-1"]
+    assert index.find(thread["key"]) is thread
+    assert events == original
+
+
+def test_legacy_merged_roster_and_outgoing_message_cannot_enable_either_new_group():
+    old_key = legacy_named_group_key("Family")
+    events = [route("Family", [ALICE, BOB], legacy=True), {
+        "kind": "sms_sent", "handle": "sent-1", "group_name": "Family",
+        "group_key": old_key, "group_reply_ready": True, "group_recipients": [ALICE, BOB],
+    }, *messages("Family", 1), *messages("FAMILY", 2)]
+    index = ConversationIndex(lambda: events, build_threads)
+    assert index.find(old_key) is None
+    for thread in index.threads():
+        assert thread["reply_ready"] is False
+        assert thread["participants_required"] is True
+        assert thread["aliases"] == []
+    # Replaying an already projected history must not promote an old route
+    # into a newly approved, spelling-specific route.
+    assert build_threads(correlate_group_events(events)) == index.threads()
+
+
+def test_explicit_roster_review_only_enables_the_selected_spelling():
+    events = [route("Family", [ALICE, BOB], legacy=True),
+              *messages("Family", 1), *messages("FAMILY", 2),
+              route("Family", [ALICE, CAROL])]
+    threads = {thread["name"]: thread for thread in build_threads(events)}
+    assert threads["Family"]["reply_ready"] is True
+    assert threads["Family"]["recipients"] == [ALICE, CAROL]
+    assert threads["FAMILY"]["reply_ready"] is False
+    assert threads["FAMILY"]["recipients"] == [ALICE]
+
+
+def test_differently_spelled_legacy_route_cannot_attach_to_a_new_notification():
+    [thread] = build_threads([
+        route("Family", [ALICE, BOB], legacy=True), *messages("FAMILY", 1),
+    ])
+    assert thread["key"] == named_group_key("FAMILY")
+    assert thread["recipients"] == [ALICE]
+    assert thread["reply_ready"] is False
+    assert thread["aliases"] == []
+
+
+def test_exactly_identical_names_remain_an_explicit_protocol_limitation():
+    # There is no conversation ID or full roster in these notifications.
+    threads = build_threads([*messages("Family", 1, ALICE), *messages("Family", 2, CAROL)])
+    assert len(threads) == 1
+    assert threads[0]["reply_ready"] is False
+
+
+@pytest.mark.parametrize("invalid", [
+    {"group_key": "group:named:unrelated"}, {"group_recipients": None},
+    {"group_recipients": [ALICE, ALICE]}, {"group_recipients": [ALICE, "not an address"]},
+])
+def test_invalid_legacy_routes_remain_read_only(invalid):
+    [thread] = build_threads([
+        {**route("Family", [ALICE, BOB], legacy=True), **invalid}, *messages("Family", 1),
+    ])
+    assert thread["reply_ready"] is False
+
+
+@pytest.fixture
+def backend(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
+    settings = tmp_path / "settings.json"
+
+    def submit(operation, *, on_success, on_error):
+        try:
+            on_success(operation())
+        except Exception as error:
+            on_error(error)
+
+    return BackendOperations(
+        SimpleNamespace(map=None, pbap=None, map_path="/fake/map"),
+        BackendDependencies(
+            submit_obex=submit,
+            starred_threads=StarredThreadsStore(settings),
+            confirmed_groups=ConfirmedGroupsStore(settings),
+        ),
+    )
+
+
+def retain(events):
+    for event in events:
+        append_event(event)
+
+
+def test_legacy_stars_read_state_and_explicit_send_use_the_canonical_thread(backend, monkeypatch):
+    old_key, key = legacy_named_group_key("Family"), named_group_key("Family")
+    token = group_confirmation_token([ALICE, BOB])
+    retain([route("Family", [ALICE, BOB], legacy=True), *messages("Family", 1)])
+    stars, approvals = backend.dependencies.starred_threads, backend.dependencies.confirmed_groups
+    stars.set_starred(old_key, True)
+    approvals.remember(old_key, token)
+    [thread] = backend.list_threads(10)
+    assert thread["key"] == key
+    assert thread["starred"] is True
+    assert thread["group_confirmed"] is False
+    assert stars.keys() == [old_key]  # Reading the projection does not rewrite preferences.
+    assert backend.mark_thread_read(old_key) == 1
+    assert backend.list_threads(10)[0]["unread"] is False
+
+    sent = []
+    backend.sessions.map = object()
+    monkeypatch.setattr(
+        backend_operations, "send_group_message",
+        lambda _path, recipients, body: sent.append((recipients, body)) or "fake-transfer",
+    )
+    with pytest.raises(ConfirmationRequiredError):
+        backend.send_to_thread(old_key, "draft", False, lambda _value: None, pytest.fail,
+                               expected_group_token=token)
+    backend.send_to_thread(old_key, "draft", True, lambda _value: None, pytest.fail,
+                           expected_group_token=token)
+    assert sent == [([ALICE, BOB], "draft")]
+    assert approvals.matches(key, token)
+    assert backend.list_threads(10)[0]["group_confirmed"] is True
+    assert backend.set_thread_starred(key, False) is False
+    assert stars.keys() == []
+
+
+def test_roster_saved_through_legacy_alias_uses_new_key_and_reloads(backend):
+    old_key, key = legacy_named_group_key("Family"), named_group_key("Family")
+    retain(messages("Family", 1))
+    backend.dependencies.confirmed_groups.remember(old_key, group_confirmation_token([ALICE, BOB]))
+    updated = backend.set_group_participants(old_key, [ALICE, BOB])
+    assert updated["key"] == key
+    assert updated["reply_ready"] is True
+    [saved] = read_events(kinds={"group_route"})
+    assert saved["group_key"] == key
+    assert not backend.dependencies.confirmed_groups.matches(old_key, group_confirmation_token([ALICE, BOB]))
+    restarted = BackendOperations(backend.sessions, backend.dependencies)
+    assert restarted.list_threads(10)[0]["recipients"] == [ALICE, BOB]
+    assert restarted.list_threads(10)[0]["key"] == key
+
+
+def test_deleting_a_migrated_group_removes_legacy_route_and_preferences(backend):
+    old_key, key = legacy_named_group_key("Family"), named_group_key("Family")
+    token = group_confirmation_token([ALICE, BOB])
+    retain([route("Family", [ALICE, BOB], legacy=True), *messages("Family", 1)])
+    for alias in (old_key, key):
+        backend.dependencies.starred_threads.set_starred(alias, True)
+        backend.dependencies.confirmed_groups.remember(alias, token)
+    assert backend.delete_threads([old_key], True) == 1
+    assert read_events() == []
+    assert backend.dependencies.starred_threads.keys() == []
+    assert backend.dependencies.confirmed_groups.matching_rosters({old_key: token, key: token}) == set()
+
+
+def test_ambiguous_legacy_requests_fail_and_deletion_preserves_the_other_spelling(backend):
+    old_key = legacy_named_group_key("Family")
+    other_events = [route("FAMILY", [ALICE, CAROL]), *messages("FAMILY", 2)]
+    retain([route("Family", [ALICE, BOB], legacy=True), *messages("Family", 1), *other_events])
+    with pytest.raises(NotFoundError):
+        backend.set_group_participants(old_key, [ALICE, BOB])
+    with pytest.raises(NotFoundError):
+        backend.send_to_thread(old_key, "draft", True, lambda _value: None, pytest.fail,
+                               expected_group_token=group_confirmation_token([ALICE, BOB]))
+    with pytest.raises(NotFoundError):
+        backend.delete_threads([old_key], True)
+    assert backend.delete_threads([named_group_key("Family")], True) == 1
+    assert read_events() == other_events
+    [remaining] = backend.list_threads(10)
+    assert remaining["name"] == "FAMILY"
+    assert remaining["recipients"] == [ALICE, CAROL]


### PR DESCRIPTION
Names such as `Family` and `FAMILY` previously shared a conversation key, mixing their history and reply rosters. Preserve spelling in versioned named-group keys and extract identity, saved-route selection, and legacy migration into `named_groups.py`.

Old keys remain aliases only when the projected history identifies one spelling. This preserves unambiguous history, stars, and operations without rewriting retained events. Ambiguous legacy rosters remain read-only until participants are reviewed separately; sends require a fresh confirmation under the new key. Saving participants and deleting conversations resolve legacy keys without affecting another spelling's route or messages.

Groups with exactly the same name remain indistinguishable because MAP/ANCS provide no conversation ID. NFC-equivalent Unicode and surrounding whitespace still normalize to one name. The protocol and architecture docs now describe those limits.

Validation: 986 tests passed on an isolated D-Bus, including 18 new separation and upgrade cases covering routes, stars, read state, sends, replay, malformed records, and deletion. Ruff, Bandit, mypy, QML lint, and whitespace checks passed. All transport and storage tests use fakes or temporary data.
