### PR TITLE
Remove re-pairing advice from ANCS recovery guidance

### DIFF
--- a/data/quickshell/PhoneSettingsPage.qml
+++ b/data/quickshell/PhoneSettingsPage.qml
@@ -43,7 +43,7 @@ Rectangle {
   function ancsUnavailableHint() {
     if (root.ancsLimited())
       return root.ancsExpectedDetail();
-    return "FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Before re-pairing, run sudo systemctl restart bluetooth.service, then forget this computer on the iPhone and pair again. This briefly disconnects all Bluetooth devices.";
+    return "FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Try running sudo systemctl restart bluetooth.service, then wait for BlueFerry to reconnect. This briefly disconnects all Bluetooth devices.";
   }
 
   color: root.theme.windowSurface

--- a/src/blueferry/onboarding.py
+++ b/src/blueferry/onboarding.py
@@ -13,9 +13,9 @@ from blueferry.setup_verification import remaining_iphone_setup_tasks
 
 ANCS_REPAIR_HINT = _(
     "FYI: If ANCS remains unavailable, BlueZ may be retaining stale "
-    "Bluetooth state. Before re-pairing, run sudo systemctl restart "
-    "bluetooth.service, then forget this computer on the iPhone and "
-    "pair again. This briefly disconnects all Bluetooth devices."
+    "Bluetooth state. Try running sudo systemctl restart bluetooth.service, "
+    "then wait for BlueFerry to reconnect. This briefly disconnects all "
+    "Bluetooth devices."
 )
 ANCS_REPAIR_HINT_CLI = _(
     "FYI: If ANCS remains unavailable after setup, BlueZ may be "

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -55,8 +55,8 @@ def _print_ancs_repair_hint(*, limited: bool = False, vendor: str = "") -> None:
             fg=typer.colors.YELLOW,
         )
     )
-    typer.echo("Before re-pairing, run: sudo systemctl restart bluetooth.service")
-    typer.echo("Then forget this computer on the iPhone and pair again.")
+    typer.echo("Run: sudo systemctl restart bluetooth.service")
+    typer.echo("Then wait for BlueFerry to reconnect.")
     typer.echo("This briefly disconnects all Bluetooth devices.")
 
 

--- a/src/blueferry/qt/qml/OnboardingSummary.qml
+++ b/src/blueferry/qt/qml/OnboardingSummary.qml
@@ -99,7 +99,7 @@ Kirigami.InlineMessage {
 
     function ancsUnavailableHint() {
         if (!ancsLimitedController())
-            return qsTr("FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Before re-pairing, run sudo systemctl restart bluetooth.service, then forget this computer on the iPhone and pair again. This briefly disconnects all Bluetooth devices.")
+            return qsTr("FYI: If ANCS remains unavailable, BlueZ may be retaining stale Bluetooth state. Try running sudo systemctl restart bluetooth.service, then wait for BlueFerry to reconnect. This briefly disconnects all Bluetooth devices.")
         return ancsLimitedDetail()
     }
 }

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -21,13 +21,13 @@ def test_verified_cli_setup_omits_the_iphone_section(capsys) -> None:
     assert capsys.readouterr().out == ""
 
 
-def test_cli_ancs_repair_hint_restarts_bluez_before_repairing(capsys) -> None:
+def test_cli_ancs_repair_hint_recommends_bluez_restart(capsys) -> None:
     _print_ancs_repair_hint()
 
     output = capsys.readouterr().out
     assert "If ANCS remains unavailable after setup" in output
     assert "sudo systemctl restart bluetooth.service" in output
-    assert "forget this computer on the iPhone and pair again" in output
+    assert "wait for BlueFerry to reconnect" in output
     assert "briefly disconnects all Bluetooth devices" in output
 
 


### PR DESCRIPTION
When ANCS remains unavailable, the recovery hint tells users to forget their pairing after restarting Bluetooth. Change the Quickshell, Qt, shared GTK/TUI, and CLI guidance to restart Bluetooth and wait for BlueFerry to reconnect. Keep the notice that restarting Bluetooth briefly disconnects all Bluetooth devices.

Validation: 22 onboarding and pairing CLI tests passed; Ruff and QML lint passed for the changed files.
