### PR TITLE
Fix time-bomb date in pruning retention test

### DIFF
--- a/tests/test_storage_security.py
+++ b/tests/test_storage_security.py
@@ -6,6 +6,7 @@ import json
 import logging
 import sqlite3
 from contextlib import closing
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -354,11 +355,12 @@ def test_plaintext_scrub_preserves_framed_ciphertext(tmp_path) -> None:
 def test_pruning_reasserts_private_encrypted_metadata(tmp_path) -> None:
     path = tmp_path / "events.sqlite"
     storage = _storage(tmp_path)
+    seen_at = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
     append_event(
         {
             "kind": "sms_received",
             "body": "private",
-            "seen_at": "2026-08-09T12:34:56+00:00",
+            "seen_at": seen_at,
         },
         path=path,
         storage=storage,


### PR DESCRIPTION
## Summary
- `test_pruning_reasserts_private_encrypted_metadata` hardcoded `seen_at="2026-08-09T12:34:56+00:00"` against the 30-day `HISTORY_RETENTION_DAYS` default.
- Once real calendar time passed 2026-09-08 12:34:56 UTC, `prune_events` legitimately started treating that event as expired and deleted it before the test's actual target behavior (reasserting sanitized metadata on a tampered-but-still-valid row) ever ran — a permanent failure from that date forward, not a transient flake.

## Changes
- Replace the hardcoded absolute timestamp with a relative one (`now() - 1 day`), so the event stays well inside the retention window indefinitely.

## Test Plan
- `pytest tests/test_storage_security.py::test_pruning_reasserts_private_encrypted_metadata` passes.
- Full suite run as part of `packaging/build-deb.sh`'s `dh_auto_test` step: 934 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnhGa4egiTHLQxAmTywKPi