### PR TITLE
Preserve GTK pairing options through asynchronous setup

### DIFF
--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -714,9 +714,17 @@ class IPhonePage(Gtk.Box):
         if not device:
             self._toast(_("Scan for and select an iPhone first"))
             return
+        # Capture choices on the GTK thread before confirmation or worker
+        # dispatch, so a later refresh cannot change this pairing request.
+        compatibility_mode = self._compatibility_switch.get_active()
+        explicit_pairing = self._explicit_pairing_switch.get_active()
         configuration = self._configuration
         if device.paired or configuration is None or not configuration.saved:
-            self._start_pairing(device)
+            self._start_pairing(
+                device,
+                compatibility_mode=compatibility_mode,
+                explicit_pairing=explicit_pairing,
+            )
             return
 
         dialog = Adw.AlertDialog(
@@ -739,6 +747,8 @@ class IPhonePage(Gtk.Box):
                 self._start_pairing(
                     device,
                     replace_saved_mac=configuration.mac,
+                    compatibility_mode=compatibility_mode,
+                    explicit_pairing=explicit_pairing,
                 )
 
         dialog.connect("response", responded)
@@ -748,6 +758,8 @@ class IPhonePage(Gtk.Box):
         self,
         device: PairedDevice,
         *,
+        compatibility_mode: bool,
+        explicit_pairing: bool,
         replace_saved_mac: str = "",
     ) -> None:
         self._toast(_("Activating Bluetooth, then starting secure pairing…"))
@@ -832,8 +844,8 @@ class IPhonePage(Gtk.Box):
                 display=display,
                 adapter=device.adapter_path.rsplit("/", 1)[-1],
                 replace_saved_mac=replace_saved_mac,
-                compatibility_mode=self._compatibility_switch.get_active(),
-                explicit_pairing=self._explicit_pairing_switch.get_active(),
+                compatibility_mode=compatibility_mode,
+                explicit_pairing=explicit_pairing,
             ),
             completed,
         )

--- a/tests/test_gtk_pairing_controls.py
+++ b/tests/test_gtk_pairing_controls.py
@@ -1,0 +1,154 @@
+"""Exercise real GTK switches on a private Broadway display, without Bluetooth."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.private_dbus
+def test_gtk_explicit_pairing_controls(tmp_path):
+    executable = shutil.which("gtk4-broadwayd")
+    if executable is None:
+        pytest.skip("GTK4 Broadway is not installed")
+    runtime = tmp_path / "run"
+    runtime.mkdir(mode=0o700)
+    environment = dict(
+        os.environ, XDG_RUNTIME_DIR=str(runtime), GDK_BACKEND="broadway",
+        BROADWAY_DISPLAY=":0", GTK_A11Y="none", GSETTINGS_BACKEND="memory",
+        PYTHONPATH=str(Path(__file__).resolve().parents[1] / "src"),
+    )
+    # Both the GTK display and its HTTP endpoint use private Unix sockets.
+    daemon = subprocess.Popen(
+        [executable, "--unixsocket", str(runtime / "http"), ":0"],
+        env=environment, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not (runtime / "broadway1.socket").exists():
+            assert daemon.poll() is None, daemon.communicate()[0].decode()
+            assert time.monotonic() < deadline, "Broadway did not create its display socket"
+            time.sleep(0.02)
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).resolve())], env=environment,
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+    finally:
+        daemon.terminate()
+        try:
+            daemon.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            daemon.kill()
+            daemon.communicate()
+
+
+def _exercise_gtk_controls():
+    # Run GTK in its own process: the suite also loads Qt and must not share
+    # toolkit event loops or adopt the operator's Wayland/X11 display.
+    from concurrent.futures import ThreadPoolExecutor
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from blueferry.bluetooth_devices import PairedDevice
+    from blueferry.setup_client import BluetoothCompatibility, ConfigurationState
+    from blueferry.ui import status
+
+    status.Gtk.init()
+    status.Gtk.Settings.get_default().set_property("gtk-enable-animations", False)
+    calls, operations, dialogs = [], [], []
+    configuration = ConfigurationState.from_dict({"configured": False, "saved": False})
+    setup = SimpleNamespace(
+        configuration=lambda: configuration,
+        complete_isolated=lambda mac, **options: calls.append((mac, options)),
+    )
+
+    class Dialog:
+        def __init__(self, **_kwargs):
+            dialogs.append(self)
+
+        def connect(self, _signal, callback):
+            self.respond = lambda: callback(self, "replace")
+
+        def __getattr__(self, _name):
+            return lambda *_args: None
+
+    with (
+        patch.object(status, "SetupClient", lambda: setup),
+        patch.object(status.IPhonePage, "_load_setup_state", lambda self: None),
+        patch.object(status.Adw, "AlertDialog", Dialog),
+    ):
+        page = status.IPhonePage(SimpleNamespace(connect=lambda *_args: None), lambda *_args: None)
+        page._run_setup = lambda operation, _done: operations.append(operation)
+        page._devices = [PairedDevice.from_dict({
+            "mac": "NEW", "name": "Phone", "paired": False,
+            "adapter_path": "/org/bluez/hci1",
+        })]
+        page._device_model.append("Phone")
+        page._device_row.set_selected(0)
+        for compatibility in (False, True):
+            for explicit in (False, True):
+                for replace in (False, True):
+                    for row_click in (False, True):
+                        calls.clear()
+                        operations.clear()
+                        dialogs.clear()
+                        page._configuration = ConfigurationState.from_dict({
+                            "configured": False, "saved": replace,
+                            "mac": "OLD" if replace else "",
+                        })
+                        capabilities = BluetoothCompatibility.from_dict({
+                            "adapter": "hci1", "notifications_supported": not compatibility,
+                            "explicit_pairing_default": not explicit,
+                        })
+                        page._explicit_pairing_overrides.clear()
+                        page._apply_compatibility(capabilities)
+                        switch = page._explicit_pairing_switch
+                        assert switch.get_active() is not explicit
+                        if row_click:
+                            page._explicit_pairing_row.activate()
+                        else:
+                            switch.activate()
+                        assert switch.get_active() is explicit
+                        # Refreshing capabilities and switching adapters must
+                        # preserve the option actually chosen by the user.
+                        page._apply_compatibility(capabilities)
+                        page._apply_compatibility(BluetoothCompatibility.from_dict({
+                            "adapter": "hci0", "notifications_supported": True,
+                        }))
+                        page._apply_compatibility(capabilities)
+                        assert switch.get_active() is explicit
+                        page._pair_button.emit("clicked")
+                        if replace:
+                            assert len(dialogs) == 1 and not operations
+                            # Background refreshes can still change controls
+                            # while the replacement confirmation is open.
+                            switch.set_active(not explicit)
+                            dialogs[0].respond()
+                        assert len(operations) == 1
+                        switch.set_active(not explicit)
+
+                        def forbid_worker_read():
+                            raise AssertionError("Pairing worker read a GTK switch")
+
+                        with (
+                            patch.object(switch, "get_active", forbid_worker_read),
+                            patch.object(page._compatibility_switch, "get_active", forbid_worker_read),
+                            ThreadPoolExecutor(max_workers=1) as worker,
+                        ):
+                            worker.submit(operations[0]).result(timeout=5)
+                        assert len(calls) == 1
+                        mac, options = calls[0]
+                        assert mac == "NEW" and options["adapter"] == "hci1"
+                        assert options["explicit_pairing"] is explicit
+                        assert options["compatibility_mode"] is compatibility
+                        assert options["replace_saved_mac"] == ("OLD" if replace else "")
+
+
+if __name__ == "__main__":
+    _exercise_gtk_controls()

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -13,9 +13,11 @@ os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 pytest.importorskip("PySide6")
 
-from PySide6.QtCore import Property, QMetaObject, QObject, QUrl, Slot
+from PySide6.QtCore import Property, QMetaObject, QObject, QPointF, Qt, QUrl, Slot
 from PySide6.QtGui import QColor, QGuiApplication
 from PySide6.QtQml import QQmlComponent, QQmlEngine
+from PySide6.QtQuick import QQuickWindow
+from PySide6.QtTest import QTest
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -521,6 +523,78 @@ def _settings_object(window, name):
     return obj
 
 
+def _click_control(window, control):
+    # Exercise Qt's actual pointer handling, including toggling checked before
+    # clicked. Emitting clicked directly would miss a broken checkbox binding.
+    QTest.qWait(30)
+    assert control.property("visible") and control.property("enabled")
+    point = control.mapToScene(QPointF(10, control.height() / 2)).toPoint()
+    assert 0 <= point.x() < window.width() and 0 <= point.y() < window.height()
+    QTest.mouseClick(window, Qt.LeftButton, Qt.NoModifier, point)
+    QGuiApplication.processEvents()
+
+
+@pytest.mark.parametrize("explicit", [False, True])
+@pytest.mark.parametrize("compatibility", [False, True])
+@pytest.mark.parametrize("replace", [False, True])
+def test_qt_pairing_checkbox_reaches_the_helper(
+    qml_engine, monkeypatch, explicit, compatibility, replace,
+):
+    from types import SimpleNamespace
+
+    from blueferry.qt.controller import BridgeController
+    from blueferry.setup_client import ConfigurationState
+
+    calls, operations = [], []
+    setup = SimpleNamespace(complete_isolated=lambda mac, **options: calls.append((mac, options)))
+    bridge = BridgeController(backend=object(), setup=setup, subscribe=False, autostart=False)
+    bridge._setup_loaded = True
+    bridge._compatibility = {
+        "adapter": "hci1", "notifications_supported": not compatibility,
+        "explicit_pairing_default": not explicit,
+    }
+    bridge._devices = [{"mac": "NEW", "display_name": "Phone", "paired": False,
+                        "adapter_path": "/org/bluez/hci1"}]
+    bridge._configuration = ConfigurationState.from_dict({
+        "configured": False, "saved": replace, "mac": "OLD" if replace else "",
+    })
+    monkeypatch.setattr(bridge, "_run", lambda operation, *_args, **_kwargs: operations.append(operation))
+    component = _component(qml_engine, "src/blueferry/qt/qml/Main.qml")
+    window = component.createWithInitialProperties({"bridge": bridge, "height": 1600})
+    assert window is not None
+    try:
+        bridge.setupLoadedChanged.emit()
+        QGuiApplication.processEvents()
+        checkbox = _settings_object(window, "explicitPairingCheckBox")
+        assert checkbox.property("checked") is not explicit
+        _click_control(window, checkbox)
+        assert checkbox.property("checked") is explicit
+        # A capability refresh must preserve the manual choice.
+        bridge._compatibility = {**bridge._compatibility, "powered": True}
+        bridge.compatibilityChanged.emit()
+        assert checkbox.property("checked") is explicit
+        _click_control(window, _settings_object(window, "pairPhoneButton"))
+        if replace:
+            dialog = _settings_object(window, "replaceTargetDialog")
+            assert dialog.property("visible")
+            qml_engine.globalObject().setProperty("pairingDialog", qml_engine.newQObject(dialog))
+            _evaluate(qml_engine, "pairingDialog.customFooterActions[0].trigger()")
+        assert len(operations) == 1
+        operations[0]()
+        assert len(calls) == 1
+        mac, options = calls[0]
+        assert mac == "NEW"
+        assert options["adapter"] == "hci1"
+        assert options.get("explicit_pairing", False) is explicit
+        assert options.get("compatibility_mode", False) is compatibility
+        assert options["replace_saved_mac"] == ("OLD" if replace else "")
+    finally:
+        window.close()
+        window.deleteLater()
+        QGuiApplication.processEvents()
+        bridge.deleteLater()
+
+
 @pytest.mark.parametrize("policy,storage_state,label", [
     ("encrypted", "locked", "Locked"), ("plaintext", "ready", "Available"),
     ("none", "disabled", "Disabled"),
@@ -916,6 +990,62 @@ def quickshell_setup(qml_engine):
     yield controller
     controller.deleteLater()
     QGuiApplication.processEvents()
+
+
+@pytest.mark.parametrize("explicit", [False, True])
+@pytest.mark.parametrize("compatibility", [False, True])
+@pytest.mark.parametrize("replace", [False, True])
+def test_quickshell_pairing_checkbox_reaches_the_helper(
+    qml_engine, quickshell_setup, explicit, compatibility, replace,
+):
+    theme_component = _component(qml_engine, "data/quickshell/ThemePalette.qml")
+    theme = theme_component.create()
+    component = _component(qml_engine, "data/quickshell/PhoneSettingsPage.qml")
+    page = component.createWithInitialProperties({
+        "ferryTheme": theme, "setup": quickshell_setup, "status": {},
+        "width": 620, "height": 1600,
+    })
+    assert page is not None
+    window = QQuickWindow()
+    window.resize(620, 1600)
+    page.setParentItem(window.contentItem())
+    window.show()
+    try:
+        _evaluate(qml_engine, '''
+            setup.loadCompatibility("hci1");
+            reply("compatibility", ''' + __import__("json").dumps({
+                "adapter": "hci1", "notifications_supported": not compatibility,
+                "explicit_pairing_default": not explicit,
+            }) + ''');
+            reply("devices", [{mac:"NEW",adapter_path:"/org/bluez/hci1"}]);
+        ''')
+        quickshell_setup.setProperty("targetSaved", replace)
+        quickshell_setup.setProperty("configuredMac", "OLD" if replace else "")
+        checkbox = _settings_object(page, "explicitPairingCheckBox")
+        assert checkbox.property("checked") is not explicit
+        _click_control(window, checkbox)
+        assert checkbox.property("checked") is explicit
+        # Scanning after selecting the option must leave it selected.
+        _evaluate(qml_engine, '''setup.loadDevices(true);
+            reply("devices", [{mac:"NEW",adapter_path:"/org/bluez/hci1"}]);''')
+        assert checkbox.property("checked") is explicit
+        _click_control(window, _settings_object(page, "pairPhoneButton"))
+        if replace:
+            _evaluate(qml_engine, "setup.confirmReplacement()")
+        command = _evaluate(qml_engine, "requests[requests.length - 1].argv")
+        assert command[:3] == ["/usr/bin/blueferry", "pairing-complete", "NEW"]
+        assert ("--explicit-pairing" in command) is explicit
+        assert ("--compatibility-mode" in command) is compatibility
+        assert command[command.index("--adapter") + 1] == "hci1"
+        assert ("--replace-saved-mac" in command) is replace
+        if replace:
+            assert command[command.index("--replace-saved-mac") + 1] == "OLD"
+    finally:
+        window.close()
+        page.deleteLater()
+        window.deleteLater()
+        QGuiApplication.processEvents()
+        theme.deleteLater()
 
 
 @pytest.mark.parametrize("scenario", [


### PR DESCRIPTION
GTK read the compatibility and explicit-pairing switches from its background worker, after any replacement confirmation. A refresh before that read could change the options used for the pending pairing request. Capture both options on the GTK thread when Pair is clicked and carry those values through confirmation and worker dispatch.

Add regression coverage using real GTK switch and row activation on a private Broadway display, plus actual mouse clicks in Quickshell and Qt/KDE. Tests cover enabling and disabling explicit pairing, normal and compatibility modes, saved-phone replacement, refreshes, and forwarding the selected options to the helper. GTK coverage also rejects worker-thread reads of the switches.

Validation: all 1,101 tests pass in an isolated D-Bus session. Ruff, mypy, Bandit, QML lint, and `git diff --check` pass. Bluetooth operations are simulated; no live phone pairing was performed.

Related: #147. The cause of that reported failure remains unconfirmed.
