### PR TITLE
Detect incompatible adapters and apply explicit pairing defaults

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -124,6 +124,13 @@ connection. MAP and PBAP are its successful end state; absence of Notification
 Access is expected and group messages may consequently lack ANCS-derived group
 metadata.
 
+The RTL8761BU (`0bda:8771`) defaults to explicit pairing because its initial
+`Connect` can abort before authentication (#144). Clients apply this default
+from the shared adapter probe and retain manual checkbox choices per adapter
+for the current session. The CLI wizard uses the same default;
+`--no-explicit-pairing` selects Connect-first instead. This does not change the
+ANCS compatibility mode or require explicit pairing on other Realtek adapters.
+
 Both modes activate obexd's local Message Notification Server before pairing
 and install BlueFerry's WirePlumber phone-audio fragment so this computer is
 not an A2DP/HFP sink when iOS first connects. A failed pairing attempt removes

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -98,9 +98,23 @@ connection hung and ended in `le-connection-abort-by-local`, while MAP/PBAP
 worked when attempted first. BlueZ still reported its LE bearer as paired and
 bonded, so those properties cannot predict whether the phone will answer.
 
-BlueFerry therefore resolves two delivery modes. Full mode requires a
-controller with BR/EDR, LE, and advertising plus BlueZ 5.86 or newer. Its
-bearer API must already be active or be activatable through the package's
+Both delivery modes require a controller with BR/EDR, secure pairing, and
+Bluetooth LE advertising (Bluetooth 4.0 or newer). MAP/PBAP carry data over
+Classic, but their iPhone permissions depend on LE solicitation. A successful
+capability probe that confirms missing features marks the adapter incompatible;
+a failed probe remains advisory because working adapters can time out
+([#28](https://github.com/erikwb/blueferry/issues/28)).
+
+The closed-issue review for #143 found no successful MAP report on a
+Bluetooth 3-only controller. The Broadcom MAP/PBAP success in
+[#113](https://github.com/erikwb/blueferry/issues/113) reports HCI version 6
+(Bluetooth 4.0), LE, and advertising. The Realtek success in
+[#17](https://github.com/erikwb/blueferry/issues/17) also supports LE advertising.
+ANCS connection failures on those adapters do not imply missing LE hardware.
+
+BlueFerry therefore resolves two delivery modes. Full mode additionally
+requires BlueZ 5.86 or newer. Its bearer API must already be active or be
+activatable through the package's
 systemd drop-in before pairing proceeds. Compatibility mode is selected
 automatically when ANCS is unavailable or explicitly for iOS 18 and earlier.
 It still broadcasts ANCS solicitation when the controller can advertise,

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -124,10 +124,13 @@ connection. MAP and PBAP are its successful end state; absence of Notification
 Access is expected and group messages may consequently lack ANCS-derived group
 metadata.
 
-The RTL8761BU (`0bda:8771`) defaults to explicit pairing because its initial
-`Connect` can abort before authentication (#144). Clients apply this default
-from the shared adapter probe and retain manual checkbox choices per adapter
-for the current session. The CLI wizard uses the same default;
+The RTL8761BU (`0bda:8771`), AzureWave RTL8852CE (`13d3:3586`), and Realtek
+`0bda:8922` default to explicit pairing. RTL8761BU can abort its initial `Connect`
+before authentication (#144); explicit pairing restored ANCS on the RTL8852CE
+(#58) and was used for a successful MAP/PBAP connection on `0bda:8922` (#68).
+Clients apply these defaults from the shared adapter probe and retain manual
+checkbox choices per adapter for the current session. The CLI wizard uses the
+same defaults;
 `--no-explicit-pairing` selects Connect-first instead. This does not change the
 ANCS compatibility mode or require explicit pairing on other Realtek adapters.
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ blueferry-qt          # KDE Plasma
 blueferry-quickshell  # Quickshell
 ```
 
+BlueFerry requires an adapter with Bluetooth Classic and Bluetooth 4.0 or newer
+with LE advertising support. LE advertising is needed to enable the iPhone's
+messages and contacts, including in compatibility mode. Bluetooth 3-only
+adapters are incompatible.
+
 Then:
 
 1. Keep the iPhone unlocked with **Settings → Bluetooth** open.

--- a/data/quickshell/OnboardingState.qml
+++ b/data/quickshell/OnboardingState.qml
@@ -5,8 +5,10 @@ QtObject {
   required property bool bluezActive
   required property bool configured
   required property var backendStatus
+  property bool pairingReady: true
 
   readonly property string stage: {
+    if (!pairingReady) return "incompatible"
     if (notificationsSupported && !bluezActive) return "activate-bluetooth"
     if (!configured) return "select-device"
     if (backendStatus.map && backendStatus.pbap) {

--- a/data/quickshell/PhoneSettingsPage.qml
+++ b/data/quickshell/PhoneSettingsPage.qml
@@ -11,6 +11,8 @@ Rectangle {
   required property var status
   property var busy: ({})
   readonly property var theme: ferryTheme
+  readonly property var connectionStatus: root.setup.pairing
+    ? root.setup.pairingTransports : root.status
   readonly property bool showIphoneSetup: root.setup.compatibilityLoaded
     && onboarding.stage === "iphone-settings" && onboarding.pendingIphoneSetupTasks().length > 0
   signal closeRequested
@@ -24,7 +26,7 @@ Rectangle {
     notificationsSupported: root.setup.notificationsSupported && root.setup.ancsEnabled && !root.setup.compatibilityModeOverride
     bluezActive: root.setup.bluezActive
     configured: root.setup.configured
-    backendStatus: root.status
+    backendStatus: root.connectionStatus
     pairingReady: root.setup.pairingReady
   }
 
@@ -281,8 +283,9 @@ Rectangle {
         }
         FerryInfoRow {
           ferryTheme: root.theme
+          objectName: "messagesConnection"
           label: "Messages"
-          value: onboarding.mapConnectionRefused() ? "Connection refused" : root.status.map ? "Connected" : "Unavailable"
+          value: onboarding.mapConnectionRefused() ? "Connection refused" : root.connectionStatus.map ? "Connected" : "Unavailable"
           Layout.fillWidth: true
         }
         FerryLabel {
@@ -296,19 +299,21 @@ Rectangle {
         }
         FerryInfoRow {
           ferryTheme: root.theme
+          objectName: "contactsConnection"
           label: "Contacts"
-          value: root.status.pbap ? "Connected" : "Unavailable"
+          value: root.connectionStatus.pbap ? "Connected" : "Unavailable"
           Layout.fillWidth: true
         }
         FerryInfoRow {
           ferryTheme: root.theme
+          objectName: "notificationsConnection"
           label: "Notifications"
-          value: root.status.ancs ? "Connected" : "Unavailable"
+          value: root.connectionStatus.ancs ? "Connected" : "Unavailable"
           Layout.fillWidth: true
         }
         FerryLabel {
           ferryTheme: root.theme
-          visible: root.setup.configured && onboarding.notificationsSupported && root.status.map === true && root.status.pbap === true && !root.status.ancs
+          visible: root.setup.configured && onboarding.notificationsSupported && root.connectionStatus.map === true && root.connectionStatus.pbap === true && !root.connectionStatus.ancs
           text: root.ancsUnavailableHint()
           color: root.ancsLimited() ? root.theme.surfaceText : root.theme.warning
           wrapMode: Text.Wrap

--- a/data/quickshell/PhoneSettingsPage.qml
+++ b/data/quickshell/PhoneSettingsPage.qml
@@ -180,12 +180,13 @@ Rectangle {
         }
         FerryCheckBox {
           id: explicitPairing
+          objectName: "explicitPairingCheckBox"
           ferryTheme: root.theme
           visible: !root.setup.configured
           text: "Use explicit Bluetooth pairing"
-          checked: root.setup.explicitPairingOverride
-          enabled: !root.setup.pairing
-          onClicked: root.setup.explicitPairingOverride = checked
+          checked: root.setup.explicitPairing
+          enabled: root.setup.compatibilityLoaded && !root.setup.pairing
+          onClicked: root.setup.setExplicitPairing(checked)
         }
         FerryLabel {
           ferryTheme: root.theme

--- a/data/quickshell/PhoneSettingsPage.qml
+++ b/data/quickshell/PhoneSettingsPage.qml
@@ -11,6 +11,8 @@ Rectangle {
   required property var status
   property var busy: ({})
   readonly property var theme: ferryTheme
+  readonly property bool showIphoneSetup: root.setup.compatibilityLoaded
+    && onboarding.stage === "iphone-settings" && onboarding.pendingIphoneSetupTasks().length > 0
   signal closeRequested
   signal pairingIssueRequested
   signal operationRequested(string method, var args)
@@ -261,15 +263,17 @@ Rectangle {
         }
         FerrySectionLabel {
           ferryTheme: root.theme
+          objectName: "iphoneSetupHeading"
           text: "Finish Setup on the iPhone"
-          visible: root.setup.configured && onboarding.pendingIphoneSetupTasks().length > 0
+          visible: root.showIphoneSetup
         }
         FerryLabel {
           ferryTheme: root.theme
+          objectName: "iphoneSetupInstructions"
           text: onboarding.pendingIphoneSetupText()
           wrapMode: Text.Wrap
           Layout.fillWidth: true
-          visible: root.setup.configured && onboarding.pendingIphoneSetupTasks().length > 0
+          visible: root.showIphoneSetup
         }
         FerrySectionLabel {
           ferryTheme: root.theme

--- a/data/quickshell/PhoneSettingsPage.qml
+++ b/data/quickshell/PhoneSettingsPage.qml
@@ -23,6 +23,7 @@ Rectangle {
     bluezActive: root.setup.bluezActive
     configured: root.setup.configured
     backendStatus: root.status
+    pairingReady: root.setup.pairingReady
   }
 
   function ancsLimited() {
@@ -89,6 +90,15 @@ Rectangle {
           wrapMode: Text.Wrap
           Layout.fillWidth: true
           visible: text !== ""
+        }
+        FerryLabel {
+          ferryTheme: root.theme
+          objectName: "hardwareCompatibilityMessage"
+          text: root.setup.compatibilityIssue
+          textFormat: Text.PlainText
+          wrapMode: Text.Wrap
+          Layout.fillWidth: true
+          visible: root.setup.compatibilityLoaded && !root.setup.pairingReady
         }
         FerryLabel {
           ferryTheme: root.theme
@@ -179,7 +189,7 @@ Rectangle {
         }
         FerryLabel {
           ferryTheme: root.theme
-          visible: !root.setup.configured && compatibilityMode.checked
+          visible: !root.setup.configured && compatibilityMode.checked && root.setup.pairingReady
           text: "Messages and contacts remain available. System notifications will be disabled; group texts may appear as individual conversations."
           wrapMode: Text.Wrap
           Layout.fillWidth: true

--- a/data/quickshell/SetupController.qml
+++ b/data/quickshell/SetupController.qml
@@ -23,6 +23,8 @@ QtObject {
   property string configurationError: ""
   property bool bluezActive: false
   property bool hardwareSupported: false
+  property bool pairingReady: true
+  property string compatibilityIssue: ""
   property bool notificationsSupported: false
   property bool ancsLimitedController: false
   property string controllerVendor: ""
@@ -50,7 +52,7 @@ QtObject {
   readonly property bool activating: pending.activate !== undefined
   readonly property bool changingPhone: pairing || forgetting
   readonly property bool canPair: selectedPairingDevice() !== null
-    && compatibilityLoaded && !scanning && !changingPhone && !activating
+    && compatibilityLoaded && pairingReady && !scanning && !changingPhone && !activating
 
   function selectedPairingDevice() {
     return selectedDeviceIndex >= 0 && selectedDeviceIndex < pairingDevices.length
@@ -214,6 +216,8 @@ QtObject {
     if (kind === "compatibility") {
       compatibilityLoaded = true
       hardwareSupported = false
+      pairingReady = true
+      compatibilityIssue = message
       notificationsSupported = false
       ancsLimitedController = false
       controllerVendor = ""
@@ -246,6 +250,8 @@ QtObject {
       if (kind === "compatibility") {
         if (typeof data.notifications_supported !== "boolean") throw new Error("Invalid compatibility response")
         hardwareSupported = data.hardware_supported === true
+        pairingReady = data.pairing_ready !== false
+        compatibilityIssue = String(data.issue || "")
         notificationsSupported = data.notifications_supported === true
         ancsLimitedController = data.ancs_limited_controller === true
         controllerVendor = String(data.controller_vendor || "")

--- a/data/quickshell/SetupController.qml
+++ b/data/quickshell/SetupController.qml
@@ -31,7 +31,10 @@ QtObject {
   property bool compatibilityLoaded: false
   property bool ancsEnabled: true
   property bool compatibilityModeOverride: false
-  property bool explicitPairingOverride: false
+  property bool explicitPairingDefault: false
+  property var explicitPairingOverrides: ({})
+  readonly property bool explicitPairing: explicitPairingOverrides[adapterName]
+    ?? explicitPairingDefault
   property bool configured: false
   property bool targetSaved: false
   property bool targetBonded: false
@@ -61,6 +64,12 @@ QtObject {
 
   function configuredPairingDevice() {
     return pairingDevices.find(device => device.mac === configuredMac) || null
+  }
+
+  function setExplicitPairing(enabled) {
+    const overrides = Object.assign({}, explicitPairingOverrides)
+    overrides[adapterName] = enabled
+    explicitPairingOverrides = overrides
   }
 
   function cancel(kind) {
@@ -133,7 +142,7 @@ QtObject {
       ? String(device.adapter_path).split("/").pop() : adapterName
     if (adapter) command.push("--adapter", adapter)
     if (!notificationsSupported || compatibilityModeOverride) command.push("--compatibility-mode")
-    if (explicitPairingOverride) command.push("--explicit-pairing")
+    if (explicitPairing) command.push("--explicit-pairing")
     if (!device.paired && targetSaved) {
       command.push("--replace-saved-mac", configuredMac)
       pendingReplacement = {command: command, adapter: adapter}
@@ -216,6 +225,7 @@ QtObject {
     if (kind === "compatibility") {
       compatibilityLoaded = true
       hardwareSupported = false
+      explicitPairingDefault = false
       pairingReady = true
       compatibilityIssue = message
       notificationsSupported = false
@@ -250,6 +260,7 @@ QtObject {
       if (kind === "compatibility") {
         if (typeof data.notifications_supported !== "boolean") throw new Error("Invalid compatibility response")
         hardwareSupported = data.hardware_supported === true
+        explicitPairingDefault = data.explicit_pairing_default === true
         pairingReady = data.pairing_ready !== false
         compatibilityIssue = String(data.issue || "")
         notificationsSupported = data.notifications_supported === true

--- a/data/quickshell/SetupController.qml
+++ b/data/quickshell/SetupController.qml
@@ -20,6 +20,7 @@ QtObject {
   property var pairingDevices: []
   property int selectedDeviceIndex: -1
   property string pairingStatus: ""
+  property var pairingTransports: ({map: false, pbap: false, ancs: false})
   property string configurationError: ""
   property bool bluezActive: false
   property bool hardwareSupported: false
@@ -164,6 +165,7 @@ QtObject {
     cancel("devices")
     cancel("compatibility")
     pairingStatus = "Starting secure pairing…"
+    pairingTransports = ({map: false, pbap: false, ancs: false})
     pairingIssueReport = ""
     clearConfirmation()
     request("pair", command, true, {adapter: adapter})
@@ -200,7 +202,14 @@ QtObject {
     if (!pending[kind] || pending[kind].id !== id || (kind !== "pair" && kind !== "forget")) return
     try {
       const data = JSON.parse(line)
-      if (data.event === "display") {
+      if (kind === "pair" && data.event === "transports") {
+        if (typeof data.map !== "boolean" || typeof data.pbap !== "boolean"
+            || typeof data.ancs !== "boolean") return
+        pairingTransports = {map: data.map, pbap: data.pbap, ancs: data.ancs}
+        pairingStatus = data.map && data.pbap
+          ? "Messages and contacts are connected. Finishing setup…"
+          : "Checking Bluetooth services…"
+      } else if (data.event === "display") {
         pairingPasskey = String(data.passkey || "")
         pairingStatus = "Compare this code with the code on your iPhone."
       } else if (data.event === "confirmation") {

--- a/src/blueferry/bluetooth_capabilities.py
+++ b/src/blueferry/bluetooth_capabilities.py
@@ -411,8 +411,8 @@ def _hci_sort_key(name: str) -> tuple[int, int | str]:
 def _pairing_capable(inspected: tuple | None) -> bool:
     if inspected is None:
         return False
-    available, _supported, _current, _error, _identity, fields = inspected
-    return bool(available and fields["classic"] and fields["secure_pairing"])
+    _available, _supported, _current, _error, _identity, fields = inspected
+    return bool(fields["hardware_supported"])
 
 
 def adapter_label(name: str, hardware: dict[str, object] | None = None) -> str:
@@ -449,19 +449,27 @@ def _profile_fields(
     low_energy = "le" in supported
     advertising = "advertising" in supported
     secure_pairing = bool({"ssp", "secure-conn"} & supported)
-    messages_supported = available and classic and secure_pairing
-    notifications_supported = (
-        available and low_energy and advertising and bearer_supported
-    )
+    # MAP/PBAP carry data over Classic, but iOS exposes their permissions only
+    # after LE solicitation. Compatibility mode still needs that advertisement.
+    messages_supported = available and classic and secure_pairing and low_energy and advertising
+    notifications_supported = messages_supported and bearer_supported
     missing = [
         label for present, label in (
-            (classic, "BR/EDR"), (secure_pairing, "secure pairing")
+            (classic, "Bluetooth Classic (BR/EDR)"),
+            (secure_pairing, "secure pairing"),
+            (low_energy, "Bluetooth LE"),
+            (advertising, "LE advertising"),
         ) if not present
     ]
     if not available:
         issue = command_error or f"Bluetooth adapter {adapter} is unavailable"
     elif missing:
-        issue = "Controller lacks " + ", ".join(missing)
+        issue = (
+            "Incompatible Bluetooth adapter: missing " + ", ".join(missing) + ". "
+            "BlueFerry requires Bluetooth Classic and Bluetooth 4.0 or newer "
+            "with LE advertising to enable iPhone messages and contacts. "
+            "Use a compatible adapter."
+        )
     elif notifications_supported and not bearer_active:
         issue = "Bluetooth support must be activated before pairing"
     elif not notifications_supported:
@@ -481,9 +489,9 @@ def _profile_fields(
         "notifications_supported": notifications_supported,
         "bearer_api_supported": bearer_supported,
         "bearer_api_active": bearer_active,
-        # Capability discovery selects a mode; the pairing transaction decides
-        # whether the adapter actually works.
-        "pairing_ready": True,
+        # A failed probe is inconclusive (#28); only confirmed missing
+        # capabilities prevent pairing (#143).
+        "pairing_ready": not available or messages_supported,
         "issue": issue,
         "supported_settings": sorted(supported),
         "current_settings": sorted(current),

--- a/src/blueferry/bluetooth_capabilities.py
+++ b/src/blueferry/bluetooth_capabilities.py
@@ -415,13 +415,6 @@ def _hci_sort_key(name: str) -> tuple[int, int | str]:
     return (1, name)
 
 
-def _pairing_capable(inspected: tuple | None) -> bool:
-    if inspected is None:
-        return False
-    _available, _supported, _current, _error, _identity, fields = inspected
-    return bool(fields["hardware_supported"])
-
-
 def adapter_label(name: str, hardware: dict[str, object] | None = None) -> str:
     """Human controller name plus the hci index so two cards stay distinct."""
     hardware = hardware or {}
@@ -586,16 +579,17 @@ def compatibility(
         inspected[name] = (available, supported, current, error, identity, fields)
     if adapter_name is not None and adapter_name in inspected:
         chosen = adapter_name
-    elif _pairing_capable(inspected.get(requested)):
-        chosen = requested
     else:
-        chosen = next(
-            (
-                str(option["name"])
-                for option in options
-                if _pairing_capable(inspected.get(str(option["name"])))
-            ),
+        # Prefer verified hardware, then an inconclusive probe that still
+        # permits pairing. Honor the configured adapter within each tier.
+        preferred = sorted(options, key=lambda option: option["name"] != requested)
+        fallback = next(
+            (str(option["name"]) for option in preferred if option["pairing_ready"]),
             names[0],
+        )
+        chosen = next(
+            (str(option["name"]) for option in preferred if option["hardware_supported"]),
+            fallback,
         )
     _available, _supported, _current, _error, identity, fields = inspected[str(chosen)]
     hardware = hardware_by_name.get(str(chosen), {})

--- a/src/blueferry/bluetooth_capabilities.py
+++ b/src/blueferry/bluetooth_capabilities.py
@@ -36,6 +36,10 @@ _BT_COMPANIES = {
 # does not complete on them. Messages and contacts still work.
 ANCS_LIMITED_VENDORS = frozenset({"realtek", "broadcom", "cypress"})
 
+# RTL8761BU can abort Connect-first pairing before authentication (#144).
+# This is a client default; users can still select Connect-first explicitly.
+_EXPLICIT_PAIRING_USB_IDS = frozenset({"0bda:8771"})
+
 
 def ancs_limited_vendor(vendor: object) -> bool:
     """Return True when iPhone notification pairing is not expected to finish."""
@@ -591,7 +595,8 @@ def compatibility(
             names[0],
         )
     _available, _supported, _current, _error, identity, fields = inspected[str(chosen)]
-    vendor = str(hardware_by_name.get(str(chosen), {}).get("vendor") or "")
+    hardware = hardware_by_name.get(str(chosen), {})
+    vendor = str(hardware.get("vendor") or "")
     result: dict[str, object] = {
         "adapter": chosen,
         **fields,
@@ -599,6 +604,9 @@ def compatibility(
         "adapters": options,
         "controller_vendor": vendor,
         "ancs_limited_controller": ancs_limited_vendor(vendor),
+        "explicit_pairing_default": (
+            str(hardware.get("usb_id") or "").casefold() in _EXPLICIT_PAIRING_USB_IDS
+        ),
     }
     if "manufacturer_id" in identity:
         result["manufacturer_id"] = identity["manufacturer_id"]

--- a/src/blueferry/bluetooth_capabilities.py
+++ b/src/blueferry/bluetooth_capabilities.py
@@ -36,9 +36,12 @@ _BT_COMPANIES = {
 # does not complete on them. Messages and contacts still work.
 ANCS_LIMITED_VENDORS = frozenset({"realtek", "broadcom", "cypress"})
 
-# RTL8761BU can abort Connect-first pairing before authentication (#144).
-# This is a client default; users can still select Connect-first explicitly.
-_EXPLICIT_PAIRING_USB_IDS = frozenset({"0bda:8771"})
+# Adapter-specific client defaults; users can still select Connect-first explicitly.
+_EXPLICIT_PAIRING_USB_IDS = frozenset({
+    "0bda:8771",  # RTL8761BU: Connect can abort before authentication (#144).
+    "0bda:8922",  # Realtek: MAP/PBAP success with explicit pairing (#68).
+    "13d3:3586",  # AzureWave RTL8852CE: explicit pairing restored ANCS (#58).
+})
 
 
 def ancs_limited_vendor(vendor: object) -> bool:

--- a/src/blueferry/cli.py
+++ b/src/blueferry/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+from typing import Optional
 
 import typer
 
@@ -142,7 +143,8 @@ def pair_setup(
             "(recommended for iOS 18 or earlier)"
         ),
     ),
-    explicit_pairing: bool | None = typer.Option(
+    # Ubuntu 24.04's Typer 0.9 requires typing.Optional for nullable CLI options.
+    explicit_pairing: Optional[bool] = typer.Option(  # noqa: UP045
         None,
         "--explicit-pairing/--no-explicit-pairing",
         help="Call Pair immediately instead of Connect (default depends on the adapter)",

--- a/src/blueferry/cli.py
+++ b/src/blueferry/cli.py
@@ -271,6 +271,7 @@ def pairing_complete(
     import sys
 
     from blueferry.errors import PairingError
+    from blueferry.pairing_types import PairingTransports
     from blueferry.setup_client import SetupClient
 
     if debug:
@@ -290,6 +291,14 @@ def pairing_complete(
 
     def display(passkey: int) -> None:
         emit({"event": "display", "passkey": f"{passkey:06d}"})
+
+    def transports_changed(transports: PairingTransports) -> None:
+        emit({
+            "event": "transports",
+            "map": transports.map,
+            "pbap": transports.pbap,
+            "ancs": transports.ancs,
+        })
 
     try:
         if not interactive_agent:
@@ -316,6 +325,7 @@ def pairing_complete(
             display=display,
             compatibility_mode=compatibility_mode,
             explicit_pairing=explicit_pairing,
+            transports_changed=transports_changed,
         )
         emit(result.to_dict())
     except PairingError as error:

--- a/src/blueferry/cli.py
+++ b/src/blueferry/cli.py
@@ -302,6 +302,9 @@ def pairing_complete(
         setup = SetupClient()
         selected = adapter.strip() or None
         if replace_saved_mac:
+            compatibility = setup.compatibility(selected)
+            if not compatibility.pairing_ready:
+                raise PairingError(compatibility.issue)
             saved = setup.configuration().adapter or None
             setup.prepare_replacement(replace_saved_mac, mac, adapter=saved)
         result = setup.complete(

--- a/src/blueferry/cli.py
+++ b/src/blueferry/cli.py
@@ -142,10 +142,10 @@ def pair_setup(
             "(recommended for iOS 18 or earlier)"
         ),
     ),
-    explicit_pairing: bool = typer.Option(
-        False,
-        "--explicit-pairing",
-        help="Call Pair immediately instead of initiating pairing with Connect",
+    explicit_pairing: bool | None = typer.Option(
+        None,
+        "--explicit-pairing/--no-explicit-pairing",
+        help="Call Pair immediately instead of Connect (default depends on the adapter)",
     ),
 ):
     """First-run wizard: pick a paired iPhone, write the local config,

--- a/src/blueferry/onboarding.py
+++ b/src/blueferry/onboarding.py
@@ -74,6 +74,7 @@ def effective_compatibility(
 
 class OnboardingStage(str, Enum):
     CHECKING = "checking"
+    INCOMPATIBLE = "incompatible"
     ACTIVATE_BLUETOOTH = "activate-bluetooth"
     SELECT_DEVICE = "select-device"
     STARTING = "starting"
@@ -154,6 +155,8 @@ def derive_stage(
     status_values = status.to_dict() if isinstance(status, BackendStatus) else status
     if not setup_loaded:
         return OnboardingStage.CHECKING
+    if compatibility.get("pairing_ready") is False:
+        return OnboardingStage.INCOMPATIBLE
     if compatibility.get("notifications_supported") and not compatibility.get("bearer_api_active"):
         return OnboardingStage.ACTIVATE_BLUETOOTH
     if not configured:

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -121,8 +121,8 @@ def configuration_status() -> dict:
 def bluetooth_compatibility(adapter_name: str | None = None) -> dict:
     """Describe whether a controller supports BlueFerry's transports.
 
-    MAP and PBAP require BR/EDR. The proven ANCS pairing flow additionally
-    requires LE advertising and secure pairing. This check is read-only and
+    MAP and PBAP require BR/EDR, secure pairing, and LE advertising to expose
+    the iPhone's permissions. This check is read-only and
     intentionally uses ``btmgmt info`` rather than vendor/model allowlists.
     """
     if adapter_name is not None and not config.is_valid_adapter(adapter_name):
@@ -1171,6 +1171,8 @@ def _prepare_pairing(
     compatibility = bluetooth_compatibility(selected_adapter)
     attempt["controller"] = _controller_snapshot(selected_adapter, compatibility)
     quirks_report.mark(attempt, "compatibility_ready")
+    if compatibility.get("pairing_ready") is False:
+        raise PairingError(compatibility["issue"])
     if not compatibility["hardware_supported"]:
         issue = compatibility["issue"] or "Controller capabilities could not be verified"
         log.warning(

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -55,6 +55,7 @@ MAX_DISCOVERY_SECONDS = 30
 
 ConfirmationCallback = Callable[[int | None], bool]
 DisplayCallback = Callable[[int], None]
+TransportCallback = Callable[[PairingTransports], None]
 
 
 class _TransportStatus(Protocol):
@@ -778,6 +779,7 @@ def _wait_for_daemon_transports(
     notifications_supported: bool = True,
     device_path: str | None = None,
     status_reader: Callable[[], _TransportStatus] | None = None,
+    transports_changed: TransportCallback | None = None,
 ) -> PairingTransports:
     """Observe the daemon while the pairing advert and agent remain active."""
     from blueferry.client import BackendClient, BackendError
@@ -799,10 +801,10 @@ def _wait_for_daemon_transports(
         try:
             status = reader()
         except BackendError:
-            time.sleep(0.5)
-            continue
-        _remember_daemon_status(attempt, status)
-        current = PairingTransports(status.map, status.pbap, status.ancs)
+            current = PairingTransports()
+        else:
+            _remember_daemon_status(attempt, status)
+            current = PairingTransports(status.map, status.pbap, status.ancs)
         if current != previous:
             log.debug(
                 "daemon transport state: MAP=%s PBAP=%s ANCS=%s",
@@ -817,8 +819,10 @@ def _wait_for_daemon_transports(
                 if current.ancs and not was.ancs:
                     quirks_report.mark(attempt, "ancs_ready")
             previous = current
-        if status.ancs or (
-            not notifications_supported and status.map and status.pbap
+            if transports_changed is not None:
+                transports_changed(current)
+        if current.ancs or (
+            not notifications_supported and current.map and current.pbap
         ):
             return current
         time.sleep(0.5)
@@ -854,6 +858,7 @@ def complete_pairing(
     display: DisplayCallback | None = None,
     compatibility_mode: bool = False,
     explicit_pairing: bool = False,
+    transports_changed: TransportCallback | None = None,
     _allow_headless: bool = False,
 ) -> PairingOutcome:
     """Pair if needed and finish every Linux-side BlueFerry setup step."""
@@ -872,6 +877,7 @@ def complete_pairing(
             display=display,
             compatibility_mode=compatibility_mode,
             explicit_pairing=explicit_pairing,
+            transports_changed=transports_changed,
             attempt=attempt,
         )
     except PairingError as error:
@@ -1451,6 +1457,8 @@ def _handoff_to_daemon(
     adapter: str,
     policy: PairingPolicy,
     attempt: PairingAttempt,
+    *,
+    transports_changed: TransportCallback | None = None,
 ) -> PairingTransports:
     if policy.ancs_enabled:
         write_local_env(device.mac, adapter)
@@ -1470,6 +1478,7 @@ def _handoff_to_daemon(
         attempt=attempt,
         notifications_supported=policy.ancs_enabled,
         device_path=device.device_path,
+        transports_changed=transports_changed,
     )
     log.info(
         "pairing-window result: MAP=%s PBAP=%s ANCS=%s",
@@ -1513,6 +1522,7 @@ def _execute_pairing(
     display: DisplayCallback | None = None,
     compatibility_mode: bool = False,
     explicit_pairing: bool = False,
+    transports_changed: TransportCallback | None = None,
     attempt: PairingAttempt,
 ) -> PairingOutcome:
     preparation = _prepare_pairing(
@@ -1556,6 +1566,7 @@ def _execute_pairing(
                 selected_adapter,
                 policy,
                 attempt,
+                transports_changed=transports_changed,
             )
         finally:
             _cleanup_pairing_resources(

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -86,6 +86,10 @@ def run_wizard(
         typer.echo("Bluetooth controllers:\n")
         for index, option in enumerate(compatibility.adapters, 1):
             marker = " (selected)" if option.name == compatibility.adapter else ""
+            if not option.pairing_ready:
+                marker += " (incompatible)"
+            elif not option.available:
+                marker += " (unverified)"
             typer.echo(f"  [{index}] {option.label}{marker}")
         raw = typer.prompt("Use which controller?", default="").strip()
         if raw:

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -64,7 +64,7 @@ def run_wizard(
     *,
     verify_after: bool = True,
     compatibility_mode: bool = False,
-    explicit_pairing: bool = False,
+    explicit_pairing: bool | None = None,
 ) -> int:
     """Run the same full pairing workflow exposed by the graphical clients."""
     typer.echo(
@@ -103,6 +103,8 @@ def run_wizard(
     if not compatibility.pairing_ready:
         typer.echo(typer.style(compatibility.issue, fg=typer.colors.RED))
         return 1
+    if explicit_pairing is None:
+        explicit_pairing = compatibility.explicit_pairing_default
     # Validate the selected adapter before removing the saved phone's bond.
     if configuration.saved:
         typer.echo(

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -77,6 +77,33 @@ def run_wizard(
     except PairingError as error:
         typer.echo(typer.style(str(error), fg=typer.colors.RED))
         return 1
+    try:
+        compatibility = setup.compatibility()
+    except PairingError as error:
+        typer.echo(typer.style(str(error), fg=typer.colors.RED))
+        return 1
+    if len(compatibility.adapters) > 1:
+        typer.echo("Bluetooth controllers:\n")
+        for index, option in enumerate(compatibility.adapters, 1):
+            marker = " (selected)" if option.name == compatibility.adapter else ""
+            typer.echo(f"  [{index}] {option.label}{marker}")
+        raw = typer.prompt("Use which controller?", default="").strip()
+        if raw:
+            try:
+                picked = compatibility.adapters[int(raw) - 1]
+            except (ValueError, IndexError):
+                typer.echo(typer.style("Invalid choice.", fg=typer.colors.RED))
+                return 1
+            try:
+                compatibility = setup.compatibility(picked.name)
+            except PairingError as error:
+                typer.echo(typer.style(str(error), fg=typer.colors.RED))
+                return 1
+    typer.echo(f"Controller: {compatibility.adapter}")
+    if not compatibility.pairing_ready:
+        typer.echo(typer.style(compatibility.issue, fg=typer.colors.RED))
+        return 1
+    # Validate the selected adapter before removing the saved phone's bond.
     if configuration.saved:
         typer.echo(
             typer.style(
@@ -102,30 +129,6 @@ def run_wizard(
             return 1
         typer.echo(typer.style("✓ Previous target forgotten", fg=typer.colors.GREEN))
         configuration = setup.configuration()
-
-    try:
-        compatibility = setup.compatibility()
-    except PairingError as error:
-        typer.echo(typer.style(str(error), fg=typer.colors.RED))
-        return 1
-    if len(compatibility.adapters) > 1:
-        typer.echo("Bluetooth controllers:\n")
-        for index, option in enumerate(compatibility.adapters, 1):
-            marker = " (selected)" if option.name == compatibility.adapter else ""
-            typer.echo(f"  [{index}] {option.label}{marker}")
-        raw = typer.prompt("Use which controller?", default="").strip()
-        if raw:
-            try:
-                picked = compatibility.adapters[int(raw) - 1]
-            except (ValueError, IndexError):
-                typer.echo(typer.style("Invalid choice.", fg=typer.colors.RED))
-                return 1
-            try:
-                compatibility = setup.compatibility(picked.name)
-            except PairingError as error:
-                typer.echo(typer.style(str(error), fg=typer.colors.RED))
-                return 1
-    typer.echo(f"Controller: {compatibility.adapter}")
     if not compatibility.hardware_supported:
         typer.echo(
             typer.style(

--- a/src/blueferry/pairing_policy.py
+++ b/src/blueferry/pairing_policy.py
@@ -47,7 +47,7 @@ def resolve_pairing_policy(
     """Choose full ANCS setup or the MAP/PBAP compatibility recipe.
 
     The short-lived ANCS solicitation is independent of connecting ANCS. It
-    remains enabled whenever the adapter can advertise because older iOS uses
+    remains enabled whenever the adapter can advertise because iOS uses
     it as the signal that exposes MAP/PBAP permissions.
     """
     ancs_capable = bool(compatibility.get("notifications_supported", False))

--- a/src/blueferry/qt/qml/OnboardingSummary.qml
+++ b/src/blueferry/qt/qml/OnboardingSummary.qml
@@ -15,6 +15,7 @@ Kirigami.InlineMessage {
         + htmlEscape(detailForStage(storagePolicy, storageState))
     type: stage === "ready" || stage === "ready-without-ancs"
         ? Kirigami.MessageType.Positive
+        : stage === "incompatible" ? Kirigami.MessageType.Error
         : Kirigami.MessageType.Information
 
     function htmlEscape(value) {
@@ -56,6 +57,7 @@ Kirigami.InlineMessage {
     function titleForStage() {
         const titles = {
             "checking": qsTr("Checking Bluetooth Support"),
+            "incompatible": qsTr("Incompatible Bluetooth Adapter"),
             "activate-bluetooth": qsTr("Activate Bluetooth Support"),
             "select-device": qsTr("Pair an iPhone"),
             "starting": qsTr("Starting the Background Service"),
@@ -69,6 +71,7 @@ Kirigami.InlineMessage {
     function detailForStage(storagePolicy, storageState) {
         const details = {
             "checking": qsTr("Inspecting the selected Bluetooth controller without changing it."),
+            "incompatible": compatibility.issue || "",
             "activate-bluetooth": qsTr("The packaged BlueZ bearer support needs one authorized Bluetooth restart."),
             "select-device": qsTr("Scan for and select your iPhone here, then choose Pair. When the pairing request appears on the iPhone, approve it and confirm that the codes match. Pairing may appear idle for up to 15 seconds. After it completes, return to the Bluetooth device list and open this computer's ⓘ page a few times; turn on any new toggles that appear. System Notification access is also how BlueFerry recognizes group text threads; without it, a group text appears as a one-to-one conversation with its sender."),
             "starting": qsTr("The configured backend is starting. This normally takes a few seconds."),

--- a/src/blueferry/qt/qml/PhoneSettingsPage.qml
+++ b/src/blueferry/qt/qml/PhoneSettingsPage.qml
@@ -157,7 +157,7 @@ Kirigami.ScrollablePage {
                     ? qsTr("Could Not Verify — Pairing Still Available")
                     : iphonePage.bridge.compatibility.hardware_supported
                         ? qsTr("Compatible")
-                        : qsTr("Compatibility Warning — Pairing Still Available")
+                        : qsTr("Incompatible")
             }
 
             Controls.Label {
@@ -268,6 +268,7 @@ Kirigami.ScrollablePage {
                 icon.name: "network-connect"
                 enabled: iphonePage.device !== null
                     && iphonePage.bridge.compatibilityLoaded
+                    && iphonePage.bridge.compatibility.pairing_ready !== false
                     && !iphonePage.bridge.busy
                 onClicked: {
                     iphonePage.pairingRequested(
@@ -290,6 +291,7 @@ Kirigami.ScrollablePage {
         Controls.Label {
             Layout.fillWidth: true
             visible: !iphonePage.bridge.configured && compatibilityMode.checked
+                && iphonePage.bridge.compatibility.pairing_ready !== false
             wrapMode: Text.Wrap
             text: qsTr("BlueFerry will still advertise ANCS solicitation so the iPhone exposes its Messages and Contacts permissions, but it will not connect system notifications.")
         }

--- a/src/blueferry/qt/qml/PhoneSettingsPage.qml
+++ b/src/blueferry/qt/qml/PhoneSettingsPage.qml
@@ -63,6 +63,7 @@ Kirigami.ScrollablePage {
     }
     property string effectiveStage: iphonePage.bridge.onboardingStage
     property bool compatibilityModeOverride: false
+    property var explicitPairingOverrides: ({})
 
     ColumnLayout {
         width: parent.width
@@ -252,10 +253,18 @@ Kirigami.ScrollablePage {
 
         Controls.CheckBox {
             id: explicitPairing
+            objectName: "explicitPairingCheckBox"
             Layout.fillWidth: true
             visible: !iphonePage.bridge.configured
             text: qsTr("Use explicit Bluetooth pairing")
-            enabled: !iphonePage.bridge.busy
+            checked: iphonePage.explicitPairingOverrides[iphonePage.bridge.compatibility.adapter]
+                ?? (iphonePage.bridge.compatibility.explicit_pairing_default === true)
+            enabled: iphonePage.bridge.compatibilityLoaded && !iphonePage.bridge.busy
+            onClicked: {
+                const overrides = Object.assign({}, iphonePage.explicitPairingOverrides)
+                overrides[iphonePage.bridge.compatibility.adapter] = checked
+                iphonePage.explicitPairingOverrides = overrides
+            }
             Accessible.description: qsTr("Skips the initial Bluetooth connection attempt and calls Pair immediately. Try this for controllers that cancel normal pairing.")
         }
 

--- a/src/blueferry/setup_client.py
+++ b/src/blueferry/setup_client.py
@@ -314,6 +314,7 @@ class SetupClient:
         display: pair_setup.DisplayCallback | None = None,
         compatibility_mode: bool = False,
         explicit_pairing: bool = False,
+        transports_changed: pair_setup.TransportCallback | None = None,
     ) -> PairingOutcome:
         return pair_setup.complete_pairing(
             mac,
@@ -322,6 +323,7 @@ class SetupClient:
             display=display,
             compatibility_mode=compatibility_mode,
             explicit_pairing=explicit_pairing,
+            transports_changed=transports_changed,
         )
 
     def complete_isolated(

--- a/src/blueferry/setup_client.py
+++ b/src/blueferry/setup_client.py
@@ -195,6 +195,7 @@ class BluetoothCompatibility:
     adapters: tuple[AdapterOption, ...] = ()
     controller_vendor: str = ""
     ancs_limited_controller: bool = False
+    explicit_pairing_default: bool = False
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> BluetoothCompatibility:
@@ -223,6 +224,7 @@ class BluetoothCompatibility:
             ),
             controller_vendor=str(value.get("controller_vendor") or ""),
             ancs_limited_controller=bool(value.get("ancs_limited_controller")),
+            explicit_pairing_default=bool(value.get("explicit_pairing_default", False)),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -429,7 +429,10 @@ class IPhonePage(Gtk.Box):
         )
         self._explicit_pairing_switch.set_sensitive(not busy)
         selected = self._selected_device()
-        self._pair_button.set_sensitive(not busy and bool(selected))
+        self._pair_button.set_sensitive(
+            not busy and bool(selected)
+            and bool(self._compatibility and self._compatibility.pairing_ready)
+        )
         self._pair_button.set_label(
             _("Use Existing Pairing") if selected and selected.paired else _("Pair Selected iPhone")
         )
@@ -480,7 +483,6 @@ class IPhonePage(Gtk.Box):
         adapters = list(compatibility.adapters)
         self._applying_adapter = True
         if len(adapters) > 1:
-            self._hardware_row.set_visible(False)
             self._adapter_row.set_visible(True)
             labels = [option.label for option in adapters]
             self._adapter_model.splice(0, self._adapter_model.get_n_items(), labels)
@@ -492,21 +494,21 @@ class IPhonePage(Gtk.Box):
             self._adapter_row.set_selected(selected)
         else:
             self._adapter_row.set_visible(False)
-            self._hardware_row.set_visible(True)
-            if not compatibility.available:
-                hardware = _("Capabilities could not be verified; pairing is still available")
-            elif not compatibility.hardware_supported:
-                hardware = _("Compatibility warning; pairing is still available")
-            elif compatibility.notifications_supported:
-                hardware = _("Compatible")
-            else:
-                hardware = _("Compatible for Messages and Contacts")
-            self._hardware_row.set_subtitle(
-                _("{adapter} — {status}").format(
-                    adapter=compatibility.adapter or _("No Adapter"),
-                    status=hardware,
-                )
+        self._hardware_row.set_visible(True)
+        if not compatibility.available:
+            hardware = _("Capabilities could not be verified; pairing is still available")
+        elif not compatibility.hardware_supported:
+            hardware = compatibility.issue
+        elif compatibility.notifications_supported:
+            hardware = _("Compatible")
+        else:
+            hardware = _("Compatible for Messages and Contacts")
+        self._hardware_row.set_subtitle(
+            _("{adapter} — {status}").format(
+                adapter=compatibility.adapter or _("No Adapter"),
+                status=hardware,
             )
+        )
         self._applying_adapter = False
         self._applying_pairing_mode = True
         self._compatibility_switch.set_active(

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -55,6 +55,8 @@ class IPhonePage(Gtk.Box):
         page = Adw.PreferencesPage()
         self.append(page)
 
+        self._hardware_group = Adw.PreferencesGroup()
+        page.add(self._hardware_group)
         self._pairing_group = Adw.PreferencesGroup(
             title=_("Pair an iPhone"),
             description=_(
@@ -79,8 +81,9 @@ class IPhonePage(Gtk.Box):
         )
         self._device_row.connect("notify::selected", lambda *_args: self._selection_changed())
         self._hardware_row = Adw.ActionRow(
-            title=_("Bluetooth Controller"),
+            title=_("Adapter Compatibility"),
             subtitle=_("Checking compatibility…"),
+            subtitle_lines=0,
             use_markup=False,
         )
         self._adapter_model = Gtk.StringList()
@@ -103,7 +106,7 @@ class IPhonePage(Gtk.Box):
         )
         self._activate_button.connect("clicked", self._confirm_activate_bluez)
         self._bluez_row.add_suffix(self._activate_button)
-        self._pairing_group.add(self._hardware_row)
+        self._hardware_group.add(self._hardware_row)
         self._pairing_group.add(self._adapter_row)
         self._pairing_group.add(self._bluez_row)
 
@@ -392,6 +395,10 @@ class IPhonePage(Gtk.Box):
 
     def _update_phone_controls(self) -> None:
         configured = bool(self._configuration and self._configuration.configured)
+        self._hardware_group.set_visible(
+            not configured
+            or bool(self._compatibility and not self._compatibility.pairing_ready)
+        )
         self._pairing_group.set_visible(not configured)
         self._paired_group.set_visible(configured)
         device = self._configured_device()
@@ -414,7 +421,7 @@ class IPhonePage(Gtk.Box):
                 self._last_status.verified_iphone_setup,
                 notifications_supported=notifications_supported,
             )
-        )
+        ) if configured and self._compatibility and self._compatibility.pairing_ready else set()
         for key, row in self._iphone_setup_rows.items():
             row.set_visible(key in remaining)
         self._iphone_setup_group.set_visible(configured and bool(remaining))

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -49,6 +49,7 @@ class IPhonePage(Gtk.Box):
         self._storage_unlock_attempted = False
         self._pairing_issue_report = ""
         self._compatibility_override = False
+        self._explicit_pairing_overrides: dict[str, bool] = {}
         self._applying_pairing_mode = False
 
         page = Adw.PreferencesPage()
@@ -142,6 +143,9 @@ class IPhonePage(Gtk.Box):
             ),
         )
         self._explicit_pairing_switch = Gtk.Switch(valign=Gtk.Align.CENTER)
+        self._explicit_pairing_switch.connect(
+            "notify::active", self._explicit_pairing_changed
+        )
         self._explicit_pairing_row.add_suffix(self._explicit_pairing_switch)
         self._explicit_pairing_row.set_activatable_widget(
             self._explicit_pairing_switch
@@ -452,6 +456,12 @@ class IPhonePage(Gtk.Box):
             self._apply_bluetooth_support_status(self._compatibility)
         self._update_onboarding()
 
+    def _explicit_pairing_changed(self, *_args) -> None:
+        if not self._applying_pairing_mode and self._compatibility is not None:
+            self._explicit_pairing_overrides[self._compatibility.adapter] = (
+                self._explicit_pairing_switch.get_active()
+            )
+
     def _apply_bluetooth_support_status(self, compatibility) -> None:
         active = compatibility.bearer_api_active
         compatibility_mode = self._compatibility_switch.get_active()
@@ -514,6 +524,11 @@ class IPhonePage(Gtk.Box):
         self._compatibility_switch.set_active(
             self._compatibility_override
             or not compatibility.notifications_supported
+        )
+        self._explicit_pairing_switch.set_active(
+            self._explicit_pairing_overrides.get(
+                compatibility.adapter, compatibility.explicit_pairing_default,
+            )
         )
         self._applying_pairing_mode = False
         self._apply_bluetooth_support_status(compatibility)

--- a/tests/test_cli_pairing.py
+++ b/tests/test_cli_pairing.py
@@ -40,6 +40,10 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
         def configuration(self):
             return SimpleNamespace(adapter="hci0")
 
+        def compatibility(self, adapter):
+            assert adapter == "hci1"
+            return SimpleNamespace(pairing_ready=True)
+
         def prepare_replacement(self, previous_mac, next_mac, *, adapter=None):
             observed.append(("replace", previous_mac, next_mac, adapter))
 
@@ -106,6 +110,32 @@ def test_pairing_complete_refuses_the_headless_path(monkeypatch):
         "pairing-complete requires an interactive BlueFerry client"
     )
     assert called == []
+
+
+def test_pairing_replacement_rejects_incompatible_adapter_before_forgetting(monkeypatch):
+    message = "Incompatible Bluetooth adapter: missing Bluetooth LE"
+    calls = []
+
+    class Setup:
+        def compatibility(self, adapter):
+            assert adapter == "hci1"
+            return SimpleNamespace(pairing_ready=False, issue=message)
+
+        def prepare_replacement(self, *_args, **_kwargs):
+            calls.append("forget")
+
+        def complete(self, *_args, **_kwargs):
+            calls.append("pair")
+
+    monkeypatch.setattr(setup_client, "SetupClient", Setup)
+    result = CliRunner().invoke(cli.app, [
+        "pairing-complete", "02:00:00:00:00:01", "--interactive-agent",
+        "--adapter", "hci1", "--replace-saved-mac", "02:00:00:00:00:02",
+        "--compatibility-mode",
+    ], input="yes\n")
+    assert result.exit_code == 2
+    assert json.loads(result.stdout.splitlines()[-1]) == {"ok": False, "error": message}
+    assert calls == []
 
 
 def test_pairing_complete_failure_includes_report_path(monkeypatch):

--- a/tests/test_cli_pairing.py
+++ b/tests/test_cli_pairing.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from typer.testing import CliRunner
 
 from blueferry import cli, pairing_cli, quirks_report, setup_client
@@ -28,9 +29,23 @@ def test_pair_setup_debug_enables_diagnostic_logging(monkeypatch):
         ("wizard", {
             "verify_after": False,
             "compatibility_mode": False,
-            "explicit_pairing": False,
+            "explicit_pairing": None,
         }),
     ]
+
+
+@pytest.mark.parametrize("flag,expected", [
+    ("--explicit-pairing", True), ("--no-explicit-pairing", False),
+])
+def test_pair_setup_can_override_the_adapter_default(monkeypatch, flag, expected):
+    observed = []
+    monkeypatch.setattr(
+        pairing_cli, "run_wizard",
+        lambda **kwargs: observed.append(kwargs["explicit_pairing"]) or 0,
+    )
+    result = CliRunner().invoke(cli.app, ["pair-setup", "--no-verify", flag])
+    assert result.exit_code == 0
+    assert observed == [expected]
 
 
 def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):

--- a/tests/test_cli_pairing.py
+++ b/tests/test_cli_pairing.py
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from blueferry import cli, pairing_cli, quirks_report, setup_client
+from blueferry.pairing_types import PairingTransports
 
 
 def test_pair_setup_debug_enables_diagnostic_logging(monkeypatch):
@@ -71,10 +72,12 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
             adapter=None,
             compatibility_mode=False,
             explicit_pairing=False,
+            transports_changed=None,
         ):
             assert compatibility_mode is False
             assert explicit_pairing is False
             observed.append((mac, adapter, confirmation(12345)))
+            transports_changed(PairingTransports(map=True, pbap=True, ancs=False))
             return SimpleNamespace(to_dict=lambda: {"ok": True, "device": {"mac": mac}})
 
     monkeypatch.setattr(setup_client, "SetupClient", Setup)
@@ -98,6 +101,7 @@ def test_interactive_pairing_emits_code_and_waits_for_acceptance(monkeypatch):
     assert events == [
         {"event": "confirmation", "passkey": "", "purpose": "bind"},
         {"event": "confirmation", "passkey": "012345"},
+        {"event": "transports", "map": True, "pbap": True, "ancs": False},
         {"ok": True, "device": {"mac": "02:00:00:00:00:01"}},
     ]
     assert observed == [

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -191,12 +191,6 @@ def test_gui_pairing_requires_confirmation_before_replacing_saved_target() -> No
     assert "--replace-saved-mac" in quickshell
 
 
-def test_capability_checks_do_not_disable_pairing_buttons() -> None:
-    gtk = (ROOT / "src/blueferry/ui/status.py").read_text()
-    assert "self._pair_button.set_sensitive(not busy and bool(selected))" in gtk
-    # Qt and Quickshell use behavioral checks against loaded settings pages.
-
-
 def test_quickshell_launcher_can_focus_an_existing_conversation() -> None:
     launcher = (ROOT / "data" / "blueferry-quickshell").read_text()
     qml = (ROOT / "data" / "quickshell" / "shell.qml").read_text()

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -55,6 +55,16 @@ def test_unverified_controller_still_requests_a_device() -> None:
     )
 
 
+def test_incompatible_controller_never_prompts_for_iphone_permissions() -> None:
+    for configured in (False, True):
+        assert derive_stage(
+            setup_loaded=True,
+            configured=configured,
+            compatibility={"pairing_ready": False, "notifications_supported": False},
+            status={"daemon": True},
+        ) is OnboardingStage.INCOMPATIBLE
+
+
 def test_optional_ancs_transport_controls_activation_step() -> None:
     inactive = {**COMPATIBLE, "bearer_api_active": False}
     assert (

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -1164,7 +1164,10 @@ def test_adapter_selection_prefers_le_advertising_but_honors_explicit_choice(mon
     assert explicit["pairing_ready"] is False
 
 
-def test_explicit_pairing_default_matches_only_the_selected_rtl8761bu(monkeypatch):
+@pytest.mark.parametrize("explicit_usb_id", ["0BDA:8771", "13D3:3586", "0bda:8922"])
+def test_explicit_pairing_default_matches_only_the_selected_listed_adapter(
+    monkeypatch, explicit_usb_id,
+):
     class Manager:
         def GetManagedObjects(self):
             return {f"/org/bluez/hci{n}": {"org.bluez.Adapter1": {}} for n in range(3)}
@@ -1175,7 +1178,7 @@ def test_explicit_pairing_default_matches_only_the_selected_rtl8761bu(monkeypatc
         )
         return type("Result", (), {"returncode": 0, "stdout": stdout})()
 
-    usb_ids = {"hci0": "8087:0029", "hci1": "0BDA:8771", "hci2": "0bda:c85b"}
+    usb_ids = {"hci0": "8087:0029", "hci1": explicit_usb_id, "hci2": "0bda:c85b"}
     monkeypatch.setattr(pair_setup, "_object_manager", Manager)
     monkeypatch.setattr(pair_setup, "run_command", controller_info)
     monkeypatch.setattr(pair_setup, "bluez_support_status", lambda: {"active": True})

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -1043,7 +1043,8 @@ def test_compatibility_explains_missing_classic_transport(monkeypatch):
     status = pair_setup.bluetooth_compatibility("hci0")
 
     assert status["hardware_supported"] is False
-    assert status["pairing_ready"] is True
+    assert status["pairing_ready"] is False
+    assert status["notifications_supported"] is False
     assert "BR/EDR" in status["issue"]
 
 
@@ -1076,7 +1077,11 @@ def test_btmgmt_timeout_is_advisory_and_keeps_pairing_available(monkeypatch):
     assert status["adapters"][0]["pairing_ready"] is True
 
 
-def test_classic_only_controller_supports_core_without_ancs(monkeypatch):
+@pytest.mark.parametrize("version,settings,missing", [
+    (5, "powered ssp br/edr", "Bluetooth LE"),
+    (6, "powered ssp br/edr le", "LE advertising"),
+])
+def test_controller_without_le_advertising_is_incompatible(monkeypatch, version, settings, missing):
     monkeypatch.setattr(
         pair_setup,
         "_object_manager",
@@ -1090,7 +1095,11 @@ def test_classic_only_controller_supports_core_without_ancs(monkeypatch):
             (),
             {
                 "returncode": 0,
-                "stdout": "supported settings: powered ssp br/edr\n",
+                "stdout": (
+                    f"addr 02:00:00:00:00:01 version {version} manufacturer 15\n"
+                    f"supported settings: {settings}\n"
+                    "current settings: powered ssp br/edr\n"
+                ),
             },
         )(),
     )
@@ -1102,9 +1111,57 @@ def test_classic_only_controller_supports_core_without_ancs(monkeypatch):
 
     status = pair_setup.bluetooth_compatibility("hci0")
 
-    assert status["messages_supported"] is True
+    assert status["hci_version"] == version
+    assert status["hardware_supported"] is False
+    assert status["messages_supported"] is False
     assert status["notifications_supported"] is False
-    assert status["pairing_ready"] is True
+    assert status["pairing_ready"] is False
+    assert "Incompatible Bluetooth adapter" in status["issue"]
+    assert missing in status["issue"]
+    assert "Bluetooth 4.0 or newer" in status["issue"]
+    assert status["adapters"][0]["pairing_ready"] is False
+
+
+def test_adapter_selection_prefers_le_advertising_but_honors_explicit_choice(monkeypatch):
+    monkeypatch.setattr(pair_setup.config, "ADAPTER", "hci0")
+
+    class Manager:
+        def GetManagedObjects(self):
+            return {
+                "/org/bluez/hci0": {"org.bluez.Adapter1": {}},
+                "/org/bluez/hci1": {"org.bluez.Adapter1": {}},
+            }
+
+    def controller_info(command, **_kwargs):
+        if command[0] == "bluetoothctl":
+            stdout = "bluetoothctl: 5.72\n"
+        else:
+            # hci0 matches #143; hci1 matches the Bluetooth 4.0 MAP success in
+            # #113, with LE supported but currently switched off.
+            version, extra = (5, "") if command[2] == "0" else (6, "le advertising")
+            stdout = (
+                f"addr 02:00:00:00:00:01 version {version} manufacturer 15\n"
+                f"supported settings: powered ssp br/edr {extra}\n"
+                "current settings: powered ssp br/edr\n"
+            )
+        return type("Result", (), {"returncode": 0, "stdout": stdout})()
+
+    monkeypatch.setattr(pair_setup, "_object_manager", Manager)
+    monkeypatch.setattr(pair_setup, "run_command", controller_info)
+    monkeypatch.setattr(pair_setup, "bluez_support_status", lambda: {"active": False})
+
+    automatic = pair_setup.bluetooth_compatibility()
+    assert automatic["adapter"] == "hci1"
+    assert automatic["hci_version"] == 6
+    assert automatic["messages_supported"] is True
+    assert automatic["pairing_ready"] is True
+    assert automatic["notifications_supported"] is False
+    assert "le" not in automatic["current_settings"]
+    assert automatic["adapters"][0]["hardware_supported"] is False
+
+    explicit = pair_setup.bluetooth_compatibility("hci0")
+    assert explicit["adapter"] == "hci0"
+    assert explicit["pairing_ready"] is False
 
 
 def test_controller_snapshot_does_not_repeat_btmgmt_or_systemctl(monkeypatch):
@@ -1696,6 +1753,29 @@ def test_unverified_controller_reaches_the_real_pairing_transaction(
         pair_setup.complete_pairing(device.mac, _allow_headless=True)
 
     assert "continuing with pairing" in caplog.text
+
+
+@pytest.mark.parametrize("paired", [False, True])
+@pytest.mark.parametrize("compatibility_mode", [False, True])
+def test_incompatible_adapter_stops_before_setup_changes(monkeypatch, paired, compatibility_mode):
+    device = _device(paired=paired)
+    monkeypatch.setattr(pair_setup, "_device", lambda *_args, **_kwargs: device)
+    compatibility = {
+        "available": True, "hardware_supported": False, "pairing_ready": False,
+        "notifications_supported": False, "low_energy": False, "advertising": False,
+        "issue": "Incompatible Bluetooth adapter: missing Bluetooth LE and LE advertising",
+    }
+    monkeypatch.setattr(pair_setup, "bluetooth_compatibility", lambda *_args: compatibility)
+    monkeypatch.setattr(pair_setup, "_controller_snapshot", lambda *_args: compatibility)
+    monkeypatch.setattr(
+        pair_setup, "_apply_phone_audio_policy",
+        lambda *_args: pytest.fail("incompatible adapter changed system configuration"),
+    )
+    with pytest.raises(pair_setup.PairingError, match="Incompatible Bluetooth adapter"):
+        pair_setup._execute_pairing(
+            device.mac, compatibility_mode=compatibility_mode,
+            attempt=pair_setup.quirks_report.start_attempt(interactive=False),
+        )
 
 
 def test_complete_pairing_prepares_the_selected_adapter_not_a_leftover_bond(

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -537,6 +537,7 @@ def test_transport_wait_samples_bluez_at_a_bounded_rate(monkeypatch):
     ] + [BackendStatus(map=True, pbap=True, ancs=True)]
     snapshots = []
     clients = []
+    progress = []
 
     class FakeClient:
         def __init__(self):
@@ -558,11 +559,43 @@ def test_transport_wait_samples_bluez_at_a_bounded_rate(monkeypatch):
         timeout=10,
         attempt={},
         device_path="/device",
+        transports_changed=lambda current: progress.append((now[0], current.as_tuple())),
     )
 
     assert result.as_tuple() == (True, True, True)
     assert snapshots == [0.0, 2.0]
     assert len(clients) == 1
+    # MAP/PBAP must reach the client before the helper finishes waiting for ANCS.
+    assert progress == [(0.0, (True, True, False)), (2.5, (True, True, True))]
+
+
+@pytest.mark.parametrize("backend_error", [False, True])
+def test_transport_progress_clears_lost_connections(monkeypatch, backend_error):
+    from blueferry.client import BackendError
+    from blueferry.models import BackendStatus
+
+    now = [0.0]
+    progress = []
+
+    def read_status():
+        if now[0] < 1:
+            return BackendStatus(map=True, pbap=True)
+        if backend_error:
+            raise BackendError("Daemon stopped")
+        return BackendStatus()
+
+    monkeypatch.setattr(pair_setup.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(pair_setup.time, "sleep", lambda seconds: now.__setitem__(0, now[0] + seconds))
+    monkeypatch.setattr(pair_setup, "_record_bluez_state", lambda *_args: None)
+
+    result = pair_setup._wait_for_daemon_transports(
+        timeout=2,
+        status_reader=read_status,
+        transports_changed=lambda current: progress.append((now[0], current.as_tuple())),
+    )
+
+    assert result == pair_setup.PairingTransports()
+    assert progress == [(0.0, (True, True, False)), (1.0, (False, False, False))]
 
 
 def test_teardown_trace_survives_quickshell_helper_processes(monkeypatch):
@@ -1486,7 +1519,17 @@ def test_complete_pairing_starts_profiles_while_pairing_advert_is_active(monkeyp
     )
     monkeypatch.setattr(pair_setup, "_restart_user_service", lambda: calls.append("restart"))
 
-    result = pair_setup.complete_pairing(device.mac, _allow_headless=True)
+    def wait_for_transports(*, transports_changed, **_kwargs):
+        state = pair_setup.PairingTransports(True, True, True)
+        transports_changed(state)
+        return state
+
+    monkeypatch.setattr(pair_setup, "_wait_for_daemon_transports", wait_for_transports)
+    result = pair_setup.complete_pairing(
+        device.mac,
+        _allow_headless=True,
+        transports_changed=lambda state: calls.append(("transports", state.as_tuple())),
+    )
 
     assert result.device.mac == device.mac
     assert result.ancs == "connected"
@@ -1500,6 +1543,7 @@ def test_complete_pairing_starts_profiles_while_pairing_advert_is_active(monkeyp
         ("advert", "hci0"),
         "config",
         "restart",
+        ("transports", (True, True, True)),
         ("unregister", "hci0"),
     ]
 
@@ -1549,7 +1593,7 @@ def test_compatibility_pairing_continues_when_solicitation_is_unavailable(
     monkeypatch.setattr(
         pair_setup,
         "_handoff_to_daemon",
-        lambda selected, adapter, selected_policy, _attempt: calls.append(
+        lambda selected, adapter, selected_policy, _attempt, **_kwargs: calls.append(
             ("handoff", selected.mac, adapter, selected_policy.ancs_enabled)
         )
         or pair_setup.PairingTransports(map=True, pbap=True, ancs=False),

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -1164,6 +1164,32 @@ def test_adapter_selection_prefers_le_advertising_but_honors_explicit_choice(mon
     assert explicit["pairing_ready"] is False
 
 
+def test_explicit_pairing_default_matches_only_the_selected_rtl8761bu(monkeypatch):
+    class Manager:
+        def GetManagedObjects(self):
+            return {f"/org/bluez/hci{n}": {"org.bluez.Adapter1": {}} for n in range(3)}
+
+    def controller_info(command, **_kwargs):
+        stdout = "bluetoothctl: 5.87\n" if command[0] == "bluetoothctl" else (
+            "supported settings: powered ssp br/edr le advertising secure-conn\n"
+        )
+        return type("Result", (), {"returncode": 0, "stdout": stdout})()
+
+    usb_ids = {"hci0": "8087:0029", "hci1": "0BDA:8771", "hci2": "0bda:c85b"}
+    monkeypatch.setattr(pair_setup, "_object_manager", Manager)
+    monkeypatch.setattr(pair_setup, "run_command", controller_info)
+    monkeypatch.setattr(pair_setup, "bluez_support_status", lambda: {"active": True})
+    monkeypatch.setattr(
+        pair_setup.capabilities, "controller_hardware",
+        lambda adapter, **_kwargs: {"usb_id": usb_ids[adapter]},
+    )
+    for adapter, expected in (("hci0", False), ("hci1", True), ("hci2", False)):
+        compatibility = pair_setup.bluetooth_compatibility(adapter)
+        assert compatibility["explicit_pairing_default"] is expected
+        assert compatibility["messages_supported"] is True
+        assert compatibility["notifications_supported"] is True
+
+
 def test_controller_snapshot_does_not_repeat_btmgmt_or_systemctl(monkeypatch):
     calls = []
 

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -1164,6 +1164,49 @@ def test_adapter_selection_prefers_le_advertising_but_honors_explicit_choice(mon
     assert explicit["pairing_ready"] is False
 
 
+@pytest.mark.parametrize("states,requested,expected", [
+    (("incompatible", "unverified"), "hci0", "hci1"),
+    (("unverified", "supported"), "hci0", "hci1"),
+    (("supported", "unverified"), "hci1", "hci0"),
+    (("unverified", "unverified"), "hci1", "hci1"),
+    (("incompatible", "incompatible"), "hci0", "hci0"),
+])
+def test_adapter_selection_ranks_verified_then_unverified_then_incompatible(
+    monkeypatch, states, requested, expected,
+):
+    class Manager:
+        def GetManagedObjects(self):
+            return {f"/org/bluez/hci{n}": {"org.bluez.Adapter1": {}} for n in range(2)}
+
+    def controller_info(command, **_kwargs):
+        if command[0] == "bluetoothctl":
+            stdout = "bluetoothctl: 5.87\n"
+        else:
+            state = states[int(command[2])]
+            if state == "unverified":
+                raise pair_setup.CommandError(tuple(command), "btmgmt timed out")
+            extra = "le advertising" if state == "supported" else ""
+            stdout = f"supported settings: powered ssp br/edr {extra}\n"
+        return type("Result", (), {"returncode": 0, "stdout": stdout})()
+
+    monkeypatch.setattr(pair_setup.config, "ADAPTER", requested)
+    monkeypatch.setattr(pair_setup, "_object_manager", Manager)
+    monkeypatch.setattr(pair_setup, "run_command", controller_info)
+    monkeypatch.setattr(pair_setup, "bluez_support_status", lambda: {"active": True})
+    monkeypatch.setattr(pair_setup.capabilities, "controller_hardware", lambda *_a, **_kw: {})
+
+    automatic = pair_setup.bluetooth_compatibility()
+    assert automatic["adapter"] == expected
+    expected_state = states[int(expected[-1])]
+    assert automatic["pairing_ready"] is (expected_state != "incompatible")
+    assert automatic["hardware_supported"] is (expected_state == "supported")
+    if expected_state == "unverified":
+        assert automatic["issue"] == "btmgmt timed out"
+
+    # An explicit selection must still be checked and reported as selected.
+    assert pair_setup.bluetooth_compatibility(requested)["adapter"] == requested
+
+
 @pytest.mark.parametrize("explicit_usb_id", ["0BDA:8771", "13D3:3586", "0bda:8922"])
 def test_explicit_pairing_default_matches_only_the_selected_listed_adapter(
     monkeypatch, explicit_usb_id,

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -125,6 +125,10 @@ def test_cli_requires_phone_side_forget_before_clearing_saved_target(
             return SimpleNamespace(saved=True, mac="02:00:00:00:00:01", adapter="hci1")
 
         @staticmethod
+        def compatibility():
+            return SimpleNamespace(adapter="hci1", pairing_ready=True, adapters=())
+
+        @staticmethod
         def forget(mac, *, adapter=None):
             forgotten.append((mac, adapter))
             raise pairing_cli.PairingError("stop after forget")
@@ -147,6 +151,36 @@ def test_cli_requires_phone_side_forget_before_clearing_saved_target(
     output = capsys.readouterr().out
     assert "Before answering Yes, forget this PC on the iPhone too" in output
     assert "Forget This Device" in output
+
+
+@pytest.mark.parametrize("saved", [False, True])
+def test_cli_incompatible_adapter_stops_before_scanning_or_forgetting(monkeypatch, capsys, saved):
+    message = "Incompatible Bluetooth adapter: missing Bluetooth LE"
+
+    class Setup:
+        @staticmethod
+        def configuration():
+            return SimpleNamespace(saved=saved, mac="02:00:00:00:00:01", adapter="hci0")
+
+        @staticmethod
+        def compatibility():
+            return SimpleNamespace(adapter="hci0", adapters=(), pairing_ready=False, issue=message)
+
+        @staticmethod
+        def devices(**_kwargs):
+            pytest.fail("scanned with an incompatible adapter")
+
+        @staticmethod
+        def forget(*_args, **_kwargs):
+            pytest.fail("removed a bond with an incompatible adapter")
+
+    monkeypatch.setattr(pairing_cli, "SetupClient", Setup)
+    monkeypatch.setattr(
+        pairing_cli.typer, "confirm",
+        lambda *_args, **_kwargs: pytest.fail("prompted for incompatible pairing"),
+    )
+    assert pairing_cli.run_wizard(verify_after=False, compatibility_mode=True) == 1
+    assert message in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(
@@ -180,6 +214,7 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(
     compatibility = SimpleNamespace(
         adapter="hci0",
         hardware_supported=hardware_supported,
+        pairing_ready=True,
         issue=issue,
         notifications_supported=notifications_supported,
         bearer_api_active=True,
@@ -271,6 +306,7 @@ def test_cli_wizard_preserves_report_for_unexpected_pairing_failure(
             return SimpleNamespace(
                 adapter="hci0",
                 hardware_supported=True,
+                pairing_ready=True,
                 issue="",
                 notifications_supported=True,
                 bearer_api_active=True,
@@ -320,6 +356,7 @@ def test_cli_wizard_points_at_pairing_issue_when_ancs_stays_down(
     compatibility = SimpleNamespace(
         adapter="hci0",
         hardware_supported=True,
+        pairing_ready=True,
         issue="",
         notifications_supported=True,
         bearer_api_active=True,

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -126,7 +126,9 @@ def test_cli_requires_phone_side_forget_before_clearing_saved_target(
 
         @staticmethod
         def compatibility():
-            return SimpleNamespace(adapter="hci1", pairing_ready=True, adapters=())
+            return SimpleNamespace(
+                adapter="hci1", pairing_ready=True, adapters=(), explicit_pairing_default=False,
+            )
 
         @staticmethod
         def forget(mac, *, adapter=None):
@@ -190,6 +192,9 @@ def test_cli_incompatible_adapter_stops_before_scanning_or_forgetting(monkeypatc
         (False, False, "btmgmt timed out", True),
     ],
 )
+@pytest.mark.parametrize("default,override,expected_explicit", [
+    (False, None, False), (True, None, True), (True, False, False), (False, True, True),
+])
 def test_cli_wizard_supplies_its_own_pairing_agent_ui(
     monkeypatch,
     capsys,
@@ -197,6 +202,9 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(
     notifications_supported,
     issue,
     expected_mode,
+    default,
+    override,
+    expected_explicit,
 ) -> None:
     prompts = []
     observed = []
@@ -215,6 +223,7 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(
         adapter="hci0",
         hardware_supported=hardware_supported,
         pairing_ready=True,
+        explicit_pairing_default=default,
         issue=issue,
         notifications_supported=notifications_supported,
         bearer_api_active=True,
@@ -246,7 +255,7 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(
             explicit_pairing=False,
         ):
             assert compatibility_mode is expected_mode
-            assert explicit_pairing is False
+            assert explicit_pairing is expected_explicit
             observed.append((mac, adapter, confirmation(12345)))
             display(12345)
             return SimpleNamespace(device=device, ancs_ready=True)
@@ -265,7 +274,7 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(
     monkeypatch.setattr(pairing_cli.typer, "confirm", confirm)
     monkeypatch.setattr(pairing_cli, "_print_iphone_steps", lambda *_args, **_kwargs: None)
 
-    assert pairing_cli.run_wizard(verify_after=False) == 0
+    assert pairing_cli.run_wizard(verify_after=False, explicit_pairing=override) == 0
     assert observed == [(device.mac, "hci0", True)]
     assert prompts == [
         ("\nUse this device?", {"default": True}),
@@ -307,6 +316,7 @@ def test_cli_wizard_preserves_report_for_unexpected_pairing_failure(
                 adapter="hci0",
                 hardware_supported=True,
                 pairing_ready=True,
+                explicit_pairing_default=False,
                 issue="",
                 notifications_supported=True,
                 bearer_api_active=True,
@@ -357,6 +367,7 @@ def test_cli_wizard_points_at_pairing_issue_when_ancs_stays_down(
         adapter="hci0",
         hardware_supported=True,
         pairing_ready=True,
+        explicit_pairing_default=False,
         issue="",
         notifications_supported=True,
         bearer_api_active=True,

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -5,7 +5,7 @@ import pytest
 from blueferry import pairing_cli
 from blueferry.bluetooth_devices import PairedDevice
 from blueferry.pairing_cli import _print_ancs_repair_hint, _print_iphone_steps
-from blueferry.setup_client import DISCOVERY_SECONDS
+from blueferry.setup_client import DISCOVERY_SECONDS, BluetoothCompatibility
 from blueferry.setup_verification import CONTACTS
 
 
@@ -153,6 +153,44 @@ def test_cli_requires_phone_side_forget_before_clearing_saved_target(
     output = capsys.readouterr().out
     assert "Before answering Yes, forget this PC on the iPhone too" in output
     assert "Forget This Device" in output
+
+
+def test_cli_labels_adapter_choices_and_checks_an_explicit_incompatible_choice(monkeypatch, capsys):
+    compatibility = BluetoothCompatibility.from_dict({
+        "adapter": "hci1", "pairing_ready": True,
+        "adapters": [
+            {"name": "hci0", "label": "Built-in (hci0)", "available": True,
+             "pairing_ready": False},
+            {"name": "hci1", "label": "Dongle (hci1)", "available": False,
+             "pairing_ready": True},
+        ],
+    })
+    selected = []
+
+    class Setup:
+        def configuration(self):
+            return SimpleNamespace(saved=True)
+
+        def compatibility(self, adapter=None):
+            selected.append(adapter)
+            if adapter is None:
+                return compatibility
+            return BluetoothCompatibility.from_dict({
+                "adapter": adapter, "pairing_ready": False,
+                "issue": "Incompatible Bluetooth adapter: missing Bluetooth LE",
+            })
+
+        def forget(self, *_args, **_kwargs):
+            pytest.fail("removed the saved phone for an incompatible choice")
+
+    monkeypatch.setattr(pairing_cli, "SetupClient", Setup)
+    monkeypatch.setattr(pairing_cli.typer, "prompt", lambda *_a, **_kw: "1")
+    assert pairing_cli.run_wizard(verify_after=False) == 1
+    assert selected == [None, "hci0"]
+    output = capsys.readouterr().out
+    assert "[1] Built-in (hci0) (incompatible)" in output
+    assert "[2] Dongle (hci1) (selected) (unverified)" in output
+    assert "Incompatible Bluetooth adapter: missing Bluetooth LE" in output
 
 
 @pytest.mark.parametrize("saved", [False, True])

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -1062,6 +1062,16 @@ def test_quickshell_settings_bindings_and_unverified_pairing(qml_engine, quicksh
     assert message.property("visible")
     assert "Incompatible Bluetooth adapter" in message.property("text")
     _evaluate(qml_engine, '''
+        setup.configured = true;
+        page.status = Object.assign({}, page.status, {daemon: true});
+    ''')
+    heading = page.findChild(QObject, "iphoneSetupHeading")
+    instructions = page.findChild(QObject, "iphoneSetupInstructions")
+    assert not pair.property("visible")
+    assert message.property("visible")
+    assert not heading.property("visible")
+    assert not instructions.property("visible")
+    _evaluate(qml_engine, '''
         setup.loadCompatibility("hci0");
         setup.finish(setup.pending.compatibility.id, "compatibility", 1, "", "btmgmt timed out");
         setup.loadDevices(false);
@@ -1069,6 +1079,11 @@ def test_quickshell_settings_bindings_and_unverified_pairing(qml_engine, quicksh
     ''')
     assert pair.property("enabled")
     assert not message.property("visible")
+    assert heading.property("visible")
+    assert instructions.property("visible")
+    assert "Enable Show Message Notifications" in instructions.property("text")
+    _evaluate(qml_engine, "setup.configured = false")
+    assert not heading.property("visible")
     QMetaObject.invokeMethod(pair, "clicked")
     assert quickshell_setup.property("pairing")
     assert not pair.property("enabled")

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -603,6 +603,37 @@ def test_phone_settings_pairing_uses_loaded_selection_and_busy_state(qml_engine,
     assert not button.property("enabled")
 
 
+def test_qt_explicit_pairing_default_preserves_per_adapter_choices(qml_engine, settings_window):
+    window, bridge = settings_window
+    bridge.setProperty("setupLoaded", True)
+    bridge.setProperty("compatibilityLoaded", True)
+    bridge.setProperty("devices", [{"mac": "NEW", "display_name": "Phone", "paired": False}])
+    checkbox = _settings_object(window, "explicitPairingCheckBox")
+    pair = _settings_object(window, "pairPhoneButton")
+    rtl = {"adapter": "hci1", "explicit_pairing_default": True}
+    other = {"adapter": "hci0", "explicit_pairing_default": False}
+    bridge.setProperty("compatibility", rtl)
+    assert checkbox.property("checked")
+    QMetaObject.invokeMethod(pair, "clicked")
+    assert _evaluate(qml_engine, "testBridge.calls[0].args") == ["NEW", True, True]
+
+    QMetaObject.invokeMethod(checkbox, "toggle")
+    QMetaObject.invokeMethod(checkbox, "clicked")
+    bridge.setProperty("compatibility", {**rtl, "powered": True})
+    assert not checkbox.property("checked")
+    QMetaObject.invokeMethod(pair, "clicked")
+    assert _evaluate(qml_engine, "testBridge.calls[1].args") == ["NEW", True, False]
+
+    bridge.setProperty("compatibility", other)
+    assert not checkbox.property("checked")
+    QMetaObject.invokeMethod(checkbox, "toggle")
+    QMetaObject.invokeMethod(checkbox, "clicked")
+    bridge.setProperty("compatibility", rtl)
+    assert not checkbox.property("checked")
+    bridge.setProperty("compatibility", other)
+    assert checkbox.property("checked")
+
+
 @pytest.mark.parametrize("confirm", [False, True])
 def test_phone_replacement_keeps_the_confirmed_targets_across_refresh(qml_engine, settings_window, confirm):
     window, bridge = settings_window
@@ -928,7 +959,7 @@ def quickshell_setup(qml_engine):
        reply("configuration", {configured:false,saved:false});
        check(setup.pairingIssueReport === "/tmp/fake-report", "failure report lost");''',
     '''ready(); setup.targetSaved = true; setup.configuredMac = "OLD";
-       setup.explicitPairingOverride = true; setup.requestPairing();
+       setup.setExplicitPairing(true); setup.requestPairing();
        check(!setup.pairing && setup.pendingReplacement, "replacement skipped confirmation");
        setup.configuredMac = "OTHER"; setup.adapterName = "hci9";
        setup.pairingDevices = [{mac:"OTHER-NEW"}]; setup.confirmReplacement();
@@ -967,8 +998,30 @@ def quickshell_setup(qml_engine):
        ready(); setup.requestPairing();
        setup.finish(setup.pending.pair.id,"pair",0,"","");
        check(!setup.configured && !setup.pairing && setup.pairingStatus.includes("no result"), "empty success accepted");''',
+    '''ready();
+       function selectAdapter(adapter, defaultValue) {
+         setup.loadCompatibility(adapter);
+         reply("compatibility", {adapter:adapter, notifications_supported:false,
+           explicit_pairing_default:defaultValue});
+         reply("devices", [{mac:"NEW",adapter_path:"/org/bluez/"+adapter}]);
+       }
+       selectAdapter("hci1", true);
+       check(setup.explicitPairing, "RTL8761BU did not default to explicit pairing");
+       setup.requestPairing();
+       check(requests[requests.length-1].argv.includes("--explicit-pairing"), "default not forwarded");
+       reply("pair", {ok:false,error:"Cancelled"}, 1);
+       setup.setExplicitPairing(false);
+       selectAdapter("hci1", true);
+       check(!setup.explicitPairing, "refresh overwrote manual opt-out");
+       selectAdapter("hci0", false);
+       check(!setup.explicitPairing, "default leaked to another adapter");
+       setup.setExplicitPairing(true);
+       selectAdapter("hci1", true);
+       check(!setup.explicitPairing, "adapter switch lost opt-out");
+       setup.requestPairing();
+       check(!requests[requests.length-1].argv.includes("--explicit-pairing"), "manual opt-out ignored");''',
 ], ids=["first-install", "adapter-switch", "cancel-scan", "failed-pair", "replacement-snapshot",
-        "forget-confirmation", "pair-success", "failed-helpers", "missing-helper"])
+        "forget-confirmation", "pair-success", "failed-helpers", "missing-helper", "explicit-default"])
 def test_quickshell_setup_responses(qml_engine, quickshell_setup, scenario):
     result = qml_engine.evaluate("(function() {" + scenario + "})()")
     assert not result.isError(), result.toString()
@@ -1000,7 +1053,7 @@ def test_quickshell_settings_bindings_and_unverified_pairing(qml_engine, quicksh
             issue: "Incompatible Bluetooth adapter: missing Bluetooth LE"});
         reply("devices", [{mac: "OLD", paired: true, adapter_path: "/org/bluez/hci1"}]);
         setup.compatibilityModeOverride = true;
-        setup.explicitPairingOverride = true;
+        setup.setExplicitPairing(true);
         setup.requestPairing();
         check(!setup.pairing, "incompatible controller started pairing");
     ''')

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -1020,8 +1020,27 @@ def quickshell_setup(qml_engine):
        check(!setup.explicitPairing, "adapter switch lost opt-out");
        setup.requestPairing();
        check(!requests[requests.length-1].argv.includes("--explicit-pairing"), "manual opt-out ignored");''',
+    '''ready(); setup.setExplicitPairing(true); setup.requestPairing();
+       const first = setup.pending.pair.id;
+       const connected = '{"event":"transports","map":true,"pbap":true,"ancs":false}';
+       setup.receiveLine(first, "pair", connected);
+       check(setup.pairingTransports.map && setup.pairingTransports.pbap, "live services missing");
+       check(setup.pairing && !setup.configured, "progress completed pairing prematurely");
+       check(setup.pairingStatus.includes("Messages and contacts are connected"), "progress text missing");
+       setup.receiveLine(first, "pair", '{"event":"transports","map":false,"pbap":false}');
+       check(setup.pairingTransports.map, "malformed progress accepted");
+       reply("pair", {ok:false,error:"Cancelled"}, 1);
+       setup.requestPairing();
+       check(!setup.pairingTransports.map && !setup.pairingTransports.pbap, "new attempt kept old services");
+       setup.receiveLine(first, "pair", connected);
+       setup.receiveLine(setup.pending.pair.id, "forget", connected);
+       check(!setup.pairingTransports.map, "stale or wrong-kind progress accepted");
+       setup.receiveLine(setup.pending.pair.id, "pair", connected);
+       setup.receiveLine(setup.pending.pair.id, "pair", '{"event":"transports","map":false,"pbap":false,"ancs":false}');
+       check(!setup.pairingTransports.map && !setup.pairingTransports.pbap, "lost services stayed connected");''',
 ], ids=["first-install", "adapter-switch", "cancel-scan", "failed-pair", "replacement-snapshot",
-        "forget-confirmation", "pair-success", "failed-helpers", "missing-helper", "explicit-default"])
+        "forget-confirmation", "pair-success", "failed-helpers", "missing-helper", "explicit-default",
+        "live-transports"])
 def test_quickshell_setup_responses(qml_engine, quickshell_setup, scenario):
     result = qml_engine.evaluate("(function() {" + scenario + "})()")
     assert not result.isError(), result.toString()
@@ -1087,9 +1106,32 @@ def test_quickshell_settings_bindings_and_unverified_pairing(qml_engine, quicksh
     QMetaObject.invokeMethod(pair, "clicked")
     assert quickshell_setup.property("pairing")
     assert not pair.property("enabled")
+    messages = page.findChild(QObject, "messagesConnection")
+    contacts = page.findChild(QObject, "contactsConnection")
+    notifications = page.findChild(QObject, "notificationsConnection")
+    assert messages.property("value") == contacts.property("value") == "Unavailable"
+    _evaluate(qml_engine, '''
+        setup.receiveLine(setup.pending.pair.id, "pair",
+            '{"event":"transports","map":false,"pbap":true,"ancs":false}');
+    ''')
+    assert contacts.property("value") == "Connected"
+    assert messages.property("value") == "Unavailable"
+    _evaluate(qml_engine, '''
+        setup.receiveLine(setup.pending.pair.id, "pair",
+            '{"event":"transports","map":true,"pbap":true,"ancs":false}');
+    ''')
+    assert messages.property("value") == contacts.property("value") == "Connected"
+    assert notifications.property("value") == "Unavailable"
+    assert quickshell_setup.property("pairing")
     result = qml_engine.evaluate('''reply("pair", {ok:false,error:"Cancelled"},1);
         setup.configured = true;''')
     assert not result.isError(), result.toString()
+    # Once the helper exits, ordinary backend status owns the connection rows.
+    assert messages.property("value") == contacts.property("value") == "Unavailable"
+    _evaluate(qml_engine, '''page.status = Object.assign({}, page.status,
+        {map: true, pbap: true, ancs: true});''')
+    assert messages.property("value") == contacts.property("value") == "Connected"
+    assert notifications.property("value") == "Connected"
     QGuiApplication.processEvents()
     qml_engine.warnings.disconnect(warnings.extend)
     assert not warnings, "\n".join(w.toString() for w in warnings)

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -138,6 +138,28 @@ def test_quickshell_unverified_controller_still_reaches_device_selection(
     presenter.deleteLater()
 
 
+def test_qt_incompatible_adapter_explains_missing_capabilities(qml_engine):
+    from blueferry.models import BackendStatus
+    from blueferry.onboarding import derive_stage
+
+    compatibility = {
+        "pairing_ready": False,
+        "issue": "Incompatible Bluetooth adapter: missing Bluetooth LE and LE advertising",
+    }
+    stage = derive_stage(
+        setup_loaded=True, configured=False,
+        compatibility=compatibility, status=BackendStatus(),
+    )
+    component = _component(qml_engine, "src/blueferry/qt/qml/OnboardingSummary.qml")
+    summary = component.createWithInitialProperties({
+        "stage": str(stage), "compatibility": compatibility, "status": {},
+    })
+    assert summary is not None
+    assert "Incompatible Bluetooth Adapter" in summary.property("text")
+    assert compatibility["issue"] in summary.property("text")
+    summary.deleteLater()
+
+
 def test_quickshell_long_message_is_truncated_to_the_timeline_height(
     qml_engine,
 ) -> None:
@@ -560,6 +582,16 @@ def test_phone_settings_pairing_uses_loaded_selection_and_busy_state(qml_engine,
     bridge.setProperty("compatibilityLoaded", True)
     assert button.property("enabled")
     assert _settings_object(window, "adapterSelector").property("currentIndex") == 1
+    unverified = bridge.property("compatibility")
+    if hasattr(unverified, "toVariant"):
+        unverified = unverified.toVariant()
+    bridge.setProperty("compatibility", {
+        **unverified, "available": True, "pairing_ready": False,
+        "issue": "Incompatible Bluetooth adapter: missing Bluetooth LE",
+    })
+    assert not button.property("enabled")
+    bridge.setProperty("compatibility", unverified)
+    assert button.property("enabled")
     bridge.setProperty("busy", True)
     assert not button.property("enabled")
     bridge.setProperty("busy", False)
@@ -961,6 +993,29 @@ def test_quickshell_settings_bindings_and_unverified_pairing(qml_engine, quicksh
     QGuiApplication.processEvents()
     pair = page.findChild(QObject, "pairPhoneButton")
     assert pair.property("enabled")
+    _evaluate(qml_engine, '''
+        setup.loadCompatibility("hci1");
+        reply("compatibility", {adapter: "hci1", available: true, pairing_ready: false,
+            hardware_supported: false, notifications_supported: false,
+            issue: "Incompatible Bluetooth adapter: missing Bluetooth LE"});
+        reply("devices", [{mac: "OLD", paired: true, adapter_path: "/org/bluez/hci1"}]);
+        setup.compatibilityModeOverride = true;
+        setup.explicitPairingOverride = true;
+        setup.requestPairing();
+        check(!setup.pairing, "incompatible controller started pairing");
+    ''')
+    assert not pair.property("enabled")
+    message = page.findChild(QObject, "hardwareCompatibilityMessage")
+    assert message.property("visible")
+    assert "Incompatible Bluetooth adapter" in message.property("text")
+    _evaluate(qml_engine, '''
+        setup.loadCompatibility("hci0");
+        setup.finish(setup.pending.compatibility.id, "compatibility", 1, "", "btmgmt timed out");
+        setup.loadDevices(false);
+        reply("devices", [{mac: "NEW", adapter_path: "/org/bluez/hci0"}]);
+    ''')
+    assert pair.property("enabled")
+    assert not message.property("visible")
     QMetaObject.invokeMethod(pair, "clicked")
     assert quickshell_setup.property("pairing")
     assert not pair.property("enabled")

--- a/tests/test_setup_client.py
+++ b/tests/test_setup_client.py
@@ -60,6 +60,7 @@ def test_compatibility_and_configuration_are_typed(monkeypatch):
             "notifications_supported": True,
             "bearer_api_active": True,
             "pairing_ready": True,
+            "explicit_pairing_default": True,
             "issue": "",
             "supported_settings": ["br/edr", "le"],
         },
@@ -80,6 +81,8 @@ def test_compatibility_and_configuration_are_typed(monkeypatch):
 
     assert client.compatibility().pairing_ready is True
     assert client.compatibility().adapter == "hci2"
+    assert client.compatibility().explicit_pairing_default is True
+    assert client.compatibility().to_dict()["explicit_pairing_default"] is True
     assert client.configuration().configured is False
     assert client.configuration().pairing_issue_report == ""
 

--- a/tests/test_setup_client.py
+++ b/tests/test_setup_client.py
@@ -163,6 +163,7 @@ def test_isolated_pairing_answers_helper_confirmation(monkeypatch):
             self.stdin = Input()
             self.stdout = iter([
                 '{"event":"confirmation","passkey":"123456"}\n',
+                '{"event":"transports","map":true,"pbap":true,"ancs":false}\n',
                 '{"ok":true,"device":' + __import__("json").dumps(device.to_dict())
                 + ',"ancs_ready":true}\n',
             ])

--- a/tests/test_status_presenter.py
+++ b/tests/test_status_presenter.py
@@ -22,6 +22,34 @@ def test_backend_incompatibility_is_preserved_on_the_status_page():
     assert "incompatible" not in connection_subtitle(BackendStatus().to_dict(), reachable=False)
 
 
+def test_gtk_pairing_blocks_incompatible_hardware_but_allows_unverified_hardware():
+    from types import SimpleNamespace
+
+    from blueferry.setup_client import BluetoothCompatibility
+    from blueferry.ui.status import IPhonePage
+
+    enabled = []
+    widget = SimpleNamespace(set_sensitive=lambda _value: None, set_spinning=lambda _value: None)
+    page = SimpleNamespace(
+        _setup_spinner=widget, _activate_button=widget, _scan_button=widget,
+        _adapter_row=widget, _compatibility_switch=widget, _explicit_pairing_switch=widget,
+        _forget_button=widget,
+        _pair_button=SimpleNamespace(set_sensitive=enabled.append, set_label=lambda _label: None),
+        _selected_device=lambda: SimpleNamespace(paired=True),
+        _update_phone_controls=lambda: None,
+        _compatibility=None,
+    )
+    for available, pairing_ready in ((True, False), (False, True), (True, True)):
+        page._compatibility = BluetoothCompatibility.from_dict({
+            "available": available, "pairing_ready": pairing_ready,
+            "notifications_supported": False,
+        })
+        IPhonePage._set_pairing_busy(page, False)
+    assert enabled == [False, True, True]
+    IPhonePage._set_pairing_busy(page, True)
+    assert enabled[-1] is False
+
+
 def test_connection_summary_includes_degraded_detail_and_retry() -> None:
     subtitle = connection_subtitle(
         {

--- a/tests/test_status_presenter.py
+++ b/tests/test_status_presenter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from blueferry.models import BackendStatus
 from blueferry.protocol import backend_compatibility_error
 from blueferry.ui.status_presenter import (
@@ -48,6 +50,43 @@ def test_gtk_pairing_blocks_incompatible_hardware_but_allows_unverified_hardware
     assert enabled == [False, True, True]
     IPhonePage._set_pairing_busy(page, True)
     assert enabled[-1] is False
+
+
+@pytest.mark.parametrize("available,pairing_ready", [(True, False), (False, True), (True, True)])
+def test_gtk_configured_phone_surfaces_incompatibility_instead_of_permission_tasks(
+    available, pairing_ready,
+):
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    from blueferry.setup_client import BluetoothCompatibility, ConfigurationState
+    from blueferry.ui.status import IPhonePage
+
+    page = SimpleNamespace(
+        _configuration=ConfigurationState.from_dict({
+            "configured": True, "saved": True, "mac": "OLD", "ancs_enabled": False,
+        }),
+        _compatibility=BluetoothCompatibility.from_dict({
+            "available": available, "pairing_ready": pairing_ready,
+            "notifications_supported": False,
+        }),
+        _last_status=BackendStatus(daemon=True),
+        _hardware_group=Mock(), _pairing_group=Mock(), _paired_group=Mock(),
+        _paired_row=Mock(), _unpair_button=Mock(),
+        _setup_spinner=Mock(get_spinning=lambda: False),
+        _configured_device=lambda: None,
+        _iphone_setup_rows={key: Mock() for key in ("message-notifications", "contacts")},
+        _iphone_setup_group=Mock(),
+    )
+    page._update_iphone_setup_tasks = lambda: IPhonePage._update_iphone_setup_tasks(page)
+    IPhonePage._update_phone_controls(page)
+
+    page._hardware_group.set_visible.assert_called_with(not pairing_ready)
+    page._pairing_group.set_visible.assert_called_with(False)
+    page._paired_group.set_visible.assert_called_with(True)
+    page._iphone_setup_group.set_visible.assert_called_with(pairing_ready)
+    for row in page._iphone_setup_rows.values():
+        row.set_visible.assert_called_with(pairing_ready)
 
 
 def test_connection_summary_includes_degraded_detail_and_retry() -> None:


### PR DESCRIPTION
Adapters without Bluetooth LE or LE advertising could enter pairing even though they cannot solicit the iPhone's message and contact permissions. Setup now rejects confirmed incompatibility before changing pairing state or removing a saved phone. A failed capability probe remains advisory, and automatic selection prefers verified hardware, then an unverified adapter that still permits pairing.

GTK, KDE, Quickshell, and the CLI explain incompatible adapters consistently. GTK keeps the warning visible for configured phones, the CLI labels incompatible and unverified choices, and GTK/Quickshell suppress misleading iPhone permission instructions when the adapter cannot work.

Explicit pairing defaults to enabled for RTL8761BU (`0bda:8771`), AzureWave RTL8852CE (`13d3:3586`), and Realtek `0bda:8922`, using the shared adapter probe. Graphical clients preserve manual choices per adapter during the session; the CLI supports `--no-explicit-pairing` to override the default.

Quickshell also displays each service connection as it happens during pairing. Previously MAP/PBAP could connect while the interface still showed them as unavailable because the helper was waiting for ANCS. The helper now streams transport changes, scoped to the active pairing request, and Quickshell returns to normal backend status when the helper finishes.

Validation: 1,084 tests pass in an isolated D-Bus session; Ruff, mypy, Bandit, QML lint, and `git diff --check` pass. The CLI default and both explicit-pairing flags also pass with Python 3.12, Typer 0.9, and Click 8.1.6, preserving Ubuntu 24.04 compatibility. Regression coverage includes mixed incompatible/unverified adapters, explicit selections, replacement protection, default overrides, configured-phone guidance, live service progress, lost connections, and stale pairing events. Tests do not exercise a live Bluetooth pairing.

Related: #143, #144, #58, #68. These defaults reflect reported pairing outcomes; they do not guarantee that every firmware/host combination will pair successfully.
