### PR TITLE
Include pairing helper diagnostic stderr in PairingError

### DIFF
--- a/src/blueferry/setup_client.py
+++ b/src/blueferry/setup_client.py
@@ -66,6 +66,15 @@ def _read_helper_stderr(stream: IO[str], diagnostics: _BoundedDiagnostics) -> No
         return
 
 
+def _drain_diagnostics(
+    diagnostics: _BoundedDiagnostics,
+    diagnostics_thread: threading.Thread | None,
+) -> str:
+    if diagnostics_thread is not None:
+        diagnostics_thread.join(timeout=0.25)
+    return diagnostics.text()
+
+
 def _helper_lines(
     stream: IO[str],
     *,
@@ -401,7 +410,11 @@ class SetupClient:
                         timeout=PAIRING_HELPER_IDLE_TIMEOUT_SECONDS,
                     )
                     if status != 0:
-                        raise PairingError(f"Pairing helper exited unexpectedly (status {status})")
+                        detail = _drain_diagnostics(diagnostics, diagnostics_thread)
+                        message = f"Pairing helper exited unexpectedly (status {status})"
+                        if detail:
+                            message = f"{message}: {detail}"
+                        raise PairingError(message)
                     return PairingOutcome.from_dict(event)
                 elif event.get("ok") is False:
                     path = str(event.get("report_path") or "").strip()
@@ -413,7 +426,11 @@ class SetupClient:
                 process,
                 timeout=PAIRING_HELPER_IDLE_TIMEOUT_SECONDS,
             )
-            raise PairingError(f"Pairing helper exited without a result (status {status})")
+            detail = _drain_diagnostics(diagnostics, diagnostics_thread)
+            message = f"Pairing helper exited without a result (status {status})"
+            if detail:
+                message = f"{message}: {detail}"
+            raise PairingError(message)
         except BaseException:
             failed = True
             raise

--- a/src/blueferry/ui/window.py
+++ b/src/blueferry/ui/window.py
@@ -88,10 +88,10 @@ class MainWindow(Adw.ApplicationWindow):
         self._on_availability(client, client.available)
 
     def toast(self, text: str) -> None:
-        self._toasts.add_toast(Adw.Toast(title=text))
+        self._toasts.add_toast(Adw.Toast(title=text, use_markup=False))
 
     def phone_toast(self, text: str) -> None:
-        self._phone_toasts.add_toast(Adw.Toast(title=text))
+        self._phone_toasts.add_toast(Adw.Toast(title=text, use_markup=False))
 
     def present_phone_settings(self) -> None:
         self._phone_dialog.present(self)

--- a/tests/test_gtk_pairing_controls.py
+++ b/tests/test_gtk_pairing_controls.py
@@ -1,4 +1,4 @@
-"""Exercise real GTK switches on a private Broadway display, without Bluetooth."""
+"""Exercise GTK pairing controls and errors on a private Broadway display."""
 from __future__ import annotations
 
 import os
@@ -12,7 +12,8 @@ import pytest
 
 
 @pytest.mark.private_dbus
-def test_gtk_explicit_pairing_controls(tmp_path):
+@pytest.mark.parametrize("scenario", ["controls", "error-toasts"])
+def test_gtk_pairing_ui(tmp_path, scenario):
     executable = shutil.which("gtk4-broadwayd")
     if executable is None:
         pytest.skip("GTK4 Broadway is not installed")
@@ -35,7 +36,7 @@ def test_gtk_explicit_pairing_controls(tmp_path):
             assert time.monotonic() < deadline, "Broadway did not create its display socket"
             time.sleep(0.02)
         result = subprocess.run(
-            [sys.executable, str(Path(__file__).resolve())], env=environment,
+            [sys.executable, str(Path(__file__).resolve()), scenario], env=environment,
             capture_output=True, text=True, timeout=30,
         )
         assert result.returncode == 0, result.stdout + result.stderr
@@ -150,5 +151,63 @@ def _exercise_gtk_controls():
                         assert options["replace_saved_mac"] == ("OLD" if replace else "")
 
 
+def _exercise_error_toasts():
+    import io
+    import traceback
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from gi.repository import GLib
+
+    from blueferry import setup_client
+    from blueferry.ui.window import Adw, Gtk, MainWindow
+
+    Adw.init()
+    try:
+        raise RuntimeError("Could not prepare <iPhone> & Bluetooth")
+    except RuntimeError:
+        diagnostic = traceback.format_exc()
+    # Real tracebacks contain markup-like names such as <module>, and errors
+    # can contain literal angle brackets and ampersands as well.
+    process = SimpleNamespace(
+        stdin=io.StringIO(), stdout=iter(()), stderr=io.StringIO(diagnostic),
+        wait=lambda **_kwargs: 1, poll=lambda: 1,
+    )
+    with patch.object(setup_client.subprocess, "Popen", return_value=process):
+        try:
+            setup_client.SetupClient().complete_isolated(
+                "02:00:00:00:00:01", confirmation=lambda _passkey: True,
+            )
+        except setup_client.PairingError as error:
+            message = f"Setup failed: {error}"
+        else:
+            raise AssertionError("The failed helper must raise PairingError")
+    assert diagnostic.strip() in message
+
+    def label_texts(widget):
+        if isinstance(widget, Gtk.Label):
+            yield widget.get_text()
+        child = widget.get_first_child()
+        while child is not None:
+            yield from label_texts(child)
+            child = child.get_next_sibling()
+
+    for show_toast in (MainWindow.toast, MainWindow.phone_toast):
+        overlay = Adw.ToastOverlay(child=Gtk.Label(label="Test content"))
+        window = Gtk.Window(default_width=680, default_height=620, child=overlay)
+        try:
+            window.present()
+            show_toast(SimpleNamespace(_toasts=overlay, _phone_toasts=overlay), message)
+            context = GLib.MainContext.default()
+            while context.pending():
+                context.iteration(False)
+            assert message in list(label_texts(overlay)), "GTK lost the diagnostic text"
+        finally:
+            window.destroy()
+
+
 if __name__ == "__main__":
-    _exercise_gtk_controls()
+    if sys.argv[1] == "controls":
+        _exercise_gtk_controls()
+    else:
+        _exercise_error_toasts()

--- a/tests/test_setup_client.py
+++ b/tests/test_setup_client.py
@@ -407,7 +407,7 @@ def test_isolated_pairing_reports_exit_status_and_logs_bounded_stderr(
     with pytest.raises(
         setup_client.PairingError,
         match=r"Pairing helper exited without a result \(status 7\)",
-    ):
+    ) as raised:
         setup_client.SetupClient().complete_isolated(
             device.mac,
             confirmation=lambda _passkey: True,
@@ -415,3 +415,41 @@ def test_isolated_pairing_reports_exit_status_and_logs_bounded_stderr(
 
     assert "discarded-prefix" not in caplog.text
     assert diagnostic[-100:] in caplog.text
+    assert diagnostic[-100:] in str(raised.value)
+
+
+def test_isolated_pairing_unexpected_exit_status_includes_diagnostic_stderr(
+    monkeypatch,
+    caplog,
+):
+    device = _device()
+
+    class Process:
+        stdin = io.StringIO()
+        stdout = iter(['{"ok":true,"device":' + json.dumps(device.to_dict()) + "}\n"])
+        stderr = io.StringIO("traceback or error detail")
+
+        @staticmethod
+        def wait(*_args, **_kwargs):
+            return 3
+
+        @staticmethod
+        def poll():
+            return 3
+
+    monkeypatch.setattr(
+        setup_client.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: Process(),
+    )
+
+    with pytest.raises(
+        setup_client.PairingError,
+        match=r"Pairing helper exited unexpectedly \(status 3\): traceback or error detail",
+    ) as raised:
+        setup_client.SetupClient().complete_isolated(
+            device.mac,
+            confirmation=lambda _passkey: True,
+        )
+
+    assert "traceback or error detail" in str(raised.value)


### PR DESCRIPTION
### Summary 📋

When the isolated pairing helper (`blueferry pairing-complete`) exits unexpectedly or terminates without returning a result, `complete_isolated` captured the bounded `stderr` tail but omitted it from the raised `PairingError`.

In graphical clients (**GTK** and **Qt**), this resulted in an opaque user-facing dialog:

> `Setup failed: Pairing helper exited without a result (status 1)`

The dialog lacked any indication of the underlying root cause, such as:
* Uncaught exceptions
* Tracebacks
* Environment or dependency conflicts

---

### Changes 🛠️

* **Diagnostics Extraction:** Added `_drain_diagnostics` in `setup_client.py` to safely join the reader thread and extract captured `stderr`.
* **Error Context Enhancement:** Attached the captured diagnostic details to `PairingError` whenever the exit status is non-zero or when the helper exits without emitting a result.
* **Test Coverage:** Added test cases in `tests/test_setup_client.py` to verify that diagnostic `stderr` is properly propagated in the raised exception.