### PR TITLE
Recover storage asynchronously after keyring startup races

### DIFF
--- a/src/blueferry/backend_operations.py
+++ b/src/blueferry/backend_operations.py
@@ -164,6 +164,8 @@ class BackendDependencies:
     starred_threads: StarredThreads | None = None
     confirmed_groups: ConfirmedGroups | None = None
     storage: StorageSecurity | None = None
+    prepare_storage: Callable[[StorageSecurity], Any] | None = None
+    on_storage_prepared: Callable[[Any], None] | None = None
     on_storage_changed: Callable[[], None] | None = None
 
 
@@ -846,9 +848,6 @@ class BackendOperations:
         storage = self.dependencies.storage
         if storage is None:
             raise NotReadyError("local storage is unavailable")
-        if storage.busy:
-            raise NotReadyError("a desktop wallet request is already pending")
-        selected = self._prepare_storage_policy(policy) if policy is not None else None
         completed = False
 
         def succeeded(status: StorageStatus) -> None:
@@ -859,22 +858,77 @@ class BackendOperations:
             except Exception as error:
                 failure(error)
 
+        if storage.busy:
+            def prepared(status: StorageStatus) -> None:
+                # A locked-wallet cleanup may finish without obtaining a key.
+                # Preserve the joined client's request for a password prompt.
+                if status.state == "locked":
+                    try:
+                        self.change_storage_async(submit, success, failure)
+                    except Exception as error:
+                        failure(error)
+                else:
+                    succeeded(status)
+
+            if policy is None and storage.join_preparation(prepared):
+                return
+            if not storage.cancel_passive_request():
+                raise NotReadyError("a desktop wallet request is already pending")
+        selected = self._prepare_storage_policy(policy) if policy is not None else None
         storage.change_async(
             submit, policy=selected, on_success=succeeded, on_error=failure,
+            **self._storage_preparation_args(),
         )
         # Publish policy changes immediately, including while key creation or
         # deletion is waiting on the wallet. Do not expose an old contact cache.
         if selected is not None and not completed:
             self._storage_changed(storage.status)
 
+    def retry_storage_async(
+        self, submit: Callable[..., object], success: Success, failure: Failure,
+        *, initialize: bool = False,
+    ) -> None:
+        """Pick up an existing key after login without opening a wallet prompt."""
+        storage = self.dependencies.storage
+        if storage is None or storage.busy:
+            return
+        previous = storage.status
+        if not initialize and previous.state != "locked":
+            return
+
+        def succeeded(status: StorageStatus) -> None:
+            if status == previous and not initialize:
+                return
+            try:
+                success(self._storage_changed(status))
+            except Exception as error:
+                failure(error)
+
+        storage.change_async(
+            submit, on_success=succeeded, on_error=failure,
+            allow_prompt=False, timeout_seconds=5,
+            **self._storage_preparation_args(),
+        )
+
+    def _storage_preparation_args(self) -> dict[str, Any]:
+        if self.dependencies.prepare_storage is None:
+            return {}
+        return {
+            "prepare": self.dependencies.prepare_storage,
+            "on_prepared": self.dependencies.on_storage_prepared,
+        }
+
     def _storage_changed(self, status: StorageStatus) -> dict:
         if self.dependencies.contacts is not None:
-            self.dependencies.contacts.refresh()
-        if self.dependencies.storage is not None:
-            status = self.dependencies.storage.status
+            # The prepared cache has already been installed by the request.
+            # Locked/error states still clear the old cache without disk I/O.
+            if self.dependencies.prepare_storage is None or not status.can_read:
+                self.dependencies.contacts.refresh()
         self.invalidate_conversations()
         if self.dependencies.on_storage_changed is not None:
             self.dependencies.on_storage_changed()
+        if self.dependencies.storage is not None:
+            status = self.dependencies.storage.status
         return {
             "storage_policy": status.policy,
             "storage_state": status.state,

--- a/src/blueferry/background_worker.py
+++ b/src/blueferry/background_worker.py
@@ -20,6 +20,10 @@ class BackgroundWorker:
         self._pending: set[Future] = set()
         self._closed = False
 
+    @property
+    def busy(self) -> bool:
+        return bool(self._pending)
+
     def submit(
         self, operation: Callable[[], Any], *,
         on_success: Callable[[Any], None], on_error: Callable[[Exception], None],

--- a/src/blueferry/contact_repository.py
+++ b/src/blueferry/contact_repository.py
@@ -208,7 +208,7 @@ class ContactRepository:
             records.append((name, phones, emails))
         return records
 
-    def load(self) -> list[ContactRecord]:
+    def load(self, *, strict: bool = False) -> list[ContactRecord]:
         if self.storage is not None and not self.storage.status.can_read:
             return []
         try:
@@ -221,5 +221,7 @@ class ContactRepository:
                     connection.execute("VACUUM")
                 return records
         except sqlite3.Error as error:
+            if strict:
+                raise
             log.warning("contacts cache warm failed: %s", error)
             return []

--- a/src/blueferry/contacts.py
+++ b/src/blueferry/contacts.py
@@ -215,15 +215,15 @@ class ContactsResolver:
     otherwise bound `resolve` methods become stale.
     """
 
-    def __init__(self, *, storage: StorageSecurity | None = None) -> None:
+    def __init__(self, *, storage: StorageSecurity | None = None, strict: bool = False) -> None:
         self.storage = storage
         self._repository = ContactRepository(storage)
         self._mem: dict[str, set[str]] = {}
         self._records: list[ContactRecord] = []
-        self._warm()
+        self._warm(strict=strict)
 
-    def _warm(self) -> None:
-        loaded = [_sanitized(record) for record in self._repository.load()]
+    def _warm(self, *, strict: bool = False) -> None:
+        loaded = [_sanitized(record) for record in self._repository.load(strict=strict)]
         # Order once here rather than per page: the cache is rebuilt only by
         # refresh(), and paging must not pay for a sort on every call.
         loaded.sort(key=lambda record: (
@@ -272,6 +272,12 @@ class ContactsResolver:
         resolver._records = self._records.copy()
         resolver._thread_addresses = self._thread_addresses.copy()
         return resolver
+
+    def adopt_cache(self, prepared: ContactsResolver) -> None:
+        """Install a worker-built cache while keeping this resolver's live repository."""
+        self._mem = prepared._mem
+        self._records = prepared._records
+        self._thread_addresses = prepared._thread_addresses
 
     def refresh(self) -> int:
         """Re-read the SQLite cache into memory. Returns new count."""

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -23,17 +23,12 @@ from blueferry.build_info import build_id, installed_build_sha, running_build_sh
 from blueferry.bus import get_system_bus, main_loop
 from blueferry.confirmed_groups import ConfirmedGroupsStore
 from blueferry.connectivity import Connectivity
-from blueferry.contacts import ContactsResolver, clear_contact_cache, pull_phonebook
+from blueferry.contacts import ContactsResolver, pull_phonebook
 from blueferry.dbus_service import MessagesService, claim_bus_name
 from blueferry.event_dispatcher import EventDispatcher
 from blueferry.history import (
-    clear_events,
     history_count,
     mark_event_handles_read,
-    minimize_ancs_history,
-    prune_events,
-    read_events,
-    scrub_unprotected_events,
 )
 from blueferry.notification_policy import (
     ALL_NOTIFICATIONS,
@@ -53,7 +48,8 @@ from blueferry.setup_verification import (
 )
 from blueferry.solicitation_supervisor import SolicitationSupervisor
 from blueferry.starred_threads import StarredThreadsStore
-from blueferry.storage_security import NO_STORAGE, StorageSecurity
+from blueferry.storage_preparation import PreparedStorage, prepare_storage
+from blueferry.storage_security import StorageSecurity
 from blueferry.wireplumber_policy import WirePlumberPhoneAudioPolicy
 
 log = logging.getLogger(__name__)
@@ -75,6 +71,7 @@ CONTACTS_REFRESH_SEC = 24 * 60 * 60  # 24h
 # every logged-in user's systemd instance.
 PACKAGE_RELEASE_CHECK_SEC = 10
 TARGET_CONFIG_CHECK_SEC = 2
+STORAGE_RETRY_SEC = 5
 RESTART_AFTER_UPGRADE_EXIT = 75
 
 
@@ -90,6 +87,7 @@ class Daemon:
         # prevents two simultaneous first launches from creating different
         # keys for the same database.
         self.storage = StorageSecurity(initialize=False)
+        self.storage.require_preparation()
         self.contacts = ContactsResolver(storage=self.storage)
         self.connectivity = Connectivity()
         self.notification_policy = NotificationPolicyStore()
@@ -142,6 +140,7 @@ class Daemon:
         )
         self._release_check_id: int | None = None
         self._target_config_check_id: int | None = None
+        self._storage_retry_id: int | None = None
         self._restart_after_upgrade = False
         self._release_missing_checks = 0
         self._startup_id: int | None = None
@@ -212,7 +211,6 @@ class Daemon:
         # the control surface before any Bluetooth operation that can wait on
         # hardware or the phone.
         self._bus_name = claim_bus_name()
-        self._initialize_storage()
         self._dbus_service = MessagesService(
             self._bus_name,
             self.sessions,
@@ -229,10 +227,13 @@ class Daemon:
                 starred_threads=self.starred_threads,
                 confirmed_groups=self.confirmed_groups,
                 storage=self.storage,
-                on_storage_changed=self._emit_status,
+                prepare_storage=prepare_storage,
+                on_storage_prepared=self._apply_storage_preparation,
+                on_storage_changed=self._on_storage_changed,
             ),
         )
         self.events.set_dbus_service(self._dbus_service)
+        self._initialize_storage()
         log.info("DBus service ready: %s", BUS_NAME)
         self._emit_status()
 
@@ -243,6 +244,9 @@ class Daemon:
         self._target_config_check_id = GLib.timeout_add_seconds(
             TARGET_CONFIG_CHECK_SEC, self._check_target_config
         )
+        self._storage_retry_id = GLib.timeout_add_seconds(
+            STORAGE_RETRY_SEC, self._retry_storage
+        )
 
         for sig in (signal.SIGINT, signal.SIGTERM):
             signal.signal(sig, self._signal)
@@ -251,41 +255,33 @@ class Daemon:
         # profile setup. This makes activation and GetStatus deterministic.
         self._startup_id = GLib.timeout_add(250, self._initialize)
 
+    def _retry_storage(self) -> bool:
+        # A daemon activated before the desktop keyring opens must recover
+        # without requiring a client launch. Wallet I/O stays off the GLib loop.
+        try:
+            if self._dbus_service is not None:
+                self._dbus_service.retry_storage_unlock()
+        except Exception:
+            log.warning("could not schedule background storage retry", exc_info=True)
+        return True
+
     def _initialize_storage(self) -> None:
-        status = self.storage.refresh(allow_prompt=False)
-        # Upgrade/scrub legacy preferences even if the wallet is locked.
-        self.starred_threads.migrate()
-        self.confirmed_groups.migrate()
-        if status.policy == NO_STORAGE:
-            clear_events()
-            clear_contact_cache()
-            return
-        if not status.can_read:
-            log.info("private storage unavailable: %s", status.detail)
-            return
-        scrubbed = scrub_unprotected_events(storage=self.storage)
-        if scrubbed:
-            log.info("scrubbed %d unprotected history events", scrubbed)
-        prune_events(storage=self.storage)
-        discarded, minimized = minimize_ancs_history(storage=self.storage)
-        if discarded or minimized:
-            log.info(
-                "minimized ANCS history (discarded=%d, compacted=%d)",
-                discarded,
-                minimized,
-            )
-        self.contacts.refresh()
-        if self.contacts.count() > 0:
-            self._mark_setup_task(CONTACTS)
-        if read_events(kinds={"sms_received"}, limit=1, storage=self.storage):
+        if self._dbus_service is not None:
+            self._dbus_service.retry_storage_unlock(initialize=True)
+
+    def _apply_storage_preparation(self, prepared: PreparedStorage) -> None:
+        self.contacts.adopt_cache(prepared.contacts)
+        self.events.seed_historical_ancs(prepared.historical_ancs)
+        if prepared.has_messages:
             self._mark_setup_task(MESSAGE_NOTIFICATIONS)
-        self.events.seed_historical_ancs(
-            read_events(
-                kinds={"ancs_notification"},
-                limit=2_000,
-                storage=self.storage,
-            )
-        )
+
+    def _on_storage_changed(self) -> None:
+        if self.storage.status.can_write:
+            if self.contacts.count() > 0:
+                self._mark_setup_task(CONTACTS)
+            else:
+                self._refresh_contacts()
+        self._emit_status()
 
     def _initialize(self) -> bool:
         self._startup_id = None
@@ -526,7 +522,11 @@ class Daemon:
 
     def _refresh_contacts(self) -> None:
         """Best-effort wrapper used by startup and the periodic timer."""
-        if self._contacts_refresh_pending or self.sessions.pbap is None:
+        if (
+            self._contacts_refresh_pending
+            or self.sessions.pbap is None
+            or not self.storage.status.can_write
+        ):
             return
         self._contacts_refresh_pending = True
 
@@ -539,7 +539,10 @@ class Daemon:
             log.error("contacts refresh failed; using previous cache: %s", error)
             self.sessions.report_error(error)
 
-        self.obex_worker.submit(self._pull_contacts, on_success=succeeded, on_error=failed)
+        try:
+            self.obex_worker.submit(self._pull_contacts, on_success=succeeded, on_error=failed)
+        except Exception as error:
+            failed(error)
 
     def _periodic_refresh_contacts(self) -> bool:
         """GLib timeout callback. Return True to keep the timer running."""
@@ -611,6 +614,7 @@ class Daemon:
             "_contacts_refresh_id",
             "_release_check_id",
             "_target_config_check_id",
+            "_storage_retry_id",
             "_startup_id",
             "_initialization_retry_id",
         ):

--- a/src/blueferry/dbus_service.py
+++ b/src/blueferry/dbus_service.py
@@ -43,7 +43,9 @@ class MessagesService(dbus.service.Object):
         self._change_revision = 0
         self.operations = operations or BackendOperations(sessions, dependencies)
         self._projection_worker = BackgroundWorker("blueferry-projection", maximum=1)
-        self._wallet_worker = BackgroundWorker("blueferry-wallet", maximum=1)
+        # One active lookup plus an interactive request queued behind a
+        # cancelled passive lookup. The executor still runs one job at a time.
+        self._wallet_worker = BackgroundWorker("blueferry-wallet", maximum=2)
 
     @staticmethod
     def _dbus_error(error: Exception) -> dbus.exceptions.DBusException:
@@ -347,6 +349,24 @@ class MessagesService(dbus.service.Object):
     )
     def UnlockStorage(self, reply_handler, error_handler, sender=None) -> None:
         self._storage_call(sender, "unlock", None, reply_handler, error_handler)
+
+    def retry_storage_unlock(self, *, initialize: bool = False) -> None:
+        """Daemon-only passive recovery, using the same worker as UI unlocks."""
+        # A timed-out lookup may still be unwinding its native call. Reserve
+        # the second slot for user action instead of queuing another poll.
+        if self._wallet_worker.busy:
+            return
+
+        def changed(status) -> None:
+            if status["storage_state"] == "ready":
+                log.info("encrypted storage became available after keyring retry")
+                self.emit_history_changed()
+
+        self.operations.retry_storage_async(
+            self._wallet_worker.submit, changed,
+            lambda error: log.warning("background storage retry failed: %s", error),
+            initialize=initialize,
+        )
 
     @dbus.service.method(
         IFACE, in_signature="su", out_signature="s",

--- a/src/blueferry/settings_store.py
+++ b/src/blueferry/settings_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from threading import Lock
 from typing import Any
 
 from blueferry import config
@@ -12,6 +13,7 @@ from blueferry.private_files import atomic_write_private_text, read_private_text
 # characters), plus roster digests and encryption framing. Keep local.env
 # parsing on its smaller, independent config limit.
 MAX_SETTINGS_FILE_BYTES = 4 * 1024 * 1024
+_UPDATE_LOCK = Lock()
 
 
 class SettingsStore:
@@ -30,11 +32,14 @@ class SettingsStore:
         return value if isinstance(value, dict) else {}
 
     def update(self, **values: Any) -> None:
-        payload = self.read()
-        payload.update(values)
-        encoded = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
-        atomic_write_private_text(
-            self.path,
-            encoded,
-            maximum_bytes=MAX_SETTINGS_FILE_BYTES,
-        )
+        # Preparation can migrate private preferences on a worker while the
+        # main loop saves notification settings. Serialize the read/modify/write.
+        with _UPDATE_LOCK:
+            payload = self.read()
+            payload.update(values)
+            encoded = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+            atomic_write_private_text(
+                self.path,
+                encoded,
+                maximum_bytes=MAX_SETTINGS_FILE_BYTES,
+            )

--- a/src/blueferry/sinks/sqlite.py
+++ b/src/blueferry/sinks/sqlite.py
@@ -29,8 +29,10 @@ class SqliteSink:
         self.storage = storage
         self._writes_since_prune = 0
         self._unavailable_logged = False
-        if storage is not None and not storage.status.can_write:
-            log.info("SQLite history sink idle: %s", storage.status.detail)
+        if storage is not None:
+            # Managed stores are prepared by the asynchronous storage lifecycle.
+            # Sink creation must not repeat those archive scans on the GLib loop.
+            log.info("SQLite history sink: %s", storage.status.detail)
             return
         discarded, minimized = minimize_ancs_history(
             path=self.path, storage=self.storage

--- a/src/blueferry/storage_preparation.py
+++ b/src/blueferry/storage_preparation.py
@@ -1,0 +1,42 @@
+"""Worker-side storage validation and the cache data committed after it succeeds."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from blueferry.confirmed_groups import ConfirmedGroupsStore
+from blueferry.contacts import ContactsResolver, clear_contact_cache
+from blueferry.history import (
+    clear_events,
+    minimize_ancs_history,
+    prune_events,
+    read_events,
+    scrub_unprotected_events,
+)
+from blueferry.starred_threads import StarredThreadsStore
+from blueferry.storage_security import NO_STORAGE, CorruptStorageError, StorageSecurity
+
+
+@dataclass
+class PreparedStorage:
+    contacts: ContactsResolver
+    historical_ancs: list[dict]
+    has_messages: bool
+
+
+def prepare_storage(storage: StorageSecurity) -> PreparedStorage:
+    """Use only the request's private key snapshot, never the live daemon state."""
+    StarredThreadsStore(storage.settings_path, storage=storage).migrate()
+    ConfirmedGroupsStore(storage.settings_path, storage=storage).migrate()
+    if storage.status.policy == NO_STORAGE:
+        clear_events()
+        clear_contact_cache()
+    elif storage.status.can_read:
+        scrub_unprotected_events(storage=storage)
+        prune_events(storage=storage)
+        minimize_ancs_history(storage=storage)
+    contacts = ContactsResolver(storage=storage, strict=True)
+    historical = read_events(kinds={"ancs_notification"}, limit=2_000, storage=storage)
+    has_messages = bool(read_events(kinds={"sms_received"}, limit=1, storage=storage))
+    if storage.status.state == "error":
+        raise CorruptStorageError(storage.status.detail)
+    return PreparedStorage(contacts, historical, has_messages)

--- a/src/blueferry/storage_security.py
+++ b/src/blueferry/storage_security.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import sqlite3
 from collections.abc import Callable
 from copy import copy
 from dataclasses import dataclass
-from typing import Protocol
+from pathlib import Path
+from threading import RLock
+from typing import Any, Protocol
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -34,6 +37,26 @@ class StorageUnavailableError(RuntimeError):
 
 class CorruptStorageError(ValueError):
     """A retained ciphertext failed authenticated decryption."""
+
+
+@dataclass
+class _PreparedKey:
+    value: bytes | bool
+    data: Any
+
+
+def _retryable_preparation_error(error: Exception) -> bool:
+    if isinstance(error, OSError):
+        return not isinstance(error, PermissionError)
+    if not isinstance(error, sqlite3.OperationalError):
+        return False
+    # SQLite primary result codes: BUSY, LOCKED, IOERR, FULL. Python 3.10
+    # does not expose sqlite_errorcode, so retain its exact-message fallback.
+    code = getattr(error, "sqlite_errorcode", 0) & 0xff
+    return code in {5, 6, 10, 13} or str(error).lower() in {
+        "database is locked", "database table is locked",
+        "disk i/o error", "database or disk is full",
+    }
 
 
 class KeyProvider(Protocol):
@@ -242,6 +265,10 @@ class StorageSecurity:
         self._policy = selected if selected in STORAGE_POLICIES else DEFAULT_STORAGE_POLICY
         self._key: bytearray | None = None
         self._cancel_request: Callable[[], None] | None = None
+        self._passive_request = False
+        self._preparing = False
+        self._request_lock = RLock()
+        self._preparation_waiters: list[Callable[[StorageStatus], None]] = []
         self._failure_generation = 0
         if self._policy == NO_STORAGE:
             self._state = "disabled"
@@ -259,21 +286,55 @@ class StorageSecurity:
     def status(self) -> StorageStatus:
         return StorageStatus(self._policy, self._state, self._detail)
 
+    @property
+    def settings_path(self) -> Path:
+        return self._settings.path
+
+    def require_preparation(self) -> None:
+        """Gate daemon startup until its asynchronous preparation has finished."""
+        if self._policy != NO_STORAGE:
+            self._forget_key()
+            self._state = "locked"
+            self._detail = "Preparing local storage"
+
     def snapshot(self) -> StorageSecurity:
         """Own a separate key buffer while a background read is in progress."""
         reader = copy(self)
         reader._key = bytearray(self._key) if self._key is not None else None
         reader._cancel_request = None
+        reader._request_lock = RLock()
+        reader._preparation_waiters = []
+        reader._preparing = False
+        reader._passive_request = False
         return reader
 
     @property
     def busy(self) -> bool:
         return self._cancel_request is not None
 
+    def cancel_passive_request(self) -> bool:
+        """Let a user action supersede a prompt-free wallet lookup."""
+        with self._request_lock:
+            if not self.busy or not self._passive_request:
+                return False
+            self.cancel_pending()
+            return True
+
+    def join_preparation(self, on_success: Callable[[StorageStatus], None]) -> bool:
+        """An unlock can await validation already in progress without restarting it."""
+        with self._request_lock:
+            if not self.busy or not self._preparing:
+                return False
+            self._preparation_waiters.append(on_success)
+            return True
+
     def change_async(
         self, submit: Callable[..., object], *, policy: str | None = None,
         on_success: Callable[[StorageStatus], None], on_error: Callable[[Exception], None],
         timeout_seconds: int = 120,
+        allow_prompt: bool = True,
+        prepare: Callable[[StorageSecurity], Any] | None = None,
+        on_prepared: Callable[[Any], None] | None = None,
     ) -> None:
         """Perform wallet I/O off-loop; apply key and policy state only on GLib."""
         from gi.repository import Gio, GLib
@@ -282,59 +343,155 @@ class StorageSecurity:
             raise StorageUnavailableError("a desktop wallet request is already pending")
         if policy is not None:
             self._select_policy(policy)
-        if self._policy == PLAINTEXT_STORAGE or (self._policy == NO_STORAGE and policy is None):
+        if prepare is None and (
+            self._policy == PLAINTEXT_STORAGE or (self._policy == NO_STORAGE and policy is None)
+        ):
             on_success(self.status)
             return
         deleting = self._policy == NO_STORAGE
+        selected_policy = self._policy
+        if prepare is not None and not deleting:
+            self._state = "locked"
+            self._detail = "Preparing local storage"
         failure_generation = self._failure_generation
         cancellable = Gio.Cancellable()
         timer: int | None = None
 
         def cancel() -> None:
             nonlocal timer
-            cancellable.cancel()
-            if timer is not None:
-                GLib.source_remove(timer)
-                timer = None
-            self._cancel_request = None
+            with self._request_lock:
+                cancellable.cancel()
+                if timer is not None:
+                    GLib.source_remove(timer)
+                    timer = None
+                self._cancel_request = None
+                self._passive_request = False
+                self._preparing = False
+                self._preparation_waiters = []
 
         self._cancel_request = cancel
+        self._passive_request = not allow_prompt and policy is None
 
-        def finish(value: bytes | bool | None, error: Exception | None = None) -> None:
+        def finish(
+            value: bytes | bool | _PreparedKey | None, error: Exception | None = None,
+        ) -> None:
             if self._cancel_request is not cancel:
                 return
+            preparing = self._preparing
+            waiters = self._preparation_waiters
             cancel()
-            if deleting:
+            prepared = value if isinstance(value, _PreparedKey) else None
+            if prepared is not None:
+                value = prepared.value
+            if self._failure_generation != failure_generation:
+                # Independent corruption detection always wins over a late result.
+                pass
+            elif isinstance(error, StorageUnavailableError) and not deleting:
+                self._forget_key()
+                self._state = "locked"
+                self._detail = str(error)
+            elif preparing and error is not None and not (
+                deleting and isinstance(error, StorageUnavailableError)
+            ):
+                if _retryable_preparation_error(error):
+                    self._forget_key()
+                    self._state = "locked"
+                    self._detail = "Local storage is temporarily unavailable; retrying"
+                else:
+                    self.fail_closed(
+                        str(error) if isinstance(error, CorruptStorageError)
+                        else "Local storage could not be prepared"
+                    )
+                log.warning("local storage preparation failed: %s", error)
+            elif deleting:
+                self._state = "disabled"
                 self._detail = (
                     "Local data is not retained; remove the old BlueFerry key "
                     "through the desktop wallet if desired"
                 ) if error else "Local data is not retained"
-            elif self._failure_generation != failure_generation:
-                # An independent archive read may detect corruption while
-                # the wallet is open. Its failure must survive a late key.
-                pass
             elif error is not None:
                 self._forget_key()
                 self._state = "locked"
                 self._detail = str(error)
+            elif selected_policy == PLAINTEXT_STORAGE:
+                self._forget_key()
+                self._state = "ready"
+                self._detail = "Local data is retained without encryption"
             elif isinstance(value, bytes) and len(value) == _KEY_BYTES:
                 self._accept_key(value)
             else:
                 self._forget_key()
                 self._state = "locked"
                 self._detail = "the desktop keyring returned an invalid BlueFerry key"
-            on_success(self.status)
+            if prepared is not None and self._failure_generation == failure_generation:
+                if on_prepared is not None:
+                    try:
+                        on_prepared(prepared.data)
+                    except Exception:
+                        self.fail_closed("Prepared storage could not be activated")
+                        log.exception("could not activate prepared storage")
+            for callback in (on_success, *waiters):
+                try:
+                    callback(self.status)
+                except Exception:
+                    log.exception("storage completion callback failed")
 
         def timed_out() -> bool:
             nonlocal timer
-            timer = None
-            finish(None, StorageUnavailableError("desktop wallet request timed out; try again"))
+            with self._request_lock:
+                timer = None
+                # Local preparation is not cancellable wallet I/O. Keep its
+                # write barrier until it exits, including after a slow SQL lock.
+                if not self._preparing:
+                    finish(None, StorageUnavailableError(
+                        "desktop wallet request timed out; try again"
+                    ))
             return False
 
-        def request() -> bytes | bool:
-            if deleting:
-                return self._provider.delete(allow_prompt=True, cancellable=cancellable)
-            return self._provider.get_or_create(allow_prompt=True, cancellable=cancellable)
+        def request() -> bytes | bool | _PreparedKey:
+            wallet_error = None
+            value: bytes | bool = True
+            try:
+                if deleting and policy is not None:
+                    value = self._provider.delete(
+                        allow_prompt=allow_prompt, cancellable=cancellable,
+                    )
+                elif selected_policy == ENCRYPTED_STORAGE:
+                    value = self._provider.get_or_create(
+                        allow_prompt=allow_prompt, cancellable=cancellable,
+                    )
+                    if not isinstance(value, bytes) or len(value) != _KEY_BYTES:
+                        raise StorageUnavailableError(
+                            "the desktop keyring returned an invalid BlueFerry key"
+                        )
+            except StorageUnavailableError as error:
+                wallet_error = error
+            if prepare is None:
+                if wallet_error is not None:
+                    raise wallet_error
+                return value
+            with self._request_lock:
+                if self._cancel_request is not cancel or cancellable.is_cancelled():
+                    raise StorageUnavailableError("storage request cancelled")
+                self._preparing = True
+                self._passive_request = False
+                candidate = self.snapshot()
+            try:
+                if wallet_error is not None:
+                    candidate._forget_key()
+                    candidate._state = "locked" if not deleting else "disabled"
+                elif isinstance(value, bytes):
+                    candidate._accept_key(value)
+                elif not deleting:
+                    candidate._state = "ready"
+                data = prepare(candidate)
+                if candidate.status.state == "error":
+                    raise CorruptStorageError(candidate.status.detail)
+                if wallet_error is not None:
+                    raise wallet_error
+                return _PreparedKey(value, data)
+            finally:
+                candidate.close()
 
         try:
             timer = GLib.timeout_add_seconds(timeout_seconds, timed_out)

--- a/tests/test_contact_threads.py
+++ b/tests/test_contact_threads.py
@@ -21,7 +21,7 @@ EMAIL = "sarah@example.com"
 @pytest.fixture
 def contacts(monkeypatch):
     records = [("Dr. Sarah Bourget", [PHONE[1:], OTHER_PHONE[1:]], [EMAIL])]
-    monkeypatch.setattr(ContactRepository, "load", lambda _self: records)
+    monkeypatch.setattr(ContactRepository, "load", lambda _self, **_kwargs: records)
     return ContactsResolver(), records
 
 

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -374,7 +374,7 @@ def test_records_tolerate_a_malformed_stored_row(tmp_path, monkeypatch):
 
     resolver = ContactsResolver.__new__(ContactsResolver)
     resolver.storage = None
-    resolver._repository = SimpleNamespace(load=lambda: [
+    resolver._repository = SimpleNamespace(load=lambda **_kwargs: [
         ("Alice Example", None, ["alice@example.com"]),
         ("Bob Other", "5551234567", None),
         (None, ["15551112222"], []),

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -18,7 +18,7 @@ def _bare_daemon():
     instance = object.__new__(daemon_mod.Daemon)
     instance.sessions = object()
     instance.obex_worker = SimpleNamespace(submit=lambda *_args, **_kwargs: None)
-    instance.contacts = object()
+    instance.contacts = SimpleNamespace(refresh=lambda: 0, count=lambda: 0)
     instance.connectivity = Connectivity()
     instance.notification_policy = SimpleNamespace(
         value="messages", contacts_only=False
@@ -56,6 +56,7 @@ def _bare_daemon():
     instance._startup_id = None
     instance._initialization_retry_id = None
     instance._target_config_check_id = None
+    instance._storage_retry_id = None
     instance._initializing = True
     instance._running_release = "0.6.0-6"
     instance._running_build_sha = None
@@ -70,6 +71,7 @@ def test_start_publishes_dbus_before_scheduling_bluetooth(monkeypatch):
     instance = _bare_daemon()
     order = []
     scheduled = []
+    periodic = []
 
     monkeypatch.setattr(daemon_mod.config, "ensure_dirs", lambda: order.append("dirs"))
     monkeypatch.setattr(
@@ -90,7 +92,7 @@ def test_start_publishes_dbus_before_scheduling_bluetooth(monkeypatch):
     monkeypatch.setattr(
         daemon_mod.GLib,
         "timeout_add_seconds",
-        lambda _delay, _callback: 2,
+        lambda delay, callback: periodic.append((delay, callback)) or len(periodic),
     )
     monkeypatch.setattr(daemon_mod.signal, "signal", lambda *_args: None)
     monkeypatch.setattr(
@@ -105,13 +107,14 @@ def test_start_publishes_dbus_before_scheduling_bluetooth(monkeypatch):
 
     instance.start()
 
-    assert order == ["dirs", "claim", "storage", "service"]
+    assert order == ["dirs", "claim", "service", "storage"]
     assert len(scheduled) == 1
+    assert (daemon_mod.STORAGE_RETRY_SEC, instance._retry_storage) in periodic
     assert instance._initializing is True
 
     scheduled[0]()
 
-    assert order == ["dirs", "claim", "storage", "service", "bluetooth"]
+    assert order == ["dirs", "claim", "service", "storage", "bluetooth"]
     assert instance._initializing is False
 
 
@@ -135,34 +138,40 @@ def test_stop_does_not_ask_obexd_to_remove_sessions(monkeypatch):
         shutdown=lambda **kwargs: kwargs["cleanup"]()
     )
     monkeypatch.setattr(daemon_mod.main_loop, "quit", lambda: None)
+    removed = []
+    instance._storage_retry_id = 99
+    monkeypatch.setattr(daemon_mod.GLib, "source_remove", removed.append)
 
     instance.stop()
 
     assert closed == [{"remove_remote": False}]
+    assert removed == [99]
+    assert instance._storage_retry_id is None
 
 
-def test_no_storage_policy_reasserts_empty_local_data(monkeypatch):
+def test_storage_poll_survives_a_transient_scheduling_failure():
     instance = _bare_daemon()
-    status = SimpleNamespace(
-        policy="none", state="disabled", detail="", can_read=False
-    )
-    instance.storage = SimpleNamespace(
-        status=status,
-        refresh=lambda **_kwargs: status,
-    )
-    cleared = []
-    instance.starred_threads.migrate = lambda: cleared.append("stars")
-    instance.confirmed_groups.migrate = lambda: cleared.append("groups")
-    monkeypatch.setattr(
-        daemon_mod, "clear_events", lambda: cleared.append("events")
-    )
-    monkeypatch.setattr(
-        daemon_mod, "clear_contact_cache", lambda: cleared.append("contacts")
-    )
+    attempts = []
 
+    def retry():
+        attempts.append(True)
+        if len(attempts) == 1:
+            raise RuntimeError("wallet worker busy")
+
+    instance._dbus_service = SimpleNamespace(retry_storage_unlock=retry)
+    assert instance._retry_storage() is True
+    assert instance._retry_storage() is True
+    assert len(attempts) == 2
+
+
+def test_startup_queues_storage_preparation_after_publishing_service():
+    instance = _bare_daemon()
+    calls = []
+    instance._dbus_service = SimpleNamespace(
+        retry_storage_unlock=lambda **kwargs: calls.append(kwargs),
+    )
     instance._initialize_storage()
-
-    assert cleared == ["stars", "groups", "events", "contacts"]
+    assert calls == [{"initialize": True}]
 
 
 def test_successful_empty_phonebook_verifies_contact_permission():

--- a/tests/test_dbus_integration.py
+++ b/tests/test_dbus_integration.py
@@ -31,7 +31,7 @@ from blueferry.protocol import (
 )
 from blueferry.recipients import group_confirmation_token
 from blueferry.settings_store import SettingsStore
-from blueferry.storage_security import StorageSecurity
+from blueferry.storage_security import StorageSecurity, StorageUnavailableError
 
 pytestmark = pytest.mark.private_dbus
 _service_ids = itertools.count()
@@ -207,6 +207,262 @@ def test_wallet_wait_keeps_status_available(public_service, tmp_path):
         storage.close()
     assert "error" not in wallet
     assert json.loads(str(wallet["value"]))["storage_state"] == "ready"
+
+
+def test_passive_wallet_retry_keeps_status_available_and_announces_history(
+    public_service, tmp_path,
+):
+    name, _pending, _policy, _changes, service = public_service
+    entered = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    class Wallet:
+        def get_or_create(self, *, allow_prompt, cancellable=None):
+            calls.append(allow_prompt)
+            entered.set()
+            assert release.wait(4), "wallet fixture was not released"
+            return b"K" * 32
+
+    storage = StorageSecurity(
+        settings=SettingsStore(tmp_path / "settings.json"), key_provider=Wallet(), initialize=False,
+    )
+    service.operations.dependencies = replace(
+        service.operations.dependencies, storage=storage,
+        on_storage_changed=service.emit_status,
+        status_provider=lambda: {"initializing": False, "storage_state": storage.status.state},
+    )
+    connection = dbus.SessionBus(private=True)
+    received = []
+    match = connection.add_signal_receiver(
+        lambda change: received.append(dict(change)), dbus_interface=EVENTS_IFACE,
+        signal_name="HistoryChanged", bus_name=name, path=OBJECT_PATH,
+    )
+    try:
+        service.retry_storage_unlock()
+        _dispatch_until(entered.is_set)
+        status_thread, status = _request_in_thread(name, "GetStatus")
+        _dispatch_until(lambda: not status_thread.is_alive())
+        assert storage.busy
+        assert "error" not in status
+        assert json.loads(str(status["value"]))["storage_state"] == "locked"
+        assert not received
+        service.retry_storage_unlock()
+        assert calls == [False]
+        release.set()
+        _dispatch_until(lambda: bool(received))
+        assert storage.status.can_write
+        assert int(received[0]["revision"]) == 1
+        service.retry_storage_unlock()
+        assert calls == [False]
+    finally:
+        release.set()
+        _dispatch_until(lambda: not storage.busy)
+        match.remove()
+        connection.close()
+        storage.close()
+
+
+@pytest.mark.parametrize("passive_times_out", [False, True])
+def test_interactive_unlock_supersedes_passive_lookup(
+    public_service, tmp_path, monkeypatch, passive_times_out,
+):
+    name, _pending, _policy, _changes, service = public_service
+    entered = threading.Event()
+    release = threading.Event()
+    calls = []
+    passive_cancellables = []
+    timers = []
+    monkeypatch.setattr(
+        GLib, "timeout_add_seconds",
+        lambda _seconds, callback: timers.append(callback) or len(timers),
+    )
+    monkeypatch.setattr(GLib, "source_remove", lambda _source: True)
+
+    class Wallet:
+        def get_or_create(self, *, allow_prompt, cancellable=None):
+            calls.append(allow_prompt)
+            if not allow_prompt:
+                passive_cancellables.append(cancellable)
+                entered.set()
+                assert release.wait(4), "wallet fixture was not released"
+                return b"P" * 32  # A cancelled result must never install this key.
+            return b"K" * 32
+
+    storage = StorageSecurity(
+        settings=SettingsStore(tmp_path / "settings.json"), key_provider=Wallet(), initialize=False,
+    )
+    service.operations.dependencies = replace(service.operations.dependencies, storage=storage)
+    wallet_thread = None
+    try:
+        service.retry_storage_unlock()
+        _dispatch_until(entered.is_set)
+        if passive_times_out:
+            timers[0]()
+            assert not storage.busy
+            # Native cancellation has not returned yet. Polling must leave
+            # capacity for the interactive request, not queue a second lookup.
+            service.retry_storage_unlock()
+            assert len(service._wallet_worker._pending) == 1
+        wallet_thread, result = _request_in_thread(name, "UnlockStorage")
+        _dispatch_until(lambda: len(service._wallet_worker._pending) == 2)
+        assert passive_cancellables[0].is_cancelled()
+        assert wallet_thread.is_alive()
+        service.retry_storage_unlock()
+        assert len(service._wallet_worker._pending) == 2
+
+        other_thread, other = _request_in_thread(name, "UnlockStorage")
+        _dispatch_until(lambda: not other_thread.is_alive())
+        assert "already pending" in str(other["error"])
+        assert calls == [False]
+
+        release.set()
+        _dispatch_until(lambda: not wallet_thread.is_alive())
+        assert "error" not in result
+        assert json.loads(str(result["value"]))["storage_state"] == "ready"
+        assert calls == [False, True]
+        verifier = StorageSecurity(
+            settings=SettingsStore(tmp_path / "verifier.json"), key_provider=Wallet(), initialize=False,
+        )
+        verifier.refresh(allow_prompt=True)
+        try:
+            assert verifier.decrypt(
+                storage.encrypt("interactive key", purpose="history-event-v1"),
+                purpose="history-event-v1",
+            ) == "interactive key"
+        finally:
+            verifier.close()
+    finally:
+        release.set()
+        _dispatch_until(lambda: not service._wallet_worker.busy)
+        if wallet_thread is not None:
+            _dispatch_until(lambda: not wallet_thread.is_alive())
+        storage.close()
+
+
+@pytest.mark.parametrize("end_preparation", ["complete", "corruption", "shutdown"])
+def test_preparation_keeps_dbus_responsive_and_holds_the_write_barrier(
+    public_service, tmp_path, monkeypatch, end_preparation,
+):
+    name, _pending, _policy, _changes, service = public_service
+    entered = threading.Event()
+    release = threading.Event()
+    committed = []
+    calls = []
+    timers = []
+    main_thread = threading.get_ident()
+    monkeypatch.setattr(
+        GLib, "timeout_add_seconds",
+        lambda _seconds, callback: timers.append(callback) or len(timers),
+    )
+    monkeypatch.setattr(GLib, "source_remove", lambda _source: True)
+
+    class Wallet:
+        def get_or_create(self, **_kwargs):
+            calls.append(True)
+            return b"K" * 32
+
+    storage = StorageSecurity(
+        settings=SettingsStore(tmp_path / "settings.json"), key_provider=Wallet(), initialize=False,
+    )
+
+    def prepare(candidate):
+        assert threading.get_ident() != main_thread
+        assert candidate.status.can_write
+        assert not storage.status.can_write
+        entered.set()
+        assert release.wait(4), "preparation fixture was not released"
+        return "prepared cache"
+
+    def commit(data):
+        assert threading.get_ident() == main_thread
+        committed.append(data)
+
+    service.operations.dependencies = replace(
+        service.operations.dependencies, storage=storage,
+        prepare_storage=prepare, on_storage_prepared=commit,
+        status_provider=lambda: {"storage_state": storage.status.state},
+    )
+    unlock_thread = None
+    try:
+        service.retry_storage_unlock(initialize=True)
+        _dispatch_until(entered.is_set)
+        status_thread, status = _request_in_thread(name, "GetStatus")
+        _dispatch_until(lambda: not status_thread.is_alive())
+        assert "error" not in status
+        assert json.loads(str(status["value"]))["storage_state"] == "locked"
+        timers[0]()  # A wallet deadline must not release an active disk operation.
+        assert storage.busy
+        policy_thread, policy = _request_in_thread(name, "SetStoragePolicy", "plaintext")
+        _dispatch_until(lambda: not policy_thread.is_alive())
+        assert "already pending" in str(policy["error"])
+        assert storage.status.policy == "encrypted"
+        if end_preparation == "shutdown":
+            service.close()
+        else:
+            unlock_thread, unlocked = _request_in_thread(name, "UnlockStorage")
+            _dispatch_until(lambda: bool(storage._preparation_waiters))
+            assert unlock_thread.is_alive()
+            if end_preparation == "corruption":
+                storage.fail_closed("independent authentication failure")
+        release.set()
+        _dispatch_until(lambda: not service._wallet_worker.busy)
+        if unlock_thread is not None:
+            _dispatch_until(lambda: not unlock_thread.is_alive())
+            assert "error" not in unlocked
+            expected = "ready" if end_preparation == "complete" else "error"
+            assert json.loads(str(unlocked["value"]))["storage_state"] == expected
+        assert calls == [True]
+        assert committed == (["prepared cache"] if end_preparation == "complete" else [])
+        assert storage.status.can_write == (end_preparation == "complete")
+    finally:
+        release.set()
+        _dispatch_until(lambda: not service._wallet_worker.busy)
+        storage.close()
+
+
+def test_unlock_joining_locked_cleanup_still_gets_a_password_prompt(public_service, tmp_path):
+    name, _pending, _policy, _changes, service = public_service
+    entered = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    class Wallet:
+        def get_or_create(self, *, allow_prompt, **_kwargs):
+            calls.append(allow_prompt)
+            if not allow_prompt:
+                raise StorageUnavailableError("wallet locked")
+            return b"K" * 32
+
+    storage = StorageSecurity(
+        settings=SettingsStore(tmp_path / "settings.json"), key_provider=Wallet(), initialize=False,
+    )
+
+    def prepare(candidate):
+        if not candidate.status.can_read:
+            entered.set()
+            assert release.wait(4), "cleanup fixture was not released"
+
+    service.operations.dependencies = replace(
+        service.operations.dependencies, storage=storage, prepare_storage=prepare,
+    )
+    unlock_thread = None
+    try:
+        service.retry_storage_unlock(initialize=True)
+        _dispatch_until(entered.is_set)
+        unlock_thread, unlocked = _request_in_thread(name, "UnlockStorage")
+        _dispatch_until(lambda: bool(storage._preparation_waiters))
+        release.set()
+        _dispatch_until(lambda: not unlock_thread.is_alive())
+        assert "error" not in unlocked
+        assert json.loads(str(unlocked["value"]))["storage_state"] == "ready"
+        assert calls == [False, True]
+    finally:
+        release.set()
+        _dispatch_until(lambda: not service._wallet_worker.busy)
+        if unlock_thread is not None:
+            _dispatch_until(lambda: not unlock_thread.is_alive())
+        storage.close()
 
 
 def test_projection_does_not_block_status_and_retries_after_history_changes(

--- a/tests/test_settings_store.py
+++ b/tests/test_settings_store.py
@@ -1,0 +1,45 @@
+"""Worker migrations must not overwrite simultaneous daemon preference updates."""
+from __future__ import annotations
+
+import threading
+
+from blueferry.settings_store import SettingsStore
+
+
+def test_concurrent_updates_preserve_both_fields(tmp_path, monkeypatch):
+    path = tmp_path / "settings.json"
+    migration = SettingsStore(path)
+    notification = SettingsStore(path)
+    read = migration.read
+    entered = threading.Event()
+    release = threading.Event()
+    second_started = threading.Event()
+
+    def paused_read():
+        result = read()
+        entered.set()
+        assert release.wait(3), "settings fixture was not released"
+        return result
+
+    def update_notification():
+        second_started.set()
+        notification.update(notification_policy="all")
+
+    monkeypatch.setattr(migration, "read", paused_read)
+    first = threading.Thread(target=lambda: migration.update(starred_thread_keys="ciphertext"))
+    second = threading.Thread(target=update_notification)
+    first.start()
+    try:
+        assert entered.wait(2)
+        second.start()
+        assert second_started.wait(2)
+        second.join(0.05)
+        assert second.is_alive()
+    finally:
+        release.set()
+        first.join(2)
+        if second.ident is not None:
+            second.join(2)
+    assert notification.read() == {
+        "starred_thread_keys": "ciphertext", "notification_policy": "all",
+    }

--- a/tests/test_storage_recovery.py
+++ b/tests/test_storage_recovery.py
@@ -1,0 +1,459 @@
+"""Late keyring availability must recover without a client or password prompt."""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from gi.repository import GLib
+
+from blueferry import config
+from blueferry import daemon as daemon_mod
+from blueferry import history as history_mod
+from blueferry import storage_preparation as preparation_mod
+from blueferry.ancs.constants import MESSAGES_APP_ID
+from blueferry.backend_operations import BackendDependencies, BackendOperations
+from blueferry.contact_repository import ContactRepository
+from blueferry.contacts import ContactsResolver
+from blueferry.events import SmsEvent
+from blueferry.history import append_event, read_events
+from blueferry.settings_store import SettingsStore
+from blueferry.sinks.sqlite import SqliteSink
+from blueferry.starred_threads import StarredThreadsStore
+from blueferry.storage_security import StorageSecurity, StorageStatus, StorageUnavailableError
+
+
+class _Wallet:
+    locked = True
+    key = b"K" * 32
+
+    def get_or_create(self, *, allow_prompt, cancellable=None):
+        if self.locked and not allow_prompt:
+            raise StorageUnavailableError("the desktop keyring is locked")
+        return self.key
+
+
+class _Queue:
+    def __init__(self):
+        self.jobs = []
+
+    def submit(self, operation, **handlers):
+        self.jobs.append((operation, handlers))
+
+    def finish(self):
+        operation, handlers = self.jobs.pop(0)
+        try:
+            value = operation()
+        except Exception as error:
+            handlers["on_error"](error)
+        else:
+            handlers["on_success"](value)
+
+
+@pytest.fixture
+def recovery(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
+    monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
+    monkeypatch.setattr(config, "HISTORY_RETENTION_DAYS", 30)
+    monkeypatch.setattr(GLib, "timeout_add_seconds", lambda *_args: 1)
+    monkeypatch.setattr(GLib, "source_remove", lambda _source: True)
+    wallet = _Wallet()
+    storage = StorageSecurity(
+        settings=SettingsStore(tmp_path / "settings.json"), key_provider=wallet,
+    )
+    daemon = object.__new__(daemon_mod.Daemon)
+    daemon.storage = storage
+    daemon.contacts = ContactsResolver(storage=storage)
+    daemon.starred_threads = SimpleNamespace(migrate=lambda: None)
+    daemon.confirmed_groups = SimpleNamespace(migrate=lambda: None)
+    seeded = []
+    daemon.events = SimpleNamespace(seed_historical_ancs=seeded.extend)
+    daemon._mark_setup_task = lambda _task: None
+    published = []
+    daemon._emit_status = lambda: published.append(storage.status)
+    daemon._dbus_service = None
+    daemon._contacts_refresh_id = None
+    daemon._contacts_refresh_pending = False
+    daemon.listener = None
+    daemon.sessions = SimpleNamespace(pbap=object(), map=None, report_error=lambda _error: None)
+    daemon.obex_worker = _Queue()
+    operations = BackendOperations(daemon.sessions, BackendDependencies(
+        storage=storage, contacts=daemon.contacts,
+        prepare_storage=preparation_mod.prepare_storage,
+        on_storage_prepared=daemon._apply_storage_preparation,
+        on_storage_changed=daemon._on_storage_changed,
+    ))
+    queue = _Queue()
+    outcomes = []
+
+    def unlock(*, interactive=False):
+        method = operations.change_storage_async if interactive else operations.retry_storage_async
+        method(queue.submit, outcomes.append, lambda error: pytest.fail(str(error)))
+        queue.finish()
+
+    yield SimpleNamespace(
+        storage=storage, wallet=wallet, daemon=daemon, operations=operations,
+        queue=queue, outcomes=outcomes, published=published, seeded=seeded, unlock=unlock,
+    )
+    storage.close()
+
+
+def test_late_keyring_restores_contacts_history_and_message_retention(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(config, "EVENTS_DB", tmp_path / "events.sqlite")
+    monkeypatch.setattr(config, "CONTACTS_DB", tmp_path / "contacts.sqlite")
+    monkeypatch.setattr(GLib, "timeout_add_seconds", lambda *_args: 1)
+    monkeypatch.setattr(GLib, "source_remove", lambda _source: True)
+
+    class Wallet:
+        def __init__(self):
+            self.locked = False
+            self.calls = []
+
+        def get_or_create(self, *, allow_prompt, cancellable=None):
+            self.calls.append(allow_prompt)
+            if self.locked:
+                raise StorageUnavailableError("the desktop keyring is locked")
+            return b"K" * 32
+
+    wallet = Wallet()
+    storage = StorageSecurity(
+        settings=SettingsStore(tmp_path / "settings.json"), key_provider=wallet,
+    )
+    ContactRepository(storage).replace([("Alice", ["15551111111"], [])])
+    append_event({
+        "kind": "sms_received", "handle": "old", "sender_address": "+15551111111",
+        "body": "retained before restart",
+    }, storage=storage)
+    storage.close()
+    wallet.locked = True
+    storage = StorageSecurity(
+        settings=SettingsStore(tmp_path / "settings.json"), key_provider=wallet,
+    )
+    contacts = ContactsResolver(storage=storage)
+    sink = SqliteSink(storage=storage)
+    status_changes = []
+    operations = BackendOperations(SimpleNamespace(), BackendDependencies(
+        storage=storage, contacts=contacts,
+        on_storage_changed=lambda: status_changes.append(storage.status),
+    ))
+    assert contacts.resolve("+15551111111") is None
+    assert operations.list_threads(10) == []
+
+    pending = []
+    outcomes = []
+
+    def submit(operation, **handlers):
+        pending.append((operation, handlers))
+
+    def finish():
+        operation, handlers = pending.pop()
+        try:
+            value = operation()
+        except Exception as error:
+            handlers["on_error"](error)
+        else:
+            handlers["on_success"](value)
+
+    def retry():
+        operations.retry_storage_async(submit, outcomes.append, lambda e: pytest.fail(str(e)))
+
+    retry()
+    assert storage.busy
+    retry()  # A poll cannot overlap an in-flight wallet request.
+    assert len(pending) == 1
+    finish()
+    assert storage.status.state == "locked"
+    assert not status_changes
+    assert not outcomes
+
+    wallet.locked = False
+    retry()
+    assert storage.status.state == "locked"  # Worker results apply on completion only.
+    finish()
+    assert storage.status.can_write
+    assert len(status_changes) == 1
+    assert outcomes[0]["storage_state"] == "ready"
+    assert contacts.resolve("+15551111111") == "Alice"
+    assert operations.list_threads(10)[0]["messages"][0]["body"] == "retained before restart"
+
+    sink.handle(SmsEvent(
+        kind="sms_received", handle="new", sender_address="+15551111111",
+        sender_phone_norm="15551111111", contact_name="Alice",
+        body="received after keyring recovery", timestamp=None, is_read=False,
+    ))
+    assert [e["handle"] for e in read_events(storage=storage)] == ["old", "new"]
+    assert b"received after keyring recovery" not in config.EVENTS_DB.read_bytes()
+    retry()
+    assert not pending
+    assert not any(wallet.calls)
+    storage.close()
+
+
+@pytest.mark.parametrize(("policy", "state", "busy"), [
+    ("encrypted", "ready", False),
+    ("encrypted", "error", False),
+    ("encrypted", "locked", True),
+    ("plaintext", "ready", False),
+    ("none", "disabled", False),
+])
+def test_passive_retry_respects_policy_pending_unlocks_and_corruption(policy, state, busy):
+    storage = SimpleNamespace(status=StorageStatus(policy, state, ""), busy=busy)
+    operations = BackendOperations(SimpleNamespace(), BackendDependencies(storage=storage))
+    operations.retry_storage_async(
+        lambda *_args, **_kwargs: pytest.fail("unexpected wallet request"),
+        lambda _status: pytest.fail("unexpected storage update"),
+        lambda error: pytest.fail(str(error)),
+    )
+
+
+@pytest.mark.parametrize("interactive", [False, True])
+def test_recovery_runs_deferred_history_cleanup_and_seeds_ancs(recovery, interactive):
+    r = recovery
+    r.wallet.locked = False
+    r.storage.refresh(allow_prompt=False)
+    now = datetime.now(timezone.utc)
+    for event in [
+        {"kind": "sms_received", "handle": "expired", "body": "expired",
+         "seen_at": (now - timedelta(days=90)).isoformat()},
+        {"kind": "sms_received", "handle": "recent", "body": "keep me",
+         "seen_at": now.isoformat()},
+        {"kind": "ancs_notification", "app_id": MESSAGES_APP_ID,
+         "notification_id": 42, "body": "correlation", "extra_private_field": "discard",
+         "seen_at": now.isoformat()},
+        {"kind": "ancs_notification", "app_id": "unrelated.app", "body": "discard",
+         "seen_at": now.isoformat()},
+    ]:
+        append_event(event, storage=r.storage)
+    append_event({"kind": "sms_received", "body": "legacy plaintext"})
+    r.wallet.locked = True
+    r.storage.refresh(allow_prompt=False)
+    r.daemon.contacts.refresh()
+    SqliteSink(storage=r.storage)
+    assert not r.seeded
+
+    r.wallet.locked = False
+    r.unlock(interactive=interactive)
+
+    retained = read_events(storage=r.storage)
+    assert len(retained) == 2
+    assert retained[0]["handle"] == "recent"
+    assert "extra_private_field" not in retained[1]
+    assert r.seeded == [retained[1]]
+    assert r.outcomes[-1]["storage_state"] == "ready"
+    assert r.published[-1].state == "ready"
+    assert b"legacy plaintext" not in config.EVENTS_DB.read_bytes()
+
+
+@pytest.mark.parametrize("interactive", [False, True])
+def test_recovery_rejects_replaced_key_before_announcing_ready_or_writing(recovery, interactive):
+    r = recovery
+    r.wallet.locked = False
+    r.storage.refresh(allow_prompt=False)
+    append_event({"kind": "sms_received", "handle": "original", "body": "keep"}, storage=r.storage)
+    before = config.EVENTS_DB.read_bytes()
+    r.wallet.locked = True
+    r.storage.refresh(allow_prompt=False)
+    r.daemon.contacts.refresh()
+    sink = SqliteSink(storage=r.storage)
+    r.wallet.key = b"L" * 32
+    r.wallet.locked = False
+
+    r.unlock(interactive=interactive)
+
+    assert r.storage.status.state == "error"
+    assert r.outcomes[-1]["storage_state"] == "error"
+    assert r.published[-1].state == "error"
+    assert not r.daemon.obex_worker.jobs
+    sink.handle(SmsEvent(
+        kind="sms_received", handle="new", sender_address="+15551111111",
+        sender_phone_norm="15551111111", contact_name=None,
+        body="must not mix keys", timestamp=None, is_read=False,
+    ))
+    assert config.EVENTS_DB.read_bytes() == before
+    r.operations.retry_storage_async(r.queue.submit, r.outcomes.append, lambda _error: None)
+    assert not r.queue.jobs
+
+    # The original ciphertext still works when the correct key is restored.
+    r.wallet.key = b"K" * 32
+    r.unlock(interactive=True)
+    assert r.outcomes[-1]["storage_state"] == "ready"
+    assert read_events(storage=r.storage)[0]["handle"] == "original"
+
+
+@pytest.mark.parametrize("cached", [False, True])
+def test_keyring_recovery_resumes_initial_phonebook_sync(recovery, monkeypatch, cached):
+    r = recovery
+    if cached:
+        r.wallet.locked = False
+        r.storage.refresh(allow_prompt=False)
+        ContactRepository(r.storage).replace([("Alice", ["15551111111"], [])])
+        r.wallet.locked = True
+    r.storage.refresh(allow_prompt=False)
+    r.daemon.contacts.refresh()
+    r.daemon._post_available_sessions_setup()
+    assert not r.daemon.obex_worker.jobs  # Defer pulls while persistence is unavailable.
+    assert r.daemon._contacts_refresh_id is not None
+
+    def pull(_sessions, *, storage):
+        assert storage.status.can_write
+        return ContactRepository(storage).replace([("Alice", ["15551111111"], [])])
+
+    monkeypatch.setattr(daemon_mod, "pull_phonebook", pull)
+    r.wallet.locked = False
+    r.unlock()
+    if cached:
+        assert not r.daemon.obex_worker.jobs
+    else:
+        assert len(r.daemon.obex_worker.jobs) == 1
+        r.daemon._on_storage_changed()
+        assert len(r.daemon.obex_worker.jobs) == 1  # No overlapping pulls.
+        r.daemon.obex_worker.finish()
+    assert r.daemon.contacts.resolve("+15551111111") == "Alice"
+    r.daemon._on_storage_changed()
+    assert not r.daemon.obex_worker.jobs
+
+
+def test_preparation_failure_does_not_publish_writable_storage(recovery, monkeypatch):
+    def fail(**_kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(preparation_mod, "prune_events", fail)
+    recovery.wallet.locked = False
+    recovery.unlock()
+    assert recovery.outcomes[-1]["storage_state"] == "locked"
+    assert recovery.published[-1].state == "locked"
+    assert not recovery.daemon.obex_worker.jobs
+
+
+def test_contact_queue_failure_does_not_hide_storage_recovery(recovery, monkeypatch):
+    r = recovery
+    submit = r.daemon.obex_worker.submit
+
+    def full(*_args, **_kwargs):
+        raise RuntimeError("OBEX operation queue is full")
+
+    monkeypatch.setattr(r.daemon.obex_worker, "submit", full)
+    r.wallet.locked = False
+    r.unlock()
+    assert r.outcomes[-1]["storage_state"] == "ready"
+    assert r.published[-1].state == "ready"
+    assert not r.daemon._contacts_refresh_pending
+    monkeypatch.setattr(r.daemon.obex_worker, "submit", submit)
+    r.daemon._refresh_contacts()
+    assert len(r.daemon.obex_worker.jobs) == 1
+
+
+def test_temporary_database_lock_recovers_on_the_next_poll(recovery, monkeypatch):
+    r = recovery
+    r.wallet.locked = False
+    r.storage.refresh(allow_prompt=False)
+    append_event({"kind": "sms_received", "body": "retained"}, storage=r.storage)
+    r.storage.require_preparation()
+    original_open = history_mod._open_database
+
+    def short_wait(path=None):
+        connection = original_open(path)
+        connection.execute("PRAGMA busy_timeout = 1")
+        return connection
+
+    monkeypatch.setattr(history_mod, "_open_database", short_wait)
+    other = sqlite3.connect(config.EVENTS_DB)
+    try:
+        other.execute("BEGIN IMMEDIATE")
+        r.unlock()
+        assert r.storage.status.state == "locked"
+        assert not r.storage.status.can_write
+        assert not r.daemon.obex_worker.jobs
+    finally:
+        other.rollback()
+        other.close()
+    r.unlock()
+    assert r.outcomes[-1]["storage_state"] == "ready"
+    assert read_events(storage=r.storage)[0]["body"] == "retained"
+
+
+@pytest.mark.parametrize("policy", ["encrypted", "plaintext", "none"])
+def test_initial_preparation_handles_every_retention_policy(recovery, policy):
+    r = recovery
+    # Seed legacy data to prove that no-storage startup still erases it.
+    append_event({"kind": "sms_received", "body": "legacy"})
+    settings = SettingsStore(r.storage.settings_path)
+    settings.update(local_data=policy)
+    r.storage._policy = policy
+    r.storage.require_preparation()
+    r.wallet.locked = False
+    r.operations.retry_storage_async(
+        r.queue.submit, r.outcomes.append, lambda error: pytest.fail(str(error)), initialize=True,
+    )
+    assert not r.storage.status.can_write
+    r.queue.finish()
+    expected = "disabled" if policy == "none" else "ready"
+    assert r.outcomes[-1]["storage_state"] == expected
+    if policy != "plaintext":
+        assert read_events() == []
+
+
+@pytest.mark.parametrize("error", [
+    PermissionError("access denied"), sqlite3.DatabaseError("database disk image is malformed"),
+])
+def test_nontransient_preparation_errors_do_not_retry(recovery, monkeypatch, error):
+    def fail(**_kwargs):
+        raise error
+
+    monkeypatch.setattr(preparation_mod, "prune_events", fail)
+    recovery.wallet.locked = False
+    recovery.unlock()
+    assert recovery.outcomes[-1]["storage_state"] == "error"
+    recovery.operations.retry_storage_async(
+        recovery.queue.submit, recovery.outcomes.append, lambda _error: None,
+    )
+    assert not recovery.queue.jobs
+
+
+@pytest.mark.parametrize("locked", [False, True])
+def test_startup_preserves_legacy_preference_privacy(recovery, locked):
+    r = recovery
+    path = r.storage.settings_path
+    key = "address:phone:15551111111"
+    StarredThreadsStore(path).set_starred(key, True)
+    r.wallet.locked = locked
+    r.operations.retry_storage_async(
+        r.queue.submit, r.outcomes.append, lambda error: pytest.fail(str(error)), initialize=True,
+    )
+    r.queue.finish()
+    assert key not in path.read_text()
+    if not locked:
+        assert StarredThreadsStore(path, storage=r.storage).keys() == [key]
+    else:
+        assert SettingsStore(path).read()["starred_thread_keys"] is None
+
+
+def test_managed_sink_does_not_repeat_preparation_on_the_main_loop(recovery, monkeypatch):
+    from blueferry.sinks import sqlite as sqlite_mod
+
+    recovery.wallet.locked = False
+    recovery.unlock()
+    monkeypatch.setattr(sqlite_mod, "prune_events", lambda **_kwargs: pytest.fail("repeated scan"))
+    monkeypatch.setattr(
+        sqlite_mod, "minimize_ancs_history", lambda **_kwargs: pytest.fail("repeated scan"),
+    )
+    SqliteSink(storage=recovery.storage)
+
+
+def test_disabling_retention_succeeds_when_wallet_key_deletion_is_unavailable(recovery, monkeypatch):
+    def locked(**_kwargs):
+        raise StorageUnavailableError("wallet locked")
+
+    r = recovery
+    monkeypatch.setattr(r.wallet, "delete", locked, raising=False)
+    r.operations.change_storage_async(
+        r.queue.submit, r.outcomes.append, lambda error: pytest.fail(str(error)), policy="none",
+    )
+    r.queue.finish()
+    assert r.outcomes[-1]["storage_state"] == "disabled"
+    assert "remove the old BlueFerry key" in r.outcomes[-1]["storage_detail"]
+    assert SettingsStore(r.storage.settings_path).read()["local_data"] == "none"
+    assert read_events() == []

--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -6,6 +6,7 @@ import json
 import logging
 import sqlite3
 from contextlib import closing
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -358,7 +359,7 @@ def test_pruning_reasserts_private_encrypted_metadata(tmp_path) -> None:
         {
             "kind": "sms_received",
             "body": "private",
-            "seen_at": "2026-08-09T12:34:56+00:00",
+            "seen_at": datetime.now(timezone.utc).isoformat(),
         },
         path=path,
         storage=storage,
@@ -412,7 +413,10 @@ def test_pruning_rolls_back_earlier_deletions_when_a_retained_row_is_corrupt(tmp
 
 
 @pytest.mark.parametrize("end_request", ["timeout", "shutdown", "corruption"])
-def test_cancelled_wallet_request_cannot_install_a_late_key(tmp_path, monkeypatch, end_request):
+@pytest.mark.parametrize("allow_prompt", [False, True])
+def test_cancelled_wallet_request_cannot_install_a_late_key(
+    tmp_path, monkeypatch, end_request, allow_prompt,
+):
     from gi.repository import GLib
 
     callbacks = []
@@ -428,11 +432,13 @@ def test_cancelled_wallet_request_cannot_install_a_late_key(tmp_path, monkeypatc
     storage.change_async(
         lambda operation, **handlers: pending.append((operation, handlers)),
         on_success=outcomes.append, on_error=errors.append,
+        allow_prompt=allow_prompt,
     )
     assert storage.busy
     assert not storage.status.can_write
     operation, handlers = pending.pop()
     key = operation()
+    assert provider.calls == [allow_prompt]
     if end_request == "timeout":
         callbacks[0]()
         assert len(outcomes) == 1


### PR DESCRIPTION
BlueFerry could start before the desktop keyring was available and remain unable to retain messages until a client unlocked it. The daemon now retries existing keys without prompting and prepares history and contacts in the background before enabling storage.

The storage request lifecycle controls lookup, preparation, and readiness. Interactive unlocks supersede passive wallet lookups or wait for preparation already in progress; policy changes cannot clear data during preparation. Temporary database and I/O failures retry automatically, while authentication failures keep storage unavailable. Recovery also resumes contact synchronization when the cache is empty.

Startup uses the same preparation path, including retention cleanup, legacy preference protection, and ANCS correlation seeding. Prepared caches are installed on the main loop, and sink creation no longer repeats history scans. Settings updates are serialized so worker migrations cannot overwrite concurrent preference changes.

Validation:

- 1,048 tests passed in an isolated D-Bus session, including recovery, cancellation, policy changes, corruption, shutdown, and temporary SQLite lock regressions.
- Ruff, mypy, Bandit, and `git diff --check` passed.
- A synthetic 10,000-row, 209 MiB archive prepared in 2.1 seconds while the largest measured main-loop gap was 21 ms.
