### PR TITLE
Fix notification activation and desktop client selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Download the native packages for your distribution from the
 Install `blueferry-backend` plus the client for your desktop. The backend also
 includes the `blueferry-tui` terminal client.
 
+Clicking a message notification opens its conversation in a running graphical
+client, preferring the most recently used one. If none is running, BlueFerry
+opens the last client you used. With no previous choice, it prefers GTK on
+GNOME, Qt on KDE, and Quickshell on Omarchy/Hyprland, using an installed client
+if the preferred one is unavailable.
+
 For Arch Linux or CachyOS, download the `.pkg.tar.zst` files and install them
 with pacman. For example, to install the GTK client:
 

--- a/data/blueferry-quickshell
+++ b/data/blueferry-quickshell
@@ -12,6 +12,10 @@ thread=""
 message=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --message=*)
+            message="${1#*=}"
+            shift
+            ;;
         --thread)
             thread="${2-}"
             shift 2
@@ -40,6 +44,8 @@ elif [[ -n "$thread" ]]; then
         exit 0
     fi
     export BLUEFERRY_OPEN_THREAD_KEY="$thread"
+elif [[ $# -eq 0 ]] && ipc open; then
+    exit 0
 fi
 
 exec "$qs" -p "$config" "$@"

--- a/data/io.weirdware.BlueFerry.xml
+++ b/data/io.weirdware.BlueFerry.xml
@@ -139,6 +139,14 @@
     <method name="IsHealthy">
       <arg name="healthy" type="b" direction="out"/>
     </method>
+    <method name="OpenLegacyGtkMessage">
+      <annotation name="org.freedesktop.DBus.Description"
+                  value="Route a notification to a GTK window left open across an upgrade"/>
+      <arg name="handle" type="s" direction="in"/>
+      <arg name="application_owner" type="s" direction="in"/>
+      <arg name="delivered" type="b" direction="out"/>
+      <annotation name="io.weirdware.BlueFerry.Errors" value="InvalidArgs"/>
+    </method>
   </interface>
   <interface name="io.weirdware.BlueFerry.Events1">
     <annotation name="org.freedesktop.DBus.Description"

--- a/data/quickshell/BackendBridge.qml
+++ b/data/quickshell/BackendBridge.qml
@@ -9,6 +9,7 @@ Item {
 
   property int nextRequestId: 1
   property bool ready: false
+  property bool desktopClient: false
   property var queuedRequests: []
   property var latestRequests: ({})
   property var latestMethods: ({})
@@ -84,7 +85,9 @@ Item {
   Process {
     id: bridgeProcess
     running: true
-    command: ["/usr/bin/blueferry-quickshell-bridge"]
+    command: bridge.desktopClient
+             ? ["/usr/bin/blueferry-quickshell-bridge", "--desktop-client"]
+             : ["/usr/bin/blueferry-quickshell-bridge"]
     stdinEnabled: true
     stdout: SplitParser {
       onRead: function(line) { bridge.handleLine(line) }

--- a/data/quickshell/shell.qml
+++ b/data/quickshell/shell.qml
@@ -126,6 +126,10 @@ ShellRoot {
   function presentWindow() {
     phoneSettingsVisible = false
     window.visible = true
+    backendBridge.request("client_active", {})
+    Qt.callLater(function() {
+      if (applicationSurface.Window.window) applicationSurface.Window.window.requestActivate()
+    })
   }
 
   function openThread(key) {
@@ -188,7 +192,7 @@ ShellRoot {
     onFinished: (id, kind, code, output, diagnostic) => setupController.finish(id, kind, code, output, diagnostic)
   }
 
-  BackendBridge { id: backendBridge }
+  BackendBridge { id: backendBridge; desktopClient: true }
 
   IpcHandler {
     target: "blueferry"
@@ -381,7 +385,10 @@ ShellRoot {
 
     Pane {
       id: applicationSurface
-      Window.onActiveChanged: root.markSelectedThreadRead()
+      Window.onActiveChanged: {
+        root.markSelectedThreadRead()
+        if (applicationSurface.Window.active) backendBridge.request("client_active", {})
+      }
       anchors.fill: parent
       padding: 0
       font.family: theme.fontFamily

--- a/src/blueferry/client_activation.py
+++ b/src/blueferry/client_activation.py
@@ -12,6 +12,7 @@ import logging
 import os
 import subprocess  # nosec B404
 import sys
+import threading
 import time
 import uuid
 from collections.abc import Mapping, Sequence
@@ -23,10 +24,12 @@ import dbus.mainloop
 
 from blueferry import config
 from blueferry.private_files import atomic_write_private_text, read_private_text
+from blueferry.protocol import BUS_NAME, MESSAGES_IFACE, OBJECT_PATH
 
 log = logging.getLogger(__name__)
 ACTIVATION_INTERFACE = "io.weirdware.BlueFerry.Client"
 ACTIVATION_PATH = "/io/weirdware/BlueFerry/Client"
+_recency_lock = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -48,6 +51,7 @@ CLIENTS = (
     DesktopClient("qt", "io.weirdware.BlueFerry.Qt"),
     DesktopClient("quickshell", "io.weirdware.BlueFerry.Quickshell"),
 )
+GTK_CLIENT = next(client for client in CLIENTS if client.key == "gtk")
 
 
 def _recency_path(client: DesktopClient) -> Path:
@@ -57,7 +61,10 @@ def _recency_path(client: DesktopClient) -> Path:
 def record_client_use(key: str) -> None:
     client = next(client for client in CLIENTS if client.key == key)
     try:
-        atomic_write_private_text(_recency_path(client), str(time.time_ns()), maximum_bytes=64)
+        # GTK/Qt record on the GUI thread; QS also receives focus on its stdin
+        # reader. Keep a slower write from replacing a newer timestamp.
+        with _recency_lock:
+            atomic_write_private_text(_recency_path(client), str(time.time_ns()), maximum_bytes=64)
     except OSError:
         log.warning("could not remember the active desktop client", exc_info=True)
 
@@ -82,7 +89,10 @@ def select_client(
         preferred = "quickshell"
     else:
         preferred = "gtk"
-    live = [client for client in CLIENTS if client.bus_name in running]
+    live = [client for client in CLIENTS if (
+        client.bus_name in running
+        or (client == GTK_CLIENT and client.desktop_id in running)
+    )]
     candidates = live or [client for client in CLIENTS if os.access(client.executable, os.X_OK)]
     return max(
         candidates, key=lambda client: (_last_used(client), client.key == preferred), default=None,
@@ -118,6 +128,61 @@ def request_message_activation(handle: str, token: str) -> None:
         log.exception("could not start desktop client activation")
 
 
+def _open_legacy_gtk(bus, handle: str, token: str) -> bool:
+    """Keep a pre-upgrade GTK window (and its drafts) alive while activating it."""
+    gtk = bus.get_object(
+        GTK_CLIENT.desktop_id, "/" + GTK_CLIENT.desktop_id.replace(".", "/"), introspect=False,
+    )
+    platform_data = dbus.Dictionary({}, signature="sv")
+    if token:
+        platform_data["activation-token"] = token
+        platform_data["desktop-startup-id"] = token
+    gtk.Activate(platform_data, dbus_interface="org.freedesktop.Application", timeout=3)
+    if handle:
+        # An up-to-date GTK process may have been between acquiring its
+        # GApplication name and registering our endpoint. Activate returns
+        # after startup, so retry the modern path before using the relay.
+        if bus.name_has_owner(GTK_CLIENT.bus_name):
+            bus.get_object(GTK_CLIENT.bus_name, ACTIVATION_PATH, introspect=False).OpenMessage(
+                handle, "", dbus_interface=ACTIVATION_INTERFACE, timeout=3,
+            )
+            record_client_use("gtk")
+            return True
+        # Only the daemon can emit the sender-authenticated legacy signal.
+        # GTK's Gio application and dbus-python listener use different bus
+        # connections; the daemon targets connections belonging to this PID.
+        daemon = bus.get_object(BUS_NAME, OBJECT_PATH, introspect=False)
+        if not daemon.OpenLegacyGtkMessage(
+            handle, gtk.bus_name, dbus_interface=MESSAGES_IFACE, timeout=3,
+        ):
+            return False
+    record_client_use("gtk")
+    return True
+
+
+def forward_to_legacy_gtk(handle: str, token: str) -> bool | None:
+    """Preflight GTK's command line: old GApplications cannot receive it.
+
+    None means normal GApplication startup/forwarding should continue.
+    """
+    bus = dbus.SessionBus(private=True, mainloop=dbus.mainloop.NULL_MAIN_LOOP)
+    try:
+        running = bus.list_names()
+        if GTK_CLIENT.bus_name in running or GTK_CLIENT.desktop_id not in running:
+            return None
+        try:
+            forwarded = _open_legacy_gtk(bus, handle, token)
+        except dbus.DBusException:
+            if bus.name_has_owner(GTK_CLIENT.desktop_id):
+                raise
+            return None
+        if not forwarded and not bus.name_has_owner(GTK_CLIENT.desktop_id):
+            return None  # the old window closed; continue normal GTK startup
+        return forwarded
+    finally:
+        bus.close()
+
+
 def open_message(handle: str, token: str) -> bool:
     """Run in a short-lived helper; focus a live client or launch the selected one."""
     bus = dbus.SessionBus(private=True, mainloop=dbus.mainloop.NULL_MAIN_LOOP)
@@ -127,16 +192,26 @@ def open_message(handle: str, token: str) -> bool:
         if client is None:
             log.warning("no BlueFerry graphical client is installed")
             return False
-        if client.bus_name in running:
+        live_name = (
+            client.bus_name if client.bus_name in running
+            else client.desktop_id if client == GTK_CLIENT and client.desktop_id in running
+            else None
+        )
+        if live_name is not None:
             try:
-                bus.get_object(client.bus_name, ACTIVATION_PATH, introspect=False).OpenMessage(
-                    handle, token, dbus_interface=ACTIVATION_INTERFACE, timeout=3,
-                )
-                return True
+                if live_name == GTK_CLIENT.desktop_id:
+                    forwarded = _open_legacy_gtk(bus, handle, token)
+                    if forwarded or bus.name_has_owner(live_name):
+                        return forwarded
+                else:
+                    bus.get_object(client.bus_name, ACTIVATION_PATH, introspect=False).OpenMessage(
+                        handle, token, dbus_interface=ACTIVATION_INTERFACE, timeout=3,
+                    )
+                    return True
             except dbus.DBusException:
                 # A GUI can exit after selection. Only relaunch when its name
                 # vanished; a timeout must not open a second, competing client.
-                if bus.name_has_owner(client.bus_name):
+                if bus.name_has_owner(live_name):
                     log.warning("the running %s client did not accept activation", client.key)
                     return False
         argv = [client.executable, f"--message={handle}"]

--- a/src/blueferry/client_activation.py
+++ b/src/blueferry/client_activation.py
@@ -1,0 +1,198 @@
+"""Choose and activate one desktop client, independently of the daemon's lifetime.
+
+Clients own a session-bus name while running and each writes its own recency
+file. This avoids concurrent GUI writes to the daemon's settings document.
+The command-line entry point also serves shells that retain an executable
+notification action instead of delivering ActionInvoked to the daemon.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess  # nosec B404
+import sys
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import dbus
+import dbus.mainloop
+
+from blueferry import config
+from blueferry.private_files import atomic_write_private_text, read_private_text
+
+log = logging.getLogger(__name__)
+ACTIVATION_INTERFACE = "io.weirdware.BlueFerry.Client"
+ACTIVATION_PATH = "/io/weirdware/BlueFerry/Client"
+
+
+@dataclass(frozen=True)
+class DesktopClient:
+    key: str
+    desktop_id: str
+
+    @property
+    def bus_name(self) -> str:
+        return f"{ACTIVATION_INTERFACE}.{self.desktop_id.rsplit('.', 1)[1]}"
+
+    @property
+    def executable(self) -> str:
+        return f"/usr/bin/blueferry-{self.key}"
+
+
+CLIENTS = (
+    DesktopClient("gtk", "io.weirdware.BlueFerry.Gtk"),
+    DesktopClient("qt", "io.weirdware.BlueFerry.Qt"),
+    DesktopClient("quickshell", "io.weirdware.BlueFerry.Quickshell"),
+)
+
+
+def _recency_path(client: DesktopClient) -> Path:
+    return config.CONFIG_DIR / "clients" / client.key
+
+
+def record_client_use(key: str) -> None:
+    client = next(client for client in CLIENTS if client.key == key)
+    try:
+        atomic_write_private_text(_recency_path(client), str(time.time_ns()), maximum_bytes=64)
+    except OSError:
+        log.warning("could not remember the active desktop client", exc_info=True)
+
+
+def _last_used(client: DesktopClient) -> int:
+    try:
+        return max(0, int(read_private_text(_recency_path(client), maximum_bytes=64)))
+    except (OSError, ValueError):
+        return 0
+
+
+def select_client(
+    running: Sequence[str], *, environment: Mapping[str, str] | None = None,
+) -> DesktopClient | None:
+    environment = os.environ if environment is None else environment
+    desktop = environment.get("XDG_CURRENT_DESKTOP", "").lower().split(":")
+    if "gnome" in desktop or "unity" in desktop:
+        preferred = "gtk"
+    elif "kde" in desktop:
+        preferred = "qt"
+    elif "hyprland" in desktop or environment.get("OMARCHY_PATH"):
+        preferred = "quickshell"
+    else:
+        preferred = "gtk"
+    live = [client for client in CLIENTS if client.bus_name in running]
+    candidates = live or [client for client in CLIENTS if os.access(client.executable, os.X_OK)]
+    return max(
+        candidates, key=lambda client: (_last_used(client), client.key == preferred), default=None,
+    )
+
+
+def activation_argv(handle: str) -> list[str]:
+    return [sys.executable, "-m", "blueferry.client_activation", f"--message={handle}"]
+
+
+def _activation_environment(token: str) -> dict[str, str]:
+    environment = dict(os.environ)
+    for name in ("XDG_ACTIVATION_TOKEN", "DESKTOP_STARTUP_ID"):
+        environment.pop(name, None)
+    if token:
+        environment["XDG_ACTIVATION_TOKEN"] = token
+        environment["DESKTOP_STARTUP_ID"] = token
+    return environment
+
+
+def request_message_activation(handle: str, token: str) -> None:
+    """Keep client startup and unresponsive GUI calls off the daemon's GLib loop."""
+    if not handle or len(handle) > 1024 or len(token) > 4096:
+        return
+    # Tokens are single-use; never inherit an earlier startup's token.
+    try:
+        # Fixed module; the opaque message handle cannot become shell code.
+        subprocess.Popen(  # nosec B603
+            activation_argv(handle), env=_activation_environment(token), stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError:
+        log.exception("could not start desktop client activation")
+
+
+def open_message(handle: str, token: str) -> bool:
+    """Run in a short-lived helper; focus a live client or launch the selected one."""
+    bus = dbus.SessionBus(private=True, mainloop=dbus.mainloop.NULL_MAIN_LOOP)
+    try:
+        running = bus.list_names()
+        client = select_client(running)
+        if client is None:
+            log.warning("no BlueFerry graphical client is installed")
+            return False
+        if client.bus_name in running:
+            try:
+                bus.get_object(client.bus_name, ACTIVATION_PATH, introspect=False).OpenMessage(
+                    handle, token, dbus_interface=ACTIVATION_INTERFACE, timeout=3,
+                )
+                return True
+            except dbus.DBusException:
+                # A GUI can exit after selection. Only relaunch when its name
+                # vanished; a timeout must not open a second, competing client.
+                if bus.name_has_owner(client.bus_name):
+                    log.warning("the running %s client did not accept activation", client.key)
+                    return False
+        argv = [client.executable, f"--message={handle}"]
+        environment = _activation_environment(token)
+        if "org.freedesktop.systemd1" in running:
+            # A child of blueferry.service inherits PrivateDevices/PrivateTmp
+            # and dies when the backend restarts. Let the user manager create
+            # the GUI outside the backend's sandbox and cgroup instead.
+            manager = bus.get_object("org.freedesktop.systemd1", "/org/freedesktop/systemd1")
+            session_keys = (
+                "DISPLAY", "WAYLAND_DISPLAY", "XAUTHORITY", "DBUS_SESSION_BUS_ADDRESS",
+                "XDG_RUNTIME_DIR", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME",
+            )
+            variables = [
+                f"{name}={environment[name]}" for name in session_keys if name in environment
+            ]
+            variables.extend(
+                f"{name}={token}" for name in ("XDG_ACTIVATION_TOKEN", "DESKTOP_STARTUP_ID")
+            )
+            manager.StartTransientUnit(
+                f"app-blueferry-{client.key}-{uuid.uuid4().hex}.service", "fail",
+                dbus.Array([
+                    ("Type", "exec"), ("CollectMode", "inactive-or-failed"),
+                    # ExecStartEx disables systemd's $VARIABLE substitution;
+                    # the handle must arrive unchanged, just as with execve.
+                    ("ExecStartEx", dbus.Array([
+                        (client.executable, argv, ["no-env-expand"]),
+                    ], signature="(sasas)")),
+                    ("Environment", dbus.Array(variables, signature="s")),
+                ], signature="(sv)"),
+                dbus.Array([], signature="(sa(sv))"),
+                dbus_interface="org.freedesktop.systemd1.Manager", timeout=3,
+            )
+        else:
+            # A manually run daemon on a desktop without a systemd user manager.
+            subprocess.Popen(  # nosec B603
+                argv, env=environment, stdin=subprocess.DEVNULL, start_new_session=True,
+            )
+        return True
+    finally:
+        bus.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Open a BlueFerry message in a desktop client")
+    parser.add_argument("--message", required=True)
+    args = parser.parse_args()
+    token = os.environ.get("XDG_ACTIVATION_TOKEN") or os.environ.get("DESKTOP_STARTUP_ID", "")
+    if not args.message or len(args.message) > 1024 or len(token) > 4096:
+        parser.error("invalid message handle or activation token")
+    try:
+        return 0 if open_message(args.message, token) else 1
+    except (OSError, dbus.DBusException):
+        log.exception("could not activate a BlueFerry desktop client")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/blueferry/dbus_service.py
+++ b/src/blueferry/dbus_service.py
@@ -6,13 +6,20 @@ import logging
 
 import dbus
 import dbus.exceptions
+import dbus.lowlevel
 import dbus.service
 
 from blueferry.backend_operations import BackendDependencies, BackendOperations, SessionState
 from blueferry.background_worker import BackgroundWorker
 from blueferry.bus import get_session_bus
+from blueferry.client_activation import GTK_CLIENT
 from blueferry.dbus_security import CallerGuard
-from blueferry.errors import BlueFerryError, OperationFailedError, ResponseTooLargeError
+from blueferry.errors import (
+    BlueFerryError,
+    InvalidArgumentsError,
+    OperationFailedError,
+    ResponseTooLargeError,
+)
 from blueferry.limits import MAX_DBUS_JSON_BYTES
 from blueferry.protocol import (
     BUS_NAME,
@@ -424,6 +431,47 @@ class MessagesService(dbus.service.Object):
         return self._sync(lambda: self._authorized(
             sender, "status", self.operations.is_healthy
         ))
+
+    @dbus.service.method(
+        IFACE, in_signature="ss", out_signature="b", sender_keyword="sender",
+    )
+    def OpenLegacyGtkMessage(self, handle: str, application_owner: str, sender=None) -> bool:
+        """Deliver to an older GTK process without broadcasting to other clients."""
+        return self._sync(lambda: self._authorized(
+            sender, "read", lambda: self._open_legacy_gtk_message(handle, application_owner),
+        ))
+
+    def _open_legacy_gtk_message(self, handle: str, application_owner: str) -> bool:
+        if not handle or len(handle) > 1024 or len(application_owner) > 255:
+            raise InvalidArgumentsError("invalid legacy client activation")
+        try:
+            dbus.validate_bus_name(application_owner, allow_well_known=False)
+        except ValueError as error:
+            raise InvalidArgumentsError("invalid legacy application owner") from error
+        bus = self.connection
+        broker = dbus.Interface(
+            bus.get_object("org.freedesktop.DBus", "/org/freedesktop/DBus", introspect=False),
+            "org.freedesktop.DBus",
+        )
+        try:
+            if bus.get_name_owner(GTK_CLIENT.desktop_id) != application_owner:
+                return False
+            pid = broker.GetConnectionUnixProcessID(application_owner)
+        except dbus.DBusException:
+            return False  # the selected window closed before delivery
+        for peer in bus.list_names():
+            if not peer.startswith(":"):
+                continue
+            try:
+                if broker.GetConnectionUnixProcessID(peer) != pid:
+                    continue
+            except dbus.DBusException:
+                continue  # a connection disappeared during the snapshot
+            message = dbus.lowlevel.SignalMessage(OBJECT_PATH, EVENTS_IFACE, "OpenMessageRequested")
+            message.set_destination(peer)
+            message.append(handle, signature="s")
+            bus.send_message(message)
+        return True
 
     @dbus.service.signal(EVENTS_IFACE, signature="a{sv}")
     def HistoryChanged(self, props):

--- a/src/blueferry/event_dispatcher.py
+++ b/src/blueferry/event_dispatcher.py
@@ -12,6 +12,7 @@ from gi.repository import GLib
 
 from blueferry.ancs.constants import MESSAGES_APP_ID
 from blueferry.bus import get_session_bus
+from blueferry.client_activation import request_message_activation
 from blueferry.events import sms_group_sent_event, sms_sent_event
 from blueferry.limits import MAX_ANCS_FINGERPRINTS
 from blueferry.sinks import Sink
@@ -216,9 +217,8 @@ class EventDispatcher:
     def set_dbus_service(self, service) -> None:
         self.dbus_service = service
 
-    def _open_message(self, handle: str) -> None:
-        if self.dbus_service is not None:
-            self.dbus_service.emit_open_message(handle)
+    def _open_message(self, handle: str, token: str) -> None:
+        request_message_activation(handle, token)
 
     def message(self, event) -> None:
         if getattr(event, "kind", "") == "sms_received" and self.on_incoming_message is not None:

--- a/src/blueferry/glib_client_activation.py
+++ b/src/blueferry/glib_client_activation.py
@@ -1,0 +1,37 @@
+"""GLib adapter for desktop activation (GTK and the standalone QS bridge)."""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import dbus
+import dbus.service
+
+from blueferry.bus import get_session_bus
+from blueferry.client_activation import (
+    ACTIVATION_INTERFACE,
+    ACTIVATION_PATH,
+    CLIENTS,
+    record_client_use,
+)
+
+
+class ClientActivation(dbus.service.Object):
+    def __init__(self, key: str, callback: Callable[[str, str], None]) -> None:
+        self._key = key
+        self._callback = callback
+        client = next(client for client in CLIENTS if client.key == key)
+        self._name = dbus.service.BusName(
+            client.bus_name, bus=get_session_bus(), do_not_queue=True,
+        )
+        super().__init__(self._name, ACTIVATION_PATH)
+
+    @dbus.service.method(ACTIVATION_INTERFACE, in_signature="ss", out_signature="")
+    def OpenMessage(self, handle: str, token: str) -> None:
+        if len(handle) > 1024 or len(token) > 4096:
+            raise dbus.DBusException("invalid activation request")
+        self._callback(str(handle), str(token))
+        record_client_use(self._key)
+
+    def close(self) -> None:
+        self.remove_from_connection()
+        get_session_bus().release_name(self._name.get_name())

--- a/src/blueferry/qt/activation.py
+++ b/src/blueferry/qt/activation.py
@@ -1,0 +1,54 @@
+"""Qt event-loop adapter for the shared desktop activation protocol."""
+from __future__ import annotations
+
+from PySide6.QtCore import QObject, Signal, Slot
+from PySide6.QtDBus import QDBusConnection, QDBusMessage
+
+from blueferry.client_activation import ACTIVATION_INTERFACE, ACTIVATION_PATH, CLIENTS
+
+QT_CLIENT = next(client for client in CLIENTS if client.key == "qt")
+
+
+class ClientActivation(QObject):
+    requested = Signal(str, str)
+
+    def __init__(self, parent: QObject) -> None:
+        super().__init__(parent)
+        self._ready = False
+        self._pending: tuple[str, str] | None = None
+        self.bus = QDBusConnection.sessionBus()
+        self.primary = self.bus.registerService(QT_CLIENT.bus_name)
+        if self.primary and not self.bus.registerObject(
+            ACTIVATION_PATH, ACTIVATION_INTERFACE, self,
+            QDBusConnection.RegisterOption.ExportAllSlots,
+        ):
+            self.bus.unregisterService(QT_CLIENT.bus_name)
+            raise RuntimeError("could not register desktop activation")
+
+    @Slot(str, str)
+    def OpenMessage(self, handle: str, token: str) -> None:
+        if len(handle) <= 1024 and len(token) <= 4096:
+            if self._ready:
+                self.requested.emit(handle, token)
+            else:
+                self._pending = (handle, token)
+
+    def ready(self) -> None:
+        """QML loading can dispatch D-Bus before a window is available."""
+        self._ready = True
+        if self._pending is not None:
+            request, self._pending = self._pending, None
+            self.requested.emit(*request)
+
+    def forward(self, handle: str, token: str) -> bool:
+        message = QDBusMessage.createMethodCall(
+            QT_CLIENT.bus_name, ACTIVATION_PATH, ACTIVATION_INTERFACE, "OpenMessage",
+        )
+        message.setArguments([handle, token])
+        reply = self.bus.call(message, timeout=3000)
+        return reply.type() != QDBusMessage.MessageType.ErrorMessage
+
+    def close(self) -> None:
+        if self.primary:
+            self.bus.unregisterObject(ACTIVATION_PATH)
+            self.bus.unregisterService(QT_CLIENT.bus_name)

--- a/src/blueferry/qt/app.py
+++ b/src/blueferry/qt/app.py
@@ -1,6 +1,7 @@
 """PySide6/Kirigami application entry point."""
 from __future__ import annotations
 
+import argparse
 import os
 import signal
 import sys
@@ -12,6 +13,8 @@ from PySide6.QtQml import QQmlApplicationEngine
 from PySide6.QtQuickControls2 import QQuickStyle
 from PySide6.QtWidgets import QApplication, QMenu, QSystemTrayIcon
 
+from blueferry.client_activation import record_client_use
+from blueferry.qt.activation import ClientActivation
 from blueferry.qt.controller import BridgeController
 
 APP_ID = "io.weirdware.BlueFerry.Qt"
@@ -53,10 +56,16 @@ def _install_terminal_signal_handlers(application: QGuiApplication) -> QTimer:
     return timer
 
 
-def _present_window(window: QWindow) -> None:
+def _present_window(window: QWindow, token: str | None = None) -> None:
+    # Qt Wayland consumes XDG_ACTIVATION_TOKEN in requestActivate(), including
+    # for an already-created window. Set it before show() as that can activate.
+    if token:
+        os.environ["XDG_ACTIVATION_TOKEN"] = token
     window.show()
     window.raise_()
     window.requestActivate()
+    os.environ.pop("XDG_ACTIVATION_TOKEN", None)
+    record_client_use("qt")
 
 
 def _create_system_tray(
@@ -101,16 +110,26 @@ def _create_system_tray(
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--message", default="")
+    args, qt_args = parser.parse_known_args(sys.argv[1:])
+    wayland_token = os.environ.pop("XDG_ACTIVATION_TOKEN", "")
+    token = wayland_token or os.environ.get("DESKTOP_STARTUP_ID", "")
     if not os.environ.get("QT_QUICK_CONTROLS_STYLE"):
         QQuickStyle.setStyle("org.kde.desktop")
 
-    application = QApplication(sys.argv)
+    application = QApplication([sys.argv[0], *qt_args])
+    # The X11 platform reads its startup ID while constructing QApplication.
+    os.environ.pop("DESKTOP_STARTUP_ID", None)
     application.setApplicationName("blueferry")
     application.setApplicationDisplayName("BlueFerry")
     application.setOrganizationDomain("weirdware.io")
     application.setDesktopFileName(APP_ID)
     application.setWindowIcon(QIcon.fromTheme(APP_ICON))
     _install_translation(application)
+    activation = ClientActivation(application)
+    if not activation.primary:
+        return 0 if activation.forward(args.message, token) else 1
 
     controller = BridgeController(parent=application)
     engine = QQmlApplicationEngine()
@@ -118,13 +137,37 @@ def main() -> int:
     qml = files("blueferry.qt").joinpath("qml/Main.qml")
     engine.load(QUrl.fromLocalFile(str(qml)))
     if not engine.rootObjects():
+        activation.close()
         return 1
     window = engine.rootObjects()[0]
-    controller.messageOpenRequested.connect(lambda _handle: _present_window(window))
+    pending_token: str | None = None
+
+    def present_message(_handle: str) -> None:
+        nonlocal pending_token
+        focus_token, pending_token = pending_token, None
+        _present_window(window, focus_token)
+
+    def activate_message(handle: str, activation_token: str) -> None:
+        nonlocal pending_token
+        pending_token = activation_token
+        if handle:
+            controller.messageOpenRequested.emit(handle)
+        else:
+            present_message("")
+
+    activation.requested.connect(activate_message)
+    controller.messageOpenRequested.connect(present_message)
+    window.activeChanged.connect(lambda: record_client_use("qt") if window.isActive() else None)
+    def ready() -> None:
+        activate_message(args.message, token)
+        activation.ready()
+
+    QTimer.singleShot(0, ready)
     system_tray = _create_system_tray(application, window)
     terminal_signal_timer = _install_terminal_signal_handlers(application)
     exit_code = application.exec()
     terminal_signal_timer.stop()
+    activation.close()
     if system_tray is not None:
         system_tray.hide()
     return exit_code

--- a/src/blueferry/quickshell_bridge.py
+++ b/src/blueferry/quickshell_bridge.py
@@ -15,6 +15,7 @@ from typing import Any, TextIO
 
 from blueferry.bus import get_session_bus
 from blueferry.client import BackendClient
+from blueferry.client_activation import record_client_use
 from blueferry.protocol import BUS_NAME, EVENTS_IFACE, OBJECT_PATH
 
 MAX_REQUEST_CHARS = 1_048_576
@@ -60,10 +61,13 @@ class QuickshellBridge:
         self,
         client: BackendClient,
         output: TextIO = sys.stdout,
+        *,
+        desktop_client: bool = False,
     ) -> None:
         self.client = client
         self.output = output
         self._output_lock = threading.Lock()
+        self.desktop_client = desktop_client
 
     def emit(self, payload: Mapping[str, Any]) -> None:
         line = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
@@ -76,6 +80,9 @@ class QuickshellBridge:
         self.emit({"event": name, "data": data})
 
     def dispatch(self, method: str, args: Mapping[str, Any]) -> object:
+        if method == "client_active" and self.desktop_client:
+            record_client_use("quickshell")
+            return None
         if method == "status":
             return self.client.status().to_dict()
         if method == "threads":
@@ -224,7 +231,16 @@ def main() -> int:
     from gi.repository import GLib
 
     DBusGMainLoop(set_as_default=True)
-    bridge = QuickshellBridge(BackendClient())
+    desktop_client = "--desktop-client" in sys.argv[1:]
+    bridge = QuickshellBridge(BackendClient(), desktop_client=desktop_client)
+    activation = None
+    if desktop_client:
+        from blueferry.glib_client_activation import ClientActivation
+
+        activation = ClientActivation(
+            "quickshell", lambda handle, _token: bridge.emit_event("open-message", handle),
+        )
+        record_client_use("quickshell")
     workers = _RequestWorkers(bridge)
     signal_matches = _install_signal_receivers(bridge)
     loop = GLib.MainLoop()
@@ -239,6 +255,8 @@ def main() -> int:
     try:
         loop.run()
     finally:
+        if activation is not None:
+            activation.close()
         for match in signal_matches:
             remove: Callable[[], object] | None = getattr(match, "remove", None)
             if remove is not None:

--- a/src/blueferry/quickshell_bridge.py
+++ b/src/blueferry/quickshell_bridge.py
@@ -175,6 +175,16 @@ class _RequestWorkers:
             self.bridge.handle_line(self.pending.get())
 
     def submit(self, line: str) -> None:
+        # Focus describes the client at receipt time. It must not wait behind
+        # slow backend I/O and then overwrite a newer client's preference.
+        if len(line) <= MAX_REQUEST_CHARS:
+            try:
+                request = json.loads(line)
+            except (ValueError, RecursionError):
+                request = None
+            if isinstance(request, dict) and request.get("method") == "client_active":
+                self.bridge.handle_line(line)  # retain normal validation and widget opt-out
+                return
         try:
             self.pending.put_nowait(line)
         except queue.Full:

--- a/src/blueferry/sinks/libnotify.py
+++ b/src/blueferry/sinks/libnotify.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import json
 import logging
 from html import escape
-from pathlib import Path
 from typing import Protocol
 
 import dbus
@@ -28,6 +27,7 @@ import dbus.exceptions
 from blueferry import config
 from blueferry.ancs.events import AncsEvent
 from blueferry.bus import get_session_bus
+from blueferry.client_activation import activation_argv, select_client
 from blueferry.events import SmsEvent
 from blueferry.limits import MAX_DESKTOP_MESSAGE_TRACKERS
 from blueferry.notification_policy import (
@@ -61,40 +61,18 @@ _ANCS_EXPIRE_MS = config.NOTIFICATION_TIMEOUT_MS
 # because the iPhone marked it read (so we'd be in a write-self-write loop).
 # Reason 1 is the normal finite-timeout path and must not mark the phone read.
 _REASON_DISMISSED = 2
-_CLIENT_LAUNCHERS = (
-    "/usr/bin/blueferry-quickshell",
-    "/usr/bin/blueferry-gtk",
-    "/usr/bin/blueferry-qt",
-)
-
-
-def _open_conversation_argv(handle: str) -> list[str]:
-    """Return an argv that focuses a client on this opaque message handle."""
-    if not handle:
-        return []
-    for binary in _CLIENT_LAUNCHERS:
-        if Path(binary).is_file():
-            if binary.endswith("quickshell"):
-                return [binary, "--message", handle]
-            return [binary]
-    return []
 
 
 def _notification_hints(handle: str) -> dict[str, object]:
     hints: dict[str, object] = {"urgency": dbus.Byte(1)}
-    argv = _open_conversation_argv(handle)
-    if not argv:
+    if not handle:
         return hints
-    binary = argv[0]
-    if binary.endswith("quickshell"):
-        hints["desktop-entry"] = "io.weirdware.BlueFerry.Quickshell"
-    elif binary.endswith("gtk"):
-        hints["desktop-entry"] = "io.weirdware.BlueFerry.Gtk"
-    elif binary.endswith("-qt"):
-        hints["desktop-entry"] = "io.weirdware.BlueFerry.Qt"
+    client = select_client(get_session_bus().list_names())
+    if client is not None:
+        hints["desktop-entry"] = client.desktop_id
     # Omarchy's notification shell prefers this JSON argv over a live
     # libnotify action, and it survives a shell restart.
-    hints["omarchy-exec-argv"] = json.dumps(argv)
+    hints["omarchy-exec-argv"] = json.dumps(activation_argv(handle))
     return hints
 
 
@@ -135,6 +113,7 @@ class LibnotifySink:
         # the message in their private thread snapshot without broadcasting a
         # phone number or message body on the session bus.
         self._open_messages: dict[int, str] = {}
+        self._activation_tokens: dict[int, str] = {}
         # notification_id -> SignalMatch for the per-Message1 PropertiesChanged sub
         self._msg_subs: dict[int, _SignalMatch] = {}
 
@@ -146,11 +125,14 @@ class LibnotifySink:
         self._action_match = self._notif.connect_to_signal(
             "ActionInvoked", self._on_action,
         )
+        self._token_match = self._notif.connect_to_signal(
+            "ActivationToken", self._on_activation_token,
+        )
         log.info("libnotify sink ready (expiring + bidirectional read-sync)")
 
     def close(self) -> None:
         """Release signal watches before a notification-daemon replacement."""
-        for attribute in ("_match", "_action_match"):
+        for attribute in ("_match", "_action_match", "_token_match"):
             match = getattr(self, attribute, None)
             if match is not None:
                 try:
@@ -166,6 +148,7 @@ class LibnotifySink:
         self._msg_subs.clear()
         self._pending.clear()
         self._open_messages.clear()
+        getattr(self, "_activation_tokens", {}).clear()
 
     def _policy(self) -> str:
         provider = getattr(self, "_notification_policy", None)
@@ -250,6 +233,7 @@ class LibnotifySink:
             oldest = next(iter(tracked))
             self._pending.pop(oldest, None)
             open_messages.pop(oldest, None)
+            getattr(self, "_activation_tokens", {}).pop(oldest, None)
             subscription = self._msg_subs.pop(oldest, None)
             if subscription is not None:
                 try:
@@ -327,8 +311,17 @@ class LibnotifySink:
 
     # ---- Linux user dismisses → mark-read on iPhone ----------------------
 
+    def _on_activation_token(self, nid, token) -> None:
+        """The notification server supplies a single-use token before the action."""
+        try:
+            nid_i = int(nid)
+        except (TypeError, ValueError):
+            return
+        if nid_i in self._open_messages and len(str(token)) <= 4096:
+            self._activation_tokens[nid_i] = str(token)
+
     def _on_action(self, nid, action) -> None:
-        """Route a notification click to every currently running client."""
+        """Route a notification click to one client, starting it if necessary."""
         try:
             nid_i = int(nid)
         except (TypeError, ValueError):
@@ -337,8 +330,9 @@ class LibnotifySink:
             return
         handle = getattr(self, "_open_messages", {}).get(nid_i)
         callback = getattr(self, "_on_open_message", None)
+        token = getattr(self, "_activation_tokens", {}).pop(nid_i, "")
         if handle and callback is not None:
-            callback(handle)
+            callback(handle, token)
 
     def _on_closed(self, nid, reason) -> None:
         try:
@@ -348,6 +342,7 @@ class LibnotifySink:
             return
 
         getattr(self, "_open_messages", {}).pop(nid_i, None)
+        getattr(self, "_activation_tokens", {}).pop(nid_i, None)
         message_path = self._pending.pop(nid_i, None)
 
         # Always remove the per-message subscription, no matter the reason

--- a/src/blueferry/ui/app.py
+++ b/src/blueferry/ui/app.py
@@ -8,6 +8,7 @@ A separate process from the daemon. Its application id is
 from __future__ import annotations
 
 import logging
+import os
 import sys
 
 import gi
@@ -15,9 +16,11 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, Gdk, Gio, Gtk  # noqa: E402
+from gi.repository import Adw, Gdk, Gio, GLib, Gtk  # noqa: E402
 
 from blueferry import __version__  # noqa: E402
+from blueferry.client_activation import record_client_use  # noqa: E402
+from blueferry.glib_client_activation import ClientActivation  # noqa: E402
 from blueferry.i18n import _  # noqa: E402
 from blueferry.ui.client import DaemonClient  # noqa: E402
 from blueferry.ui.window import MainWindow  # noqa: E402
@@ -36,11 +39,20 @@ _CSS = """
 
 class BlueFerryApp(Adw.Application):
     def __init__(self) -> None:
-        super().__init__(application_id=APP_ID, flags=Gio.ApplicationFlags.DEFAULT_FLAGS)
+        super().__init__(
+            application_id=APP_ID,
+            flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE | Gio.ApplicationFlags.SEND_ENVIRONMENT,
+        )
+        self.add_main_option(
+            "message", 0, GLib.OptionFlags.NONE, GLib.OptionArg.STRING,
+            "Open the conversation containing a message handle", "HANDLE",
+        )
         self._client: DaemonClient | None = None
+        self._activation: ClientActivation | None = None
 
     def do_startup(self) -> None:
         Adw.Application.do_startup(self)
+        self._activation = ClientActivation("gtk", self._open_message)
         for name, callback in (
             ("about", self._show_about),
             ("shortcuts", self._show_shortcuts),
@@ -99,15 +111,44 @@ class BlueFerryApp(Adw.Application):
         dialog.present(self.props.active_window)
 
     def do_activate(self) -> None:
+        self._open_message("", "")
+
+    def do_command_line(self, command_line: Gio.ApplicationCommandLine) -> int:
+        handle = command_line.get_options_dict().lookup_value("message", None)
+        token = (
+            command_line.getenv("XDG_ACTIVATION_TOKEN")
+            or command_line.getenv("DESKTOP_STARTUP_ID") or ""
+        )
+        self._open_message(handle.unpack() if handle is not None else "", token)
+        return 0
+
+    def _open_message(self, handle: str, token: str) -> None:
         win = self.props.active_window
         if win is None:
             if self._client is None:
                 self._client = DaemonClient()
             win = MainWindow(application=self, client=self._client)
-        win.present()
-        win.present_initial_setup()
+            win.connect("notify::is-active", self._window_active_changed)
+        if token:
+            win.set_startup_id(token)
+        if handle:
+            win.open_message(handle)
+        else:
+            win.present()
+        record_client_use("gtk")
+        if not handle:
+            win.present_initial_setup()
+        # A later manual activation must not accidentally reuse this token.
+        os.environ.pop("XDG_ACTIVATION_TOKEN", None)
+        os.environ.pop("DESKTOP_STARTUP_ID", None)
+
+    def _window_active_changed(self, win: Gtk.Window, _pspec) -> None:
+        if win.is_active():
+            record_client_use("gtk")
 
     def do_shutdown(self) -> None:
+        if self._activation is not None:
+            self._activation.close()
         if self._client is not None:
             self._client.stop()
         Adw.Application.do_shutdown(self)

--- a/src/blueferry/ui/app.py
+++ b/src/blueferry/ui/app.py
@@ -11,6 +11,7 @@ import logging
 import os
 import sys
 
+import dbus
 import gi
 
 gi.require_version("Gtk", "4.0")
@@ -19,7 +20,7 @@ gi.require_version("Adw", "1")
 from gi.repository import Adw, Gdk, Gio, GLib, Gtk  # noqa: E402
 
 from blueferry import __version__  # noqa: E402
-from blueferry.client_activation import record_client_use  # noqa: E402
+from blueferry.client_activation import forward_to_legacy_gtk, record_client_use  # noqa: E402
 from blueferry.glib_client_activation import ClientActivation  # noqa: E402
 from blueferry.i18n import _  # noqa: E402
 from blueferry.ui.client import DaemonClient  # noqa: E402
@@ -112,6 +113,16 @@ class BlueFerryApp(Adw.Application):
 
     def do_activate(self) -> None:
         self._open_message("", "")
+
+    def do_handle_local_options(self, options: GLib.VariantDict) -> int:
+        handle = options.lookup_value("message", None)
+        token = os.environ.get("XDG_ACTIVATION_TOKEN") or os.environ.get("DESKTOP_STARTUP_ID", "")
+        try:
+            forwarded = forward_to_legacy_gtk(handle.unpack() if handle is not None else "", token)
+        except dbus.DBusException:
+            logging.getLogger(__name__).exception("could not activate the existing GTK client")
+            return 1
+        return -1 if forwarded is None else 0 if forwarded else 1
 
     def do_command_line(self, command_line: Gio.ApplicationCommandLine) -> int:
         handle = command_line.get_options_dict().lookup_value("message", None)

--- a/src/blueferry/ui/window.py
+++ b/src/blueferry/ui/window.py
@@ -103,6 +103,9 @@ class MainWindow(Adw.ApplicationWindow):
         self.present_phone_settings()
 
     def _on_open_message_requested(self, _client, handle: str) -> None:
+        self.open_message(handle)
+
+    def open_message(self, handle: str) -> None:
         self._phone_dialog.close()
         self.present()
         self.messages.open_message(handle)

--- a/tests/test_client_activation.py
+++ b/tests/test_client_activation.py
@@ -38,6 +38,50 @@ def test_running_client_wins_over_last_used_and_desktop(preferences):
     assert client.key == "quickshell"
 
 
+def test_legacy_gtk_counts_as_running_after_upgrade(preferences):
+    activation.record_client_use("qt")
+    client = activation.select_client(
+        [activation.GTK_CLIENT.desktop_id], environment={"XDG_CURRENT_DESKTOP": "KDE"},
+    )
+    assert client == activation.GTK_CLIENT
+
+
+def test_gtk_finishing_startup_uses_new_endpoint_after_activation(preferences):
+    calls = []
+
+    def get_object(name, _path, **_kwargs):
+        if name == activation.GTK_CLIENT.desktop_id:
+            return SimpleNamespace(Activate=lambda data, **_kw: calls.append(("activate", dict(data))))
+        assert name == activation.GTK_CLIENT.bus_name  # no legacy daemon call
+        return SimpleNamespace(OpenMessage=lambda *args, **_kw: calls.append(("open", args)))
+
+    bus = SimpleNamespace(get_object=get_object, name_has_owner=lambda _name: True)
+    assert activation._open_legacy_gtk(bus, "message", "single-use-token")
+    assert calls == [
+        ("activate", {"activation-token": "single-use-token", "desktop-startup-id": "single-use-token"}),
+        ("open", ("message", "")),
+    ]
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_legacy_gtk_exit_during_forwarding_allows_fresh_start(preferences, monkeypatch, raises):
+    def forward(*_args):
+        if raises:
+            raise dbus.DBusException("old window exited")
+        return False
+
+    launched = []
+    monkeypatch.setattr(activation, "_open_legacy_gtk", forward)
+    monkeypatch.setattr(activation.dbus, "SessionBus", lambda **_kw: SimpleNamespace(
+        list_names=lambda: [activation.GTK_CLIENT.desktop_id],
+        name_has_owner=lambda _name: False, close=lambda: None,
+    ))
+    monkeypatch.setattr(activation.subprocess, "Popen", lambda argv, **_kw: launched.append(argv))
+    assert activation.forward_to_legacy_gtk("handle", "") is None
+    assert activation.open_message("handle", "")
+    assert launched == [[activation.GTK_CLIENT.executable, "--message=handle"]]
+
+
 def test_most_recent_running_client_wins(preferences, monkeypatch):
     monkeypatch.setattr(activation.time, "time_ns", lambda: 100)
     activation.record_client_use("gtk")

--- a/tests/test_client_activation.py
+++ b/tests/test_client_activation.py
@@ -154,6 +154,9 @@ def test_exit_race_relaunches_but_timeout_does_not_duplicate(preferences, monkey
 @pytest.mark.parametrize("key", ["gtk", "qt", "quickshell", "systemd"])
 def test_real_client_dbus_activation(tmp_path, monkeypatch, key):
     """Exercise both actual event-loop adapters on an isolated session bus."""
+    if key == "qt":
+        # Debian package builds do not require the optional Qt runtime.
+        pytest.importorskip("PySide6")
     monkeypatch.setattr(activation.config, "CONFIG_DIR", tmp_path)
     environment = dict(os.environ, XDG_CONFIG_HOME=str(tmp_path))
     process = subprocess.Popen(

--- a/tests/test_client_activation.py
+++ b/tests/test_client_activation.py
@@ -1,0 +1,211 @@
+"""Notification routing stays independent of a daemon/client restart."""
+from __future__ import annotations
+
+import json
+import os
+import select
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import dbus
+import pytest
+
+from blueferry import client_activation as activation
+
+
+@pytest.fixture
+def preferences(monkeypatch, tmp_path):
+    monkeypatch.setattr(activation.config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(activation.os, "access", lambda *_args: True)
+    return tmp_path
+
+
+@pytest.mark.parametrize("desktop,key", [
+    ("GNOME", "gtk"), ("ubuntu:GNOME", "gtk"), ("KDE", "qt"),
+    ("Hyprland", "quickshell"), ("", "gtk"),
+])
+def test_first_launch_uses_desktop(preferences, desktop, key):
+    assert activation.select_client([], environment={"XDG_CURRENT_DESKTOP": desktop}).key == key
+
+
+def test_running_client_wins_over_last_used_and_desktop(preferences):
+    activation.record_client_use("qt")
+    client = activation.select_client(
+        [activation.CLIENTS[2].bus_name], environment={"XDG_CURRENT_DESKTOP": "GNOME"},
+    )
+    assert client.key == "quickshell"
+
+
+def test_most_recent_running_client_wins(preferences, monkeypatch):
+    monkeypatch.setattr(activation.time, "time_ns", lambda: 100)
+    activation.record_client_use("gtk")
+    monkeypatch.setattr(activation.time, "time_ns", lambda: 200)
+    activation.record_client_use("qt")
+    assert activation.select_client([c.bus_name for c in activation.CLIENTS]).key == "qt"
+    assert activation.select_client([]).key == "qt"
+
+
+def test_removed_preference_and_corrupt_file_fall_back(preferences, monkeypatch):
+    activation.record_client_use("qt")
+    monkeypatch.setattr(activation.os, "access", lambda path, _mode: path.endswith("gtk"))
+    assert activation.select_client([]).key == "gtk"
+    (preferences / "clients" / "qt").write_text("invalid")
+    monkeypatch.setattr(activation.os, "access", lambda *_args: True)
+    assert activation.select_client([], environment={}).key == "gtk"
+    monkeypatch.setattr(activation.os, "access", lambda *_args: False)
+    assert activation.select_client([]) is None
+
+
+def test_recency_files_are_private_and_leave_daemon_settings_alone(preferences):
+    settings = preferences / "settings.json"
+    settings.write_text('{"storage_policy":"keep"}')
+    activation.record_client_use("qt")
+    activation.record_client_use("gtk")
+    assert settings.read_text() == '{"storage_policy":"keep"}'
+    assert (preferences / "clients" / "qt").stat().st_mode & 0o777 == 0o600
+    assert (preferences / "clients").stat().st_mode & 0o777 == 0o700
+
+
+@pytest.mark.parametrize("token", ["", "wayland-token"])
+def test_closed_client_gets_handle_and_only_current_token(preferences, monkeypatch, token):
+    launched = []
+    closed = []
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "KDE")
+    monkeypatch.setenv("XDG_ACTIVATION_TOKEN", "stale")
+    monkeypatch.setenv("DESKTOP_STARTUP_ID", "stale")
+    monkeypatch.setattr(activation.dbus, "SessionBus", lambda **_kwargs: SimpleNamespace(
+        list_names=lambda: [], close=lambda: closed.append(True),
+    ))
+    monkeypatch.setattr(activation.subprocess, "Popen", lambda argv, **kw: launched.append((argv, kw)))
+    handle = "opaque handle; $(do not execute)"
+    assert activation.open_message(handle, token)
+    argv, kwargs = launched[0]
+    assert argv == ["/usr/bin/blueferry-qt", f"--message={handle}"]
+    assert kwargs["env"].get("XDG_ACTIVATION_TOKEN", "") == token
+    assert kwargs["env"].get("DESKTOP_STARTUP_ID", "") == token
+    assert "shell" not in kwargs
+    assert closed == [True]
+
+
+@pytest.mark.parametrize("still_running", [False, True])
+def test_exit_race_relaunches_but_timeout_does_not_duplicate(preferences, monkeypatch, still_running):
+    launched = []
+
+    def failed(*_args, **_kwargs):
+        raise dbus.DBusException("lost client")
+
+    monkeypatch.setattr(activation.dbus, "SessionBus", lambda **_kwargs: SimpleNamespace(
+        list_names=lambda: [activation.CLIENTS[0].bus_name], close=lambda: None,
+        get_object=lambda *_args, **_kwargs: SimpleNamespace(OpenMessage=failed),
+        name_has_owner=lambda _name: still_running,
+    ))
+    monkeypatch.setattr(activation.subprocess, "Popen", lambda *_args, **_kw: launched.append(True))
+    assert activation.open_message("handle", "") is not still_running
+    assert bool(launched) is not still_running
+
+
+@pytest.mark.private_dbus
+@pytest.mark.parametrize("key", ["gtk", "qt", "quickshell", "systemd"])
+def test_real_client_dbus_activation(tmp_path, monkeypatch, key):
+    """Exercise both actual event-loop adapters on an isolated session bus."""
+    monkeypatch.setattr(activation.config, "CONFIG_DIR", tmp_path)
+    environment = dict(os.environ, XDG_CONFIG_HOME=str(tmp_path))
+    process = subprocess.Popen(
+        [sys.executable, str(Path(__file__).resolve()), key], env=environment,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0,
+    )
+
+    def read_line():
+        ready, _, _ = select.select([process.stdout], [], [], 5)
+        assert ready, "client activation timed out"
+        line = process.stdout.readline()
+        assert line, process.stderr.read()
+        return line.decode().strip()
+
+    try:
+        if key == "qt":
+            assert json.loads(read_line()) == ["during-load", "early-token"]
+        assert read_line() == "ready"
+        if key == "systemd":
+            monkeypatch.setattr(activation.os, "access", lambda *_args: True)
+            monkeypatch.setenv("XDG_CURRENT_DESKTOP", "GNOME")
+            assert activation.open_message("-$HOME literal", "focus-token")
+            unit, mode, properties, aux = json.loads(read_line())
+            properties = dict(properties)
+            assert unit.startswith("app-blueferry-gtk-") and unit.endswith(".service")
+            assert mode == "fail" and aux == []
+            assert properties["Type"] == "exec"
+            assert properties["ExecStartEx"] == [[
+                "/usr/bin/blueferry-gtk", ["/usr/bin/blueferry-gtk", "--message=-$HOME literal"],
+                ["no-env-expand"],
+            ]]
+            assert "XDG_ACTIVATION_TOKEN=focus-token" in properties["Environment"]
+            assert "DESKTOP_STARTUP_ID=focus-token" in properties["Environment"]
+        else:
+            assert activation.open_message("opaque message", "focus-token")
+            assert json.loads(read_line()) == ["opaque message", "focus-token"]
+        if key == "qt":
+            # A second Qt invocation must forward to the first event loop.
+            result = subprocess.run(
+                [sys.executable, str(Path(__file__).resolve()), "qt-forward"],
+                env=environment, capture_output=True, text=True, timeout=10,
+            )
+            assert result.returncode == 0, result.stdout + result.stderr
+            assert json.loads(read_line()) == ["second", "second-token"]
+    finally:
+        process.terminate()
+        process.communicate(timeout=5)
+
+
+def _serve(key):
+    def received(handle, token):
+        print(json.dumps([handle, token]), flush=True)
+
+    if key.startswith("qt"):
+        from PySide6.QtCore import QCoreApplication
+
+        from blueferry.qt.activation import ClientActivation
+
+        app = QCoreApplication([])
+        service = ClientActivation(app)
+        if key == "qt-forward":
+            assert not service.primary
+            assert service.forward("second", "second-token")
+            return
+        assert service.primary
+        service.OpenMessage("during-load", "early-token")
+        service.requested.connect(received)
+        service.ready()
+        print("ready", flush=True)
+        app.exec()
+    else:
+        from gi.repository import GLib
+
+        from blueferry.glib_client_activation import ClientActivation
+
+        if key == "systemd":
+            import dbus.service
+
+            from blueferry.bus import get_session_bus
+
+            class Manager(dbus.service.Object):
+                @dbus.service.method(
+                    "org.freedesktop.systemd1.Manager", in_signature="ssa(sv)a(sa(sv))",
+                    out_signature="o",
+                )
+                def StartTransientUnit(self, unit, mode, properties, aux):
+                    print(json.dumps([unit, mode, properties, aux]), flush=True)
+                    return "/org/freedesktop/systemd1/job/1"
+
+            name = dbus.service.BusName("org.freedesktop.systemd1", get_session_bus())
+            service = Manager(name, "/org/freedesktop/systemd1")
+        else:
+            service = ClientActivation(key, received)
+        print("ready", flush=True)
+        GLib.MainLoop().run()
+
+
+if __name__ == "__main__":
+    _serve(sys.argv[1])

--- a/tests/test_dbus_integration.py
+++ b/tests/test_dbus_integration.py
@@ -132,6 +132,34 @@ def _request_in_thread(name, method, *args):
     return thread, outcome
 
 
+@pytest.mark.parametrize("handle,owner", [
+    ("", ":1.1"), ("x" * 1025, ":1.1"), ("handle", ""),
+    ("handle", "io.weirdware.BlueFerry.Gtk"), ("handle", ":invalid"),
+])
+def test_legacy_activation_rejects_invalid_requests(public_service, handle, owner):
+    name, *_ = public_service
+    thread, outcome = _request_in_thread(name, "OpenLegacyGtkMessage", handle, owner)
+    _dispatch_until(lambda: bool(outcome))
+    thread.join(1)
+    assert outcome["error"].get_dbus_name().endswith(".InvalidArgs")
+
+
+def test_legacy_activation_does_not_route_to_a_replaced_owner(public_service):
+    from blueferry.client_activation import GTK_CLIENT
+
+    name, *_ = public_service
+    gtk_bus = dbus.SessionBus(private=True)
+    gtk_name = dbus.service.BusName(GTK_CLIENT.desktop_id, bus=gtk_bus, do_not_queue=True)
+    try:
+        thread, outcome = _request_in_thread(name, "OpenLegacyGtkMessage", "handle", ":999.999")
+        _dispatch_until(lambda: bool(outcome))
+        thread.join(1)
+        assert not outcome["value"]
+    finally:
+        del gtk_name  # release the name before closing the connection
+        gtk_bus.close()
+
+
 def test_fresh_profile_unlock_and_snapshots_use_the_compatible_public_client(
     public_service, tmp_path, monkeypatch,
 ):

--- a/tests/test_event_dispatcher.py
+++ b/tests/test_event_dispatcher.py
@@ -201,17 +201,21 @@ def test_only_an_incoming_map_message_verifies_message_notifications():
     assert verified == [True]
 
 
-def test_notification_action_is_broadcast_through_current_dbus_service():
+def test_notification_action_routes_to_one_client_even_without_backend_service(monkeypatch):
+    opened = []
+    monkeypatch.setattr(
+        event_dispatcher, "request_message_activation",
+        lambda handle, token: opened.append((handle, token)),
+    )
     dispatcher = EventDispatcher(
         object(),
         submit_obex=lambda *_args, **_kwargs: None,
     )
     service = _Service()
-    dispatcher.set_dbus_service(service)
+    dispatcher._open_message("message-opaque-42", "focus-token")
 
-    dispatcher._open_message("message-opaque-42")
-
-    assert service.events == [("open", "message-opaque-42")]
+    assert service.events == []
+    assert opened == [("message-opaque-42", "focus-token")]
 
 
 def test_libnotify_is_added_when_notification_server_appears(monkeypatch):

--- a/tests/test_gtk_pairing_controls.py
+++ b/tests/test_gtk_pairing_controls.py
@@ -12,7 +12,7 @@ import pytest
 
 
 @pytest.mark.private_dbus
-@pytest.mark.parametrize("scenario", ["controls", "error-toasts", "activation"])
+@pytest.mark.parametrize("scenario", ["controls", "error-toasts", "activation", "upgrade-activation"])
 def test_gtk_pairing_ui(tmp_path, scenario):
     executable = shutil.which("gtk4-broadwayd")
     if executable is None:
@@ -260,10 +260,135 @@ def _exercise_gtk_activation():
     ], calls
 
 
+def _serve_activation_backend():
+    from types import SimpleNamespace
+
+    import dbus.service
+    from gi.repository import GLib
+
+    from blueferry.bus import get_session_bus
+    from blueferry.dbus_service import MessagesService
+    from blueferry.protocol import BUS_NAME, EVENTS_IFACE, OBJECT_PATH
+
+    bus = get_session_bus()
+    name = dbus.service.BusName(BUS_NAME, bus=bus, do_not_queue=True)
+    service = MessagesService(name, SimpleNamespace(map=None, pbap=None, map_path=None))
+    # A second process listening for the same backend signal must not be
+    # activated by the legacy relay. The GTK process has two bus connections.
+    observer = dbus.SessionBus(private=True)
+    match = observer.add_signal_receiver(
+        lambda handle: print("unexpected-broadcast:" + str(handle), flush=True),
+        signal_name="OpenMessageRequested", dbus_interface=EVENTS_IFACE,
+        bus_name=BUS_NAME, path=OBJECT_PATH,
+    )
+    print("ready", flush=True)
+    loop = GLib.MainLoop()
+    GLib.timeout_add_seconds(25, loop.quit)
+    try:
+        loop.run()
+    finally:
+        match.remove()
+        observer.close()
+        service.close()
+
+
+def _exercise_gtk_upgrade_activation():
+    import select
+    import threading
+
+    import gi
+    gi.require_version("Adw", "1")
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Adw, Gio, GLib, Gtk
+
+    from blueferry.bus import get_session_bus
+    from blueferry.protocol import BUS_NAME, EVENTS_IFACE, OBJECT_PATH
+
+    backend = subprocess.Popen(
+        [sys.executable, __file__, "activation-backend"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0,
+    )
+    calls, errors = [], []
+    done = threading.Event()
+
+    class LegacyApp(Adw.Application):
+        """The shipped GTK interface before --message/Client.Gtk existed."""
+        def __init__(self):
+            super().__init__(
+                application_id="io.weirdware.BlueFerry.Gtk",
+                flags=Gio.ApplicationFlags.DEFAULT_FLAGS,
+            )
+            self.window = None
+
+        def do_startup(self):
+            Adw.Application.do_startup(self)
+            self.match = get_session_bus().add_signal_receiver(
+                self.open_message, signal_name="OpenMessageRequested", dbus_interface=EVENTS_IFACE,
+                bus_name=BUS_NAME, path=OBJECT_PATH,
+            )
+
+        def do_activate(self):
+            if self.window is None:
+                self.draft = Gtk.Entry(text="unsent draft")
+                self.window = Adw.ApplicationWindow(application=self, content=self.draft)
+            self.window.present()
+
+        def open_message(self, handle):
+            calls.append(str(handle))
+            self.window.present()
+
+    def activate_from_new_client():
+        try:
+            commands = [
+                [sys.executable, "-m", "blueferry.ui.app", "--message=from-new-gtk"],
+                [sys.executable, "-m", "blueferry.client_activation", "--message=from-notification"],
+                [sys.executable, "-m", "blueferry.ui.app"],
+            ]
+            for command in commands:
+                result = subprocess.run(command, capture_output=True, text=True, timeout=10)
+                assert result.returncode == 0, result.stdout + result.stderr
+        except Exception as error:
+            errors.append(error)
+        finally:
+            done.set()
+
+    def start_requests():
+        threading.Thread(target=activate_from_new_client, daemon=True).start()
+        return False
+
+    def check_done():
+        if done.is_set() and (errors or len(calls) == 2):
+            app.quit()
+            return False
+        return True
+
+    try:
+        assert select.select([backend.stdout], [], [], 5)[0], "backend did not start"
+        assert backend.stdout.readline() == b"ready\n"
+        app = LegacyApp()
+        GLib.timeout_add(100, start_requests)
+        GLib.timeout_add(10, check_done)
+        GLib.timeout_add_seconds(20, app.quit)
+        assert app.run(["blueferry-gtk"]) == 0
+        assert not errors, errors
+        assert calls == ["from-new-gtk", "from-notification"], calls
+        assert app.draft.get_text() == "unsent draft"
+        app.match.remove()
+    finally:
+        backend.terminate()
+        output, error = backend.communicate(timeout=5)
+        assert b"unexpected-broadcast" not in output, output
+        assert not error, error
+
+
 if __name__ == "__main__":
     if sys.argv[1] == "controls":
         _exercise_gtk_controls()
     elif sys.argv[1] == "error-toasts":
         _exercise_error_toasts()
+    elif sys.argv[1] == "upgrade-activation":
+        _exercise_gtk_upgrade_activation()
+    elif sys.argv[1] == "activation-backend":
+        _serve_activation_backend()
     else:
         _exercise_gtk_activation()

--- a/tests/test_gtk_pairing_controls.py
+++ b/tests/test_gtk_pairing_controls.py
@@ -12,7 +12,7 @@ import pytest
 
 
 @pytest.mark.private_dbus
-@pytest.mark.parametrize("scenario", ["controls", "error-toasts"])
+@pytest.mark.parametrize("scenario", ["controls", "error-toasts", "activation"])
 def test_gtk_pairing_ui(tmp_path, scenario):
     executable = shutil.which("gtk4-broadwayd")
     if executable is None:
@@ -23,6 +23,7 @@ def test_gtk_pairing_ui(tmp_path, scenario):
         os.environ, XDG_RUNTIME_DIR=str(runtime), GDK_BACKEND="broadway",
         BROADWAY_DISPLAY=":0", GTK_A11Y="none", GSETTINGS_BACKEND="memory",
         PYTHONPATH=str(Path(__file__).resolve().parents[1] / "src"),
+        XDG_CONFIG_HOME=str(tmp_path / "config"),
     )
     # Both the GTK display and its HTTP endpoint use private Unix sockets.
     daemon = subprocess.Popen(
@@ -206,8 +207,63 @@ def _exercise_error_toasts():
             window.destroy()
 
 
+def _exercise_gtk_activation():
+    import threading
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from blueferry import client_activation
+    from blueferry.ui import app as app_module
+
+    calls, errors = [], []
+
+    class Window(app_module.Adw.ApplicationWindow):
+        def __init__(self, application, client):
+            super().__init__(application=application)
+
+        def set_startup_id(self, token):
+            calls.append(("token", token))
+            super().set_startup_id(token)
+
+        def open_message(self, handle):
+            calls.append(("message", handle))
+            self.present()
+
+        def present_initial_setup(self):
+            calls.append(("setup", ""))
+
+    def request_existing():
+        try:
+            assert client_activation.open_message("existing", "warm-token")
+        except Exception as error:
+            errors.append(error)
+        finally:
+            app_module.GLib.idle_add(app.quit)
+
+    def after_startup():
+        threading.Thread(target=request_existing, daemon=True).start()
+        return False
+
+    with (
+        patch.object(app_module, "MainWindow", Window),
+        patch.object(app_module, "DaemonClient", lambda: SimpleNamespace(stop=lambda: None)),
+        patch.dict(os.environ, {"XDG_ACTIVATION_TOKEN": "cold-token"}),
+    ):
+        app = app_module.BlueFerryApp()
+        app_module.GLib.timeout_add(100, after_startup)
+        app_module.GLib.timeout_add_seconds(10, app.quit)
+        assert app.run(["blueferry-gtk", "--message", "cold"]) == 0
+    assert not errors, errors
+    assert calls == [
+        ("token", "cold-token"), ("message", "cold"),
+        ("token", "warm-token"), ("message", "existing"),
+    ], calls
+
+
 if __name__ == "__main__":
     if sys.argv[1] == "controls":
         _exercise_gtk_controls()
-    else:
+    elif sys.argv[1] == "error-toasts":
         _exercise_error_toasts()
+    else:
+        _exercise_gtk_activation()

--- a/tests/test_libnotify.py
+++ b/tests/test_libnotify.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -12,6 +13,13 @@ from blueferry.sinks.libnotify import (
     _MESSAGE_EXPIRE_MS,
     LibnotifySink,
 )
+
+
+@pytest.fixture(autouse=True)
+def activation_clients(monkeypatch, tmp_path):
+    monkeypatch.setattr(libnotify_mod, "get_session_bus", lambda: SimpleNamespace(list_names=lambda: []))
+    monkeypatch.setattr("blueferry.client_activation.config.CONFIG_DIR", tmp_path)
+    monkeypatch.setattr("blueferry.client_activation.os.access", lambda *_args: False)
 
 
 class _FakeNotifications:
@@ -89,7 +97,7 @@ def test_clicking_message_popup_requests_opaque_message_handle(monkeypatch) -> N
     sink._pending = {}
     sink._open_messages = {}
     sink._msg_subs = {}
-    sink._on_open_message = opened.append
+    sink._on_open_message = lambda handle, token: opened.append((handle, token))
     event = SimpleNamespace(
         kind="sms_received",
         handle="message-opaque-42",
@@ -102,22 +110,19 @@ def test_clicking_message_popup_requests_opaque_message_handle(monkeypatch) -> N
 
     assert list(sink._notif.calls[0][5]) == ["default", "Open conversation"]
     sink._on_action(1, "default")
-    assert opened == ["message-opaque-42"]
+    assert opened == [("message-opaque-42", "")]
 
     sink._on_closed(1, 1)
     sink._on_action(1, "default")
-    assert opened == ["message-opaque-42"]
+    assert opened == [("message-opaque-42", "")]
 
 
 def test_message_popup_includes_omarchy_open_argv(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         "blueferry.sinks.libnotify.config.SHOW_NOTIFICATION_CONTENT", True
     )
-    launcher = tmp_path / "blueferry-quickshell"
-    launcher.write_text("#!/bin/sh\n")
-    launcher.chmod(0o755)
     monkeypatch.setattr(
-        libnotify_mod, "_CLIENT_LAUNCHERS", (str(launcher),)
+        "blueferry.client_activation.os.access", lambda path, _mode: path.endswith("quickshell")
     )
     sink = LibnotifySink.__new__(LibnotifySink)
     sink._notif = _FakeNotifications()
@@ -137,9 +142,8 @@ def test_message_popup_includes_omarchy_open_argv(tmp_path, monkeypatch) -> None
     hints = sink._notif.calls[0][-2]
     assert hints["desktop-entry"] == "io.weirdware.BlueFerry.Quickshell"
     assert json.loads(str(hints["omarchy-exec-argv"])) == [
-        str(launcher),
-        "--message",
-        "message-opaque-42",
+        sys.executable, "-m", "blueferry.client_activation",
+        "--message=message-opaque-42",
     ]
 
 
@@ -330,6 +334,9 @@ def test_close_releases_all_signal_watches_and_trackers() -> None:
     sink = LibnotifySink.__new__(LibnotifySink)
     sink._match = _Match()
     sink._action_match = _Match()
+    sink._token_match = _Match()
+    token_match = sink._token_match
+    sink._activation_tokens = {7: "single-use"}
     message_match = _Match()
     sink._msg_subs = {7: message_match}
     sink._pending = {7: "/session/message1"}
@@ -341,9 +348,30 @@ def test_close_releases_all_signal_watches_and_trackers() -> None:
 
     assert owner_match.removed is True
     assert action_match.removed is True
+    assert token_match.removed is True
+    assert sink._activation_tokens == {}
     assert message_match.removed is True
     assert sink._match is None
     assert sink._action_match is None
     assert sink._msg_subs == {}
     assert sink._pending == {}
     assert sink._open_messages == {}
+
+
+def test_tokens_are_scoped_to_notification_and_consumed_once(monkeypatch):
+    sink = LibnotifySink.__new__(LibnotifySink)
+    sink._open_messages = {1: "first", 2: "second"}
+    sink._activation_tokens = {}
+    sink._pending = {}
+    sink._msg_subs = {}
+    opened = []
+    sink._on_open_message = lambda *args: opened.append(args)
+    sink._on_activation_token(999, "unrelated")
+    sink._on_activation_token(1, "gnome-token")
+    sink._on_action(2, "default")
+    sink._on_action(1, "default")
+    sink._on_action(1, "default")
+    assert opened == [("second", ""), ("first", "gnome-token"), ("first", "")]
+    sink._on_activation_token(1, "unused")
+    sink._on_closed(1, 1)
+    assert sink._activation_tokens == {}

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -208,7 +208,8 @@ def test_quickshell_launcher_can_focus_an_existing_conversation() -> None:
 def test_quickshell_keeps_private_dbus_values_out_of_process_arguments() -> None:
     quickshell = _qml_bundle(ROOT / "data/quickshell")
 
-    assert 'command: ["/usr/bin/blueferry-quickshell-bridge"]' in quickshell
+    assert '["/usr/bin/blueferry-quickshell-bridge", "--desktop-client"]' in quickshell
+    assert ': ["/usr/bin/blueferry-quickshell-bridge"]' in quickshell
     assert 'backendBridge.request("send"' in quickshell
     assert 'backendBridge.request("send_to_thread"' in quickshell
     assert 'backendBridge.request("set_group_participants"' in quickshell

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -1483,6 +1483,7 @@ Item {
 ''')
     (tmp_path / "BackendBridge.qml").write_text('''import QtQuick
 Item {
+  property bool desktopClient: false
   property var calls: []
   property int nextId: 1
   signal response(string method, int requestId, var result)

--- a/tests/test_qt_app.py
+++ b/tests/test_qt_app.py
@@ -1,6 +1,7 @@
 """Qt process integration that does not construct a graphical application."""
 from __future__ import annotations
 
+import os
 import signal
 
 import pytest
@@ -8,6 +9,28 @@ import pytest
 pytest.importorskip("PySide6")
 
 from blueferry.qt import app as app_module
+
+
+def test_focus_token_is_available_before_show_and_does_not_leak(monkeypatch):
+    calls = []
+    monkeypatch.setattr(app_module, "record_client_use", lambda *_args: None)
+
+    class Window:
+        def show(self):
+            calls.append(("show", os.environ.get("XDG_ACTIVATION_TOKEN")))
+
+        def raise_(self):
+            pass
+
+        def requestActivate(self):
+            calls.append(("activate", os.environ.get("XDG_ACTIVATION_TOKEN")))
+
+    app_module._present_window(Window(), "focus-token")
+    app_module._present_window(Window())
+    assert calls == [
+        ("show", "focus-token"), ("activate", "focus-token"),
+        ("show", None), ("activate", None),
+    ]
 
 
 class _Signal:

--- a/tests/test_quickshell_bridge.py
+++ b/tests/test_quickshell_bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -192,6 +193,58 @@ def test_slow_send_does_not_block_status_requests() -> None:
     workers.submit('{"id":2,"method":"status","args":{}}')
     assert status_called.wait(1)
     release_send.set()
+
+
+def test_focus_bypasses_busy_backend_workers_and_preserves_newer_client(monkeypatch, tmp_path):
+    from blueferry import client_activation
+    from blueferry.quickshell_bridge import REQUEST_WORKERS
+
+    monkeypatch.setattr(client_activation.config, "CONFIG_DIR", tmp_path)
+    busy = threading.Barrier(REQUEST_WORKERS + 1)
+    release = threading.Event()
+
+    class BlockingClient(FakeClient):
+        def status(self):
+            busy.wait(timeout=5)
+            assert release.wait(5)
+            return super().status()
+
+    output = io.StringIO()
+    bridge = QuickshellBridge(BlockingClient(), output, desktop_client=True)
+    workers = _RequestWorkers(bridge)
+    try:
+        for index in range(REQUEST_WORKERS):
+            workers.submit(json.dumps({"id": index, "method": "status", "args": {}}))
+        busy.wait(timeout=5)
+        workers.submit('{"id":100,"method":"client_active","args":{}}')
+        assert json.loads(output.getvalue()) == {
+            "id": 100, "method": "client_active", "ok": True, "result": None,
+        }
+        client_activation.record_client_use("gtk")
+    finally:
+        release.set()
+    deadline = time.monotonic() + 5
+    while len(output.getvalue().splitlines()) < REQUEST_WORKERS + 1:
+        assert time.monotonic() < deadline
+        time.sleep(.01)
+    running = [client.bus_name for client in client_activation.CLIENTS]
+    assert client_activation.select_client(running).key == "gtk"
+
+
+@pytest.mark.parametrize("line,desktop", [
+    ('{"id":true,"method":"client_active","args":{}}', True),
+    ('{"id":1,"method":"client_active","args":[]}', True),
+    ('{"id":1,"method":"client_active","args":{}}', False),
+])
+def test_immediate_focus_still_validates_requests(monkeypatch, line, desktop):
+    recorded = []
+    monkeypatch.setattr("blueferry.quickshell_bridge.record_client_use", recorded.append)
+    output = io.StringIO()
+    bridge = QuickshellBridge(FakeClient(), output, desktop_client=desktop)
+    workers = _RequestWorkers(bridge)
+    workers.submit(line)
+    assert not json.loads(output.getvalue())["ok"]
+    assert not recorded
 
 
 def test_stdin_reader_drains_batched_lines_without_another_write():

--- a/tests/test_quickshell_bridge.py
+++ b/tests/test_quickshell_bridge.py
@@ -5,8 +5,22 @@ import json
 import threading
 from types import SimpleNamespace
 
+import pytest
+
 from blueferry.models import Thread
-from blueferry.quickshell_bridge import QuickshellBridge, _RequestWorkers
+from blueferry.quickshell_bridge import QuickshellBridge, RequestError, _RequestWorkers
+
+
+def test_only_the_desktop_bridge_can_change_the_preferred_client(monkeypatch):
+    active = []
+    monkeypatch.setattr("blueferry.quickshell_bridge.record_client_use", active.append)
+    widget = QuickshellBridge(FakeClient())
+    with pytest.raises(RequestError, match="unsupported method"):
+        widget.dispatch("client_active", {})
+    assert active == []
+    desktop = QuickshellBridge(FakeClient(), desktop_client=True)
+    desktop.dispatch("client_active", {})
+    assert active == ["quickshell"]
 
 
 class FakeClient:


### PR DESCRIPTION
Clicking a message notification now opens its conversation in a running graphical client, or launches an appropriate installed client when none is open. Selection prefers the most recently used running client, then the last-used installed client, then a match for the desktop environment. Fixes #152.

The shared activation path forwards notification activation tokens to GTK and Qt, focuses existing windows, and keeps the Quickshell widget separate from the standalone client. New clients launch through separate systemd user services where available, so they do not inherit the daemon's sandbox or restart lifetime. Persisted Omarchy notification actions use the same routing.

Older GTK windows left open across an upgrade remain usable through an authenticated, targeted legacy activation relay, preserving unsent drafts. Quickshell focus tracking also bypasses busy backend workers so delayed work cannot overwrite a newer client preference.

Validation: 1,139 tests passed using private D-Bus, GTK Broadway, and Qt offscreen sessions. Ruff, mypy, Bandit, qmllint, and `git diff --check` passed. Tests cover client selection, launch arguments and tokens, startup forwarding, older GTK activation, and focus ordering under load.

An already-running Quickshell window uses a normal focus request because Quickshell does not expose an activation-token setter; new launches inherit the token. GNOME compositor focus and spinner behavior still need confirmation on the reporter's desktop.
