### PR TITLE
Prepare BlueFerry 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [0.8.0](https://github.com/erikwb/blueferry/releases/tag/v0.8.0) - 2026-09-07
+
+### Added
+
+- Star conversations and keep them at the top of the list, show unread threads,
+  and open the matching conversation from notifications and client launches.
+- Filter message notifications to known contacts and configure which iPhone
+  applications can send ANCS notifications to the desktop.
+- Provide separate Fedora 45 RPMs for its Python version.
+
+### Changed
+
+- Group direct conversations across addresses that belong unambiguously to the
+  same synced contact, preserving the sender and reply destination.
+- Match Quickshell's fonts, colors, and controls to Omarchy themes while keeping
+  outgoing message bubbles blue. Improve text selection, long-message layout,
+  and single-line composer alignment.
+- Use the saved group members directly for Quickshell replies without a separate
+  confirmation checkbox.
+- Share conversation refresh, routing, and setup logic across clients, and
+  extract Qt and Quickshell settings components for easier maintenance.
+
+### Fixed
+
+- Improve Bluetooth pairing and recovery across Classic and LE reconnects,
+  adapter resets, and stale ANCS notification subscriptions.
+- Apply the WirePlumber phone-audio policy before pairing and avoid unnecessary
+  OBEX session cleanup after shutdown or transport loss.
+- Preserve conversation scroll, read state, and saved preferences across
+  refreshes, contact merges, and storage changes.
+- Separate named groups by spelling, migrate legacy routes safely, and prevent
+  stale group rosters or delayed responses from enabling incorrect replies.
+- Check backend API compatibility after recovering stale packaged daemons and
+  provide guidance to install the most recent version when incompatible.
+- Build Arch packages with the system Python and give Quickshell tests a private
+  runtime directory. Support Ubuntu 24.04's setuptools metadata format and ship
+  missing Qt startup dependencies in Debian and Fedora packages.
+- Check installed Qt startup with the default KDE style across the supported
+  native package matrix.
+
 ## [0.7.7](https://github.com/erikwb/blueferry/releases/tag/v0.7.7) - 2026-08-17
 
 ### Fixed

--- a/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Gtk.metainfo.xml
@@ -40,6 +40,13 @@
   </developer>
 
   <releases>
+    <release version="0.8.0" date="2026-09-07">
+      <description>
+        <p>Adds starred and unread conversations, groups messages by synced
+        contact, and expands notification filtering. Improves Bluetooth pairing
+        and recovery, group reply safety, and native package startup.</p>
+      </description>
+    </release>
     <release version="0.7.7" date="2026-08-17">
       <description>
         <p>Restores Debian backend startup on systemd 255 while retaining

--- a/data/io.weirdware.BlueFerry.Qt.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Qt.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.8.0" date="2026-09-07"><description><p>Adds starred and unread conversations, groups messages by synced contact, and expands notification filtering. Improves Bluetooth pairing and recovery, group reply safety, and first-install Qt startup.</p></description></release>
     <release version="0.7.7" date="2026-08-17"><description><p>Restores Debian backend startup on systemd 255 while retaining stronger service sandboxing in other native packages.</p></description></release>
     <release version="0.7.6" date="2026-08-17"><description><p>Adds local conversation deletion, improves pairing diagnostics and Bluetooth recovery, and fixes backend startup on systemd 255.</p></description></release>
     <release version="0.7.5" date="2026-08-16"><description><p>Recovers ANCS when a previously authorized iPhone stops responding after a Bluetooth reconnect.</p></description></release>

--- a/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
+++ b/data/io.weirdware.BlueFerry.Quickshell.metainfo.xml
@@ -14,6 +14,7 @@
   <content_rating type="oars-1.1"/>
   <developer id="io.weirdware"><name>BlueFerry contributors</name></developer>
   <releases>
+    <release version="0.8.0" date="2026-09-07"><description><p>Matches Omarchy themes while retaining blue message bubbles, improves the message composer, and uses saved group members directly for replies. Adds starred and unread conversations and improves Bluetooth recovery.</p></description></release>
     <release version="0.7.7" date="2026-08-17"><description><p>Restores Debian backend startup on systemd 255 while retaining stronger service sandboxing in other native packages.</p></description></release>
     <release version="0.7.6" date="2026-08-17"><description><p>Adds local conversation deletion, improves pairing diagnostics and Bluetooth recovery, and fixes backend startup on systemd 255.</p></description></release>
     <release version="0.7.5" date="2026-08-16"><description><p>Recovers ANCS when a previously authorized iPhone stops responding after a Bluetooth reconnect.</p></description></release>

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=(
   blueferry-qt
   blueferry-quickshell
 )
-pkgver=0.7.7
+pkgver=0.8.0
 pkgrel=1
 pkgdesc='BlueFerry Bluetooth bridge from iPhone to Linux'
 arch=('any')

--- a/packaging/deb/changelog
+++ b/packaging/deb/changelog
@@ -1,3 +1,16 @@
+blueferry (0.8.0-1) unstable; urgency=medium
+
+  * Add starred and unread conversations, contact-based conversation grouping,
+    and notification filtering.
+  * Improve group reply safety and share conversation and setup logic across
+    clients.
+  * Align the Quickshell client with Omarchy themes and simplify group replies.
+  * Harden Bluetooth pairing, reconnect recovery, and backend compatibility.
+  * Fix native package builds and Qt startup dependencies, and verify installed
+    Qt startup across the supported package matrix.
+
+ -- BlueFerry Contributors <blueferry@weirdware.io>  Mon, 07 Sep 2026 18:39:35 -0400
+
 blueferry (0.7.7-1) unstable; urgency=medium
 
   * Keep the backend user service compatible with systemd 255 on Debian while

--- a/packaging/rpm/blueferry.spec
+++ b/packaging/rpm/blueferry.spec
@@ -1,5 +1,5 @@
 Name:           blueferry-backend
-Version:        0.7.7
+Version:        0.8.0
 Release:        1%{?dist}
 Summary:        iPhone Bluetooth bridge backend, daemon, and CLI
 License:        GPL-2.0-or-later AND MIT AND BSD-2-Clause AND PSF-2.0
@@ -197,6 +197,14 @@ fi
 %{_metainfodir}/io.weirdware.BlueFerry.Qt.metainfo.xml
 
 %changelog
+* Mon Sep 07 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.8.0-1
+- Add starred and unread conversations, contact-based conversation grouping,
+  and notification filtering.
+- Improve group reply safety, shared client behavior, and the Quickshell UI.
+- Harden Bluetooth pairing, reconnect recovery, and backend compatibility.
+- Add Fedora 45 RPMs and fix native package builds and Qt startup dependencies.
+- Verify installed Qt startup across the supported package matrix.
+
 * Mon Aug 17 2026 BlueFerry Contributors <blueferry@weirdware.io> - 0.7.7-1
 - Keep the Debian backend user service compatible with systemd 255.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "blueferry"
-version = "0.7.7"
+version = "0.8.0"
 description = "BlueFerry brings iPhone messages, notifications, and contacts to Linux"
 authors = [
   {name = "Erik Bourget", email = "erik@ebourget.net"},

--- a/src/blueferry/__init__.py
+++ b/src/blueferry/__init__.py
@@ -1,3 +1,3 @@
 """BlueFerry — Bluetooth bridge from a paired iPhone to Linux desktop."""
 
-__version__ = "0.7.7"
+__version__ = "0.8.0"


### PR DESCRIPTION
Prepare BlueFerry 0.8.0 across Python metadata, the Arch/DEB/RPM recipes, and all three AppStream release histories. Add release notes for the conversation, Bluetooth recovery, client UI, and packaging changes since 0.7.7.

Validation:
- 62 focused packaging, metadata, build identity, and diagnostic-report tests passed.
- All three AppStream files validated, and Ruff passed.
- All PR CI checks and all 14 native build/install jobs passed: https://github.com/erikwb/blueferry/actions/runs/34167551665
- Confirmed all 15 generated binary/source packages carry version 0.8.0.
