### PR TITLE
Support ANCS on legacy BlueZ without per-bearer controls

### DIFF
--- a/data/quickshell/SetupController.qml
+++ b/data/quickshell/SetupController.qml
@@ -275,7 +275,7 @@ QtObject {
         notificationsSupported = data.notifications_supported === true
         ancsLimitedController = data.ancs_limited_controller === true
         controllerVendor = String(data.controller_vendor || "")
-        bluezActive = data.bearer_api_active === true
+        bluezActive = (data.experimental ?? data.bearer_api_active) === true
         adapterName = String(data.adapter || adapterName)
         adapters = Array.isArray(data.adapters) ? data.adapters : []
         compatibilityLoaded = true

--- a/packaging/deb/README.md
+++ b/packaging/deb/README.md
@@ -31,7 +31,11 @@ so the bundle cannot replace or conflict with `python3-textual`.
 The backend intentionally leaves the distribution's `bluetooth.service`
 unchanged: installing, upgrading, or removing the DEB never enables `-E` or
 restarts Bluetooth. MAP messages and PBAP contacts work with the package's
-BlueZ 5.72 minimum. ANCS notifications are available only when the machine
-already has BlueZ 5.86 or newer and its running `bluetoothd` exposes the
-experimental bearer API through `-E` or `--experimental`; otherwise BlueFerry
-automatically stays in MAP/PBAP-only mode.
+BlueZ 5.72 minimum. ANCS notifications also require the running `bluetoothd`
+to enable experimental support through `-E` or `--experimental`. BlueZ 5.86
+and newer provide per-bearer connection monitoring and recovery. On older
+BlueZ, BlueFerry waits for the iPhone's solicited LE connection and verifies
+ANCS through a content-free GATT request/response. It retries failed GATT
+requests without disconnecting Classic or cancelling pending notification
+registrations. Without experimental support, BlueFerry automatically stays
+in MAP/PBAP-only mode.

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -604,6 +604,13 @@ class AncsClient:
         elif uuid == CONTROL_POINT_CHAR:
             self._cp_path = path_s
             log.info("ANCS Control Point found:       %s", path_s)
+        if self._legacy_connected and self._transport_blocked:
+            # Removal cancels the old retry. Once all characteristics return,
+            # resume bounded GATT probes without requiring an LE state change
+            # that legacy BlueZ cannot report. Native recovery still waits for
+            # its monitored bearer to cycle.
+            self._schedule_subscribe_retry()
+            return
         self._try_subscribe()
 
     def _on_iface_removed(self, path, ifaces):

--- a/src/blueferry/ancs/client.py
+++ b/src/blueferry/ancs/client.py
@@ -69,6 +69,8 @@ AUTHORIZATION_RETRY_SECONDS = 5
 MANAGER_RETRY_SECONDS = 2
 BEARER_SETTLE_SECONDS = 2
 TRANSPORT_RESET_SECONDS = 15
+LEGACY_RETRY_CAP_SECONDS = 60
+LEGACY_HEALTH_SECONDS = 60
 
 _BLUEZ_BUS_NAME = "org.bluez"
 _DBUS_BUS_NAME = "org.freedesktop.DBus"
@@ -171,9 +173,12 @@ class AncsClient:
         # evidence that the rebuilt GATT transport is stale.
         self._was_authorized = previously_authorized
         self._bearer_connected: bool | None = None
+        self._legacy_connected = False
+        self._legacy_retry_delay = SUBSCRIBE_RETRY_SECONDS
         self._bearer_ready = False
         self._transport_blocked = False
         self._owned_notify_paths: set[str] = set()
+        self._subscription_generation = 0
 
         # In-flight per-notification attribute requests + app-name cache
         self._app_name_cache: OrderedDict[str, str] = OrderedDict()
@@ -201,6 +206,7 @@ class AncsClient:
         self._authorization_retry_id: int | None = None
         self._bearer_settle_id: int | None = None
         self._transport_reset_id: int | None = None
+        self._legacy_health_id: int | None = None
         self._started = False
 
     # ---- lifecycle ------------------------------------------------------
@@ -230,7 +236,7 @@ class AncsClient:
             except Exception:
                 log.debug("could not remove partial BlueZ owner watch", exc_info=True)
             raise
-        if self._bearer_connected is True:
+        if self._transport_available:
             self._schedule_bearer_settle()
 
     def _bind_manager_and_rescan(self) -> None:
@@ -334,6 +340,8 @@ class AncsClient:
             self._cancel_subscribe_retry()
             self._clear_characteristic_subscription(stop_notify=False)
             self._bearer_connected = None
+            self._legacy_connected = False
+            self._legacy_retry_delay = SUBSCRIBE_RETRY_SECONDS
             self._bearer_ready = False
             self._transport_blocked = False
             self._owned_notify_paths.clear()
@@ -398,33 +406,54 @@ class AncsClient:
         return self._authorized
 
     @property
+    def _transport_available(self) -> bool:
+        return self._bearer_connected is True or self._legacy_connected
+
+    @property
     def connected(self) -> bool:
         # StartNotify only proves that BlueZ subscribed to the GATT
         # characteristics. iOS notification access is usable only after an
         # authorized Control Point round trip succeeds.
         return (
-            self._bearer_connected is True
+            self._transport_available
             and self._bearer_ready
             and not self._transport_blocked
             and self.subscribed
             and self.authorized
         )
 
-    def observe_bearer_state(self, connected: bool | None) -> None:
+    def observe_bearer_state(
+        self, connected: bool | None, *, legacy_connected: bool = False,
+    ) -> None:
         """Invalidate stale GATT state and rebuild it after an LE reconnect.
 
         BlueZ retains ANCS characteristic objects, and sometimes their
         ``Notifying`` property, across a physical LE disconnect. ObjectManager
         removal alone therefore cannot define the subscription lifecycle.
+
+        ``legacy_connected`` means Device1 is connected and the LE bearer API
+        is absent. It permits GATT probes; only an ANCS response proves LE up.
         """
-        if connected is None:
+        legacy_changed = self._legacy_connected != legacy_connected
+        self._legacy_connected = legacy_connected
+        if legacy_changed:
+            self._cancel_subscribe_retry()
+            self._cancel_bearer_settle()
+            self._cancel_transport_reset()
+            self._clear_characteristic_subscription(stop_notify=False)
+            self._bearer_ready = False
+            self._transport_blocked = False
+            self._legacy_retry_delay = SUBSCRIBE_RETRY_SECONDS
+            if self.on_status is not None:
+                self.on_status()
+        if connected is None and not legacy_connected:
             self._bearer_connected = None
             self._bearer_ready = False
             self._cancel_bearer_settle()
             return
         previous = self._bearer_connected
         self._bearer_connected = connected
-        if not connected:
+        if not self._transport_available:
             self._bearer_ready = False
             self._cancel_bearer_settle()
             self._cancel_transport_reset()
@@ -449,7 +478,7 @@ class AncsClient:
                 self.on_status()
             return
 
-        if previous is True:
+        if previous is True and not legacy_changed:
             return
         if previous is False:
             log.info("iPhone LE bearer reconnected; rebuilding ANCS subscription")
@@ -459,7 +488,7 @@ class AncsClient:
             self._schedule_bearer_settle()
 
     def _schedule_bearer_settle(self) -> None:
-        if self._bearer_settle_id is not None or self._bearer_connected is not True:
+        if self._bearer_settle_id is not None or not self._transport_available:
             return
         self._bearer_settle_id = self._schedule(
             BEARER_SETTLE_SECONDS,
@@ -468,7 +497,7 @@ class AncsClient:
 
     def _finish_bearer_settle(self) -> bool:
         self._bearer_settle_id = None
-        if not self._started or self._bearer_connected is not True:
+        if not self._started or not self._transport_available:
             return False
         self._bearer_ready = True
         self._try_subscribe()
@@ -484,14 +513,18 @@ class AncsClient:
         self._bearer_settle_id = None
 
     def _mark_transport_failed(self) -> None:
-        """Latch a stale GATT transport until LE genuinely cycles."""
+        """Reset a monitored bearer, or back off GATT probes on legacy BlueZ."""
         was_connected = self.connected
         self._transport_blocked = True
         self._bearer_ready = False
         self._cancel_bearer_settle()
         self._cancel_subscribe_retry()
         self._clear_characteristic_subscription(stop_notify=False)
-        if (
+        if self._legacy_connected:
+            # No targeted reset exists here. Keep CCC ownership intact and
+            # allow BlueZ to finish or restore its registrations on inbound LE.
+            self._schedule_subscribe_retry()
+        elif (
             self._started
             and self._bearer_connected is True
             and self._on_transport_failure is not None
@@ -590,7 +623,9 @@ class AncsClient:
 
     def _clear_characteristic_subscription(self, *, stop_notify: bool = True) -> None:
         """Remove receivers and notification ownership before rediscovery."""
+        self._subscription_generation += 1
         self._cancel_authorization_retry()
+        self._cancel_legacy_health()
         for match in self._characteristic_signal_matches:
             try:
                 match.remove()
@@ -633,21 +668,26 @@ class AncsClient:
     def _try_subscribe(self) -> None:
         if self._notify_started:
             return
-        if self._transport_blocked:
+        if self._transport_blocked or self._subscribe_retry_id is not None:
             return
         # BlueZ keeps bonded ANCS objects after ATT drops. StartNotify/CP on
         # those objects returns Not connected / No ATT transport and never
         # reaches iOS, so the notification-access prompt does not appear.
-        if self._bearer_connected is not True or not self._bearer_ready:
+        if not self._transport_available or not self._bearer_ready:
             return
         if not (self._ns_path and self._ds_path and self._cp_path):
             return
         generation = self._bluez_owner_generation
+        subscription_generation = self._subscription_generation
         ns_path = self._ns_path
         ds_path = self._ds_path
 
         def current_attempt() -> bool:
-            return self._started and generation == self._bluez_owner_generation
+            return (
+                self._started
+                and generation == self._bluez_owner_generation
+                and subscription_generation == self._subscription_generation
+            )
 
         def remove_attempt_matches(matches) -> None:
             for match in matches:
@@ -688,14 +728,14 @@ class AncsClient:
             )
             if self._should_start_notify(ns_path):
                 ns.StartNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
-                if current_attempt():
+                if generation == self._bluez_owner_generation and ns_path == self._ns_path:
                     self._owned_notify_paths.add(ns_path)
             if not current_attempt():
                 remove_attempt_matches(matches)
                 return
             if self._should_start_notify(ds_path):
                 ds.StartNotify(timeout=DBUS_CALL_TIMEOUT_SECONDS)
-                if current_attempt():
+                if generation == self._bluez_owner_generation and ds_path == self._ds_path:
                     self._owned_notify_paths.add(ds_path)
         except dbus.exceptions.DBusException as e:
             if not current_attempt():
@@ -763,14 +803,18 @@ class AncsClient:
             or not (self._ns_path and self._ds_path and self._cp_path)
         ):
             return
-        self._subscribe_retry_id = self._schedule(
-            SUBSCRIBE_RETRY_SECONDS,
-            self._retry_subscribe,
-        )
+        delay = SUBSCRIBE_RETRY_SECONDS
+        if self._legacy_connected:
+            delay = self._legacy_retry_delay
+            self._legacy_retry_delay = min(delay * 2, LEGACY_RETRY_CAP_SECONDS)
+        self._subscribe_retry_id = self._schedule(delay, self._retry_subscribe)
 
     def _retry_subscribe(self) -> bool:
         self._subscribe_retry_id = None
         if self._started:
+            if self._legacy_connected:
+                self._transport_blocked = False
+                self._bearer_ready = True
             self._try_subscribe()
         return False
 
@@ -783,8 +827,8 @@ class AncsClient:
             log.debug("could not remove ANCS subscription retry", exc_info=True)
         self._subscribe_retry_id = None
 
-    def _queue_authorization_probe(self) -> None:
-        if not self._notify_started or self._authorized:
+    def _queue_authorization_probe(self, *, health_check: bool = False) -> None:
+        if not self._notify_started or (self._authorized and not health_check):
             return
         request = _PendingRequest(
             key="authorization",
@@ -831,6 +875,8 @@ class AncsClient:
         self._authorization_retry_id = None
 
     def _mark_authorized(self) -> None:
+        self._legacy_retry_delay = SUBSCRIBE_RETRY_SECONDS
+        self._schedule_legacy_health()
         if self._authorized:
             return
         self._authorized = True
@@ -840,11 +886,36 @@ class AncsClient:
         if self.on_status is not None:
             self.on_status()
 
+    def _schedule_legacy_health(self) -> None:
+        # Device1 can stay connected through Classic after LE disappears. A
+        # content-free round trip prevents retaining an obsolete ANCS success.
+        if self._started and self._legacy_connected and self._legacy_health_id is None:
+            self._legacy_health_id = self._schedule(
+                LEGACY_HEALTH_SECONDS, self._check_legacy_health,
+            )
+
+    def _check_legacy_health(self) -> bool:
+        self._legacy_health_id = None
+        if self._started and self._legacy_connected and self._authorized:
+            self._queue_authorization_probe(health_check=True)
+            if self._authorized:
+                self._schedule_legacy_health()
+        return False
+
+    def _cancel_legacy_health(self) -> None:
+        if self._legacy_health_id is not None:
+            self._cancel(self._legacy_health_id)
+            self._legacy_health_id = None
+
     # ---- Notification Source: new/modified/removed events --------------
 
     def _on_ns_changed(self, iface, changed, _invalidated):
         if iface != "org.bluez.GattCharacteristic1":
             return
+        if self._legacy_connected and changed.get("Notifying") is not None:
+            if not changed["Notifying"]:
+                self._mark_transport_failed()
+                return
         value = changed.get("Value")
         if value is None:
             return
@@ -936,7 +1007,9 @@ class AncsClient:
             name = error.get_dbus_name() or type(error).__name__
             detail = error.get_dbus_message() or str(error)
             log.warning("ANCS CP WriteValue failed: %s: %s", name, detail)
-            if _connection_was_lost(error):
+            if _connection_was_lost(error) or (
+                self._legacy_connected and request.authorization_probe
+            ):
                 self._mark_transport_failed()
                 return
             self._abandon_request(request)
@@ -957,10 +1030,12 @@ class AncsClient:
             request.assembler.command if request else "none",
         )
         self._request_timeout_id = None
-        if request is not None and request.authorization_probe and self._was_authorized:
+        if (
+            request is not None and request.authorization_probe
+            and (self._was_authorized or self._legacy_connected)
+        ):
             log.warning(
-                "previously authorized ANCS transport stopped responding; "
-                "resetting the LE bearer"
+                "ANCS authorization probe stopped responding; recovering the transport"
             )
             # A completed Control Point write followed by silence can mean
             # BlueZ retained dead CCC registrations despite Notifying=true.
@@ -1016,6 +1091,10 @@ class AncsClient:
     def _on_ds_changed(self, iface, changed, _invalidated):
         if iface != "org.bluez.GattCharacteristic1":
             return
+        if self._legacy_connected and changed.get("Notifying") is not None:
+            if not changed["Notifying"]:
+                self._mark_transport_failed()
+                return
         value = changed.get("Value")
         if value is None:
             return

--- a/src/blueferry/bearer_supervisor.py
+++ b/src/blueferry/bearer_supervisor.py
@@ -97,7 +97,10 @@ def bearer_connected_unavailable(error: Exception) -> bool:
     }:
         return True
     detail = (error.get_dbus_message() or "").casefold()
-    return "no such property" in detail and "connected" in detail
+    return (
+        ("no such property" in detail and "connected" in detail)
+        or "no such interface" in detail
+    )
 
 
 ReadConnected = Callable[[str], bool | None]
@@ -152,6 +155,10 @@ class BearerSupervisor:
         self._cancel = cancel
         self._clock = clock
         self._le_enabled = le_enabled
+        # Missing bearer APIs are different from a transient failed read.
+        # Recheck them: BlueZ can add per-device interfaces after discovery.
+        self._le_api_available: bool | None = None
+        self._legacy_device_connected = False
         self._timer_id: int | None = None
         self._le_settle_id: int | None = None
         self._running = False
@@ -198,6 +205,14 @@ class BearerSupervisor:
     def le_state(self) -> bool | None:
         """Return the latest observed LE bearer state."""
         return self._states["le"]
+
+    @property
+    def legacy_connected(self) -> bool:
+        """Allow GATT probing when only aggregate Device1 state is available.
+
+        This is permission to try ANCS, not evidence of an LE connection.
+        """
+        return self._le_api_available is False and self._legacy_device_connected
 
     def start(self) -> None:
         if self._running:
@@ -258,6 +273,8 @@ class BearerSupervisor:
         """Forget callbacks and observations owned by the previous daemon."""
         previous = dict(self._states)
         self._generation += 1
+        self._le_api_available = None
+        self._legacy_device_connected = False
         self._connecting.clear()
         self._connect_request_ids.clear()
         self._connect_targeted.clear()
@@ -286,7 +303,7 @@ class BearerSupervisor:
 
     def recover_le_transport(self) -> None:
         """Request one serialized LE reset after GATT and bearer state diverge."""
-        if not self._running:
+        if not self._running or self._le_api_available is False:
             return
         # A successful reset is published locally as disconnected before the
         # polling source can see a replacement inbound link. Ignore duplicate
@@ -309,6 +326,7 @@ class BearerSupervisor:
 
     def stop(self) -> None:
         self._running = False
+        self._legacy_device_connected = False
         self._generation += 1
         self._connecting.clear()
         self._connect_request_ids.clear()
@@ -346,13 +364,7 @@ class BearerSupervisor:
             return False
 
         log.debug("probing iPhone BR/EDR and LE bearer state")
-        bredr = self._read("bredr")
-        le = self._read("le")
-        self._update_state("bredr", bredr)
-        # The profile gate controls BlueFerry's outbound LE requests, not links
-        # initiated by the phone. Publishing an inbound link lets ANCS perform
-        # its authorization handshake while Classic recovers independently.
-        self._update_state("le", le)
+        bredr, le = self._refresh_states()
 
         if self._le_reset_pending and self._le_enabled:
             if le is False:
@@ -379,7 +391,11 @@ class BearerSupervisor:
         return True
 
     def _schedule_le_connect(self) -> None:
-        if self._le_settle_id is not None or self._le_dial_exhausted():
+        if (
+            self._le_api_available is False
+            or self._le_settle_id is not None
+            or self._le_dial_exhausted()
+        ):
             return
         log.info(
             "iPhone BR/EDR connected; allowing %ds to settle before LE",
@@ -394,11 +410,11 @@ class BearerSupervisor:
         self._le_settle_id = None
         if not self._running:
             return False
-        bredr = self._read("bredr")
-        le = self._read("le")
-        self._update_state("bredr", bredr)
-        self._update_state("le", le)
-        if bredr is True and le is False and self._le_enabled:
+        bredr, le = self._refresh_states()
+        if (
+            bredr is True and le is False and self._le_enabled
+            and self._le_api_available is not False
+        ):
             # The handoff may have failed when LE was enabled or when this
             # timer was armed. Retry at the last safe point before the
             # targeted dial; a transient Set failure must not suppress the
@@ -410,6 +426,26 @@ class BearerSupervisor:
             self._request_connect("bredr")
         return False
 
+    def _refresh_states(self) -> tuple[bool | None, bool | None]:
+        bredr = self._read("bredr")
+        self._update_state("bredr", bredr)
+        return bredr, self._refresh_le_state()
+
+    def _refresh_le_state(self) -> bool | None:
+        previous_le = self.le_state
+        previous_legacy = self.legacy_connected
+        le = self._read("le")
+        self._update_state("le", le)
+        # Discovery of a missing API can leave LE unknown -> unknown. ANCS
+        # still needs the newly available aggregate connection observation.
+        if (
+            previous_le == le
+            and previous_legacy != self.legacy_connected
+            and self._on_le_state is not None
+        ):
+            self._on_le_state(le)
+        return le
+
     def _cancel_le_settle(self) -> None:
         if self._le_settle_id is None:
             return
@@ -420,6 +456,8 @@ class BearerSupervisor:
         self._le_settle_id = None
 
     def _read(self, kind: str) -> bool | None:
+        if kind == "le":
+            self._legacy_device_connected = False
         try:
             return self._read_connected(kind)
         except dbus.exceptions.DBusException as error:
@@ -617,7 +655,7 @@ class BearerSupervisor:
                     # state so an inbound link supersedes this untyped request
                     # with Bearer.BREDR1.Connect instead of creating a false
                     # Classic success and quiet window.
-                    self._update_state("le", self._read("le"))
+                    self._refresh_le_state()
                     if not self._connect_request_is_current(
                         kind,
                         generation,
@@ -769,6 +807,8 @@ class BearerSupervisor:
         return BACKOFF_CAP_SECONDS
 
     def _request_le_disconnect(self, *, force: bool = False) -> None:
+        if self._le_api_available is False:
+            return
         if "le" in self._disconnecting:
             return
         if not force and self._clock() < self._next_le_reset_attempt:
@@ -855,7 +895,22 @@ class BearerSupervisor:
                         timeout=5.0,
                     )
                 )
-        return bool(properties.Get(_INTERFACES[kind], "Connected", timeout=5.0))
+        try:
+            connected = bool(properties.Get(_INTERFACES[kind], "Connected", timeout=5.0))
+        except dbus.exceptions.DBusException as error:
+            if not bearer_connected_unavailable(error):
+                raise
+            if self._le_api_available is not False:
+                log.info("BlueZ has no LE bearer state; ANCS will verify its GATT transport")
+            self._le_api_available = False
+        else:
+            self._le_api_available = True
+            return connected
+        self._legacy_device_connected = bool(
+            properties.Get("org.bluez.Device1", "Connected", timeout=5.0)
+        )
+        # Aggregate false rules out LE; aggregate true might be Classic only.
+        return None if self._legacy_device_connected else False
 
     def _connect_bluez(
         self,

--- a/src/blueferry/bluetooth_capabilities.py
+++ b/src/blueferry/bluetooth_capabilities.py
@@ -442,8 +442,9 @@ def _profile_fields(
     supported: set[str],
     current: set[str],
     command_error: str,
-    bearer_active: bool,
+    experimental_active: bool,
     bearer_supported: bool,
+    notifications_configurable: bool,
 ) -> dict[str, object]:
     classic = bool({"br/edr", "bredr"} & supported)
     low_energy = "le" in supported
@@ -452,7 +453,8 @@ def _profile_fields(
     # MAP/PBAP carry data over Classic, but iOS exposes their permissions only
     # after LE solicitation. Compatibility mode still needs that advertisement.
     messages_supported = available and classic and secure_pairing and low_energy and advertising
-    notifications_supported = messages_supported and bearer_supported
+    # Legacy BlueZ can expose ANCS GATT without the newer bearer controls.
+    notifications_supported = messages_supported and notifications_configurable
     missing = [
         label for present, label in (
             (classic, "Bluetooth Classic (BR/EDR)"),
@@ -470,7 +472,7 @@ def _profile_fields(
             "with LE advertising to enable iPhone messages and contacts. "
             "Use a compatible adapter."
         )
-    elif notifications_supported and not bearer_active:
+    elif notifications_supported and not experimental_active:
         issue = "Bluetooth support must be activated before pairing"
     elif not notifications_supported:
         issue = "Messages and contacts are supported; per-app notifications are not"
@@ -488,7 +490,7 @@ def _profile_fields(
         "messages_supported": messages_supported,
         "notifications_supported": notifications_supported,
         "bearer_api_supported": bearer_supported,
-        "bearer_api_active": bearer_active,
+        "bearer_api_active": experimental_active and bearer_supported,
         # A failed probe is inconclusive (#28); only confirmed missing
         # capabilities prevent pairing (#143).
         "pairing_ready": not available or messages_supported,
@@ -533,12 +535,12 @@ def compatibility(
         support = support_status()
     except PairingError:
         support = {}
-    bearer_active = bool(support.get("active"))
-    bearer_configurable = bearer_active or bool(support.get("packaged_drop_in"))
-    stack = bluez_stack(run_command=run_command, experimental=bearer_active)
+    experimental_active = bool(support.get("active"))
+    experimental_configurable = experimental_active or bool(support.get("packaged_drop_in"))
+    stack = bluez_stack(run_command=run_command, experimental=experimental_active)
     bearer_supported = (
         bluez_bearer_api_supported(stack.get("bluez_version"))
-        and bearer_configurable
+        and experimental_configurable
     )
     options: list[dict[str, object]] = []
     inspected: dict[str, tuple] = {}
@@ -561,8 +563,9 @@ def compatibility(
             supported,
             current,
             error,
-            bearer_active and bearer_supported,
+            experimental_active,
             bearer_supported,
+            experimental_configurable,
         )
         options.append(
             {

--- a/src/blueferry/bluez_setup.py
+++ b/src/blueferry/bluez_setup.py
@@ -5,8 +5,8 @@ the Linux side:
 
 1. Adapter Class-of-Device set to A/V Hands-Free (Major=4 Minor=8).
 2. A connectable, discoverable BLE peripheral advert is active with
-   SolicitUUIDs containing the ANCS UUID.  The small manufacturer/service
-   payloads keep the advertisement visible to iOS during first pairing.
+   SolicitUUIDs containing the ANCS UUID, with a small manufacturer payload
+   retained from the working first-pairing flow.
 3. Adapter is powered.
 
 This module owns those three concerns. Class-of-Device changes run through a
@@ -146,11 +146,10 @@ def set_cod(
 class _AncsAdvert(dbus.service.Object):
     """LEAdvertisement1 object shaped like a real ANCS accessory.
 
-    SolicitUUIDs is the meaningful protocol field.  The otherwise inert
-    manufacturer/service payloads mirror the working ancs4linux pairing flow:
+    SolicitUUIDs is the meaningful protocol field. The otherwise inert
+    manufacturer payload is retained from the working ancs4linux pairing flow:
     some iOS/controller combinations ignored the solicitation-only advert
-    during first pairing.  0xffff and 0x9999 are explicitly test/private IDs;
-    they do not impersonate a hardware vendor or service.
+    during first pairing. The payload fits in a legacy advertising packet.
     """
 
     PATH = config.BLE_ADVERT_DBUS_PATH
@@ -179,12 +178,10 @@ class _AncsAdvert(dbus.service.Object):
                     signature="y", variant_level=1,
                 ),
             }, signature="qv"),
-            "ServiceData": dbus.Dictionary({
-                "00009999-0000-1000-8000-00805f9b34fb": dbus.Array(
-                    [dbus.Byte(v) for v in (0x9E, 0x85, 0x39, 0x96)],
-                    signature="y", variant_level=1,
-                ),
-            }, signature="sv"),
+            # Legacy advertising has 31 bytes: solicitation uses 18, the
+            # manufacturer field 8, and flags 3. Dummy ServiceData and the
+            # optional tx-power include would overflow that budget. LocalName
+            # goes in the separate scan response on this advertising type.
             # Scoped to this advertisement rather than making the whole
             # adapter permanently discoverable.  Three minutes is enough for
             # a deliberate first-pair operation; ANCS solicitation remains
@@ -192,7 +189,6 @@ class _AncsAdvert(dbus.service.Object):
             "Discoverable": dbus.Boolean(True),
             "DiscoverableTimeout": dbus.UInt16(180),
             "LocalName": dbus.String(config.BLE_ADVERT_LOCAL_NAME),
-            "Includes": dbus.Array(["tx-power"], signature="s"),
         }
 
     @dbus.service.method("org.freedesktop.DBus.Properties",

--- a/src/blueferry/daemon.py
+++ b/src/blueferry/daemon.py
@@ -173,7 +173,9 @@ class Daemon:
         if connected is not True:
             self.solicitation.set_needed(True)
         if self.ancs is not None:
-            self.ancs.observe_bearer_state(connected)
+            self.ancs.observe_bearer_state(
+                connected, legacy_connected=self.bearers.legacy_connected,
+            )
 
     def _on_ancs_status(self) -> None:
         # StartNotify is not the success boundary.  Keep solicitation on air
@@ -349,7 +351,10 @@ class Daemon:
                 ),
             )
             try:
-                candidate.observe_bearer_state(self.bearers.le_state)
+                candidate.observe_bearer_state(
+                    self.bearers.le_state,
+                    legacy_connected=self.bearers.legacy_connected,
+                )
                 candidate.start()
             except Exception:
                 candidate.stop()
@@ -491,6 +496,9 @@ class Daemon:
             "ancs_subscribed": bool(ancs and ancs.subscribed),
             "ancs_authorized": bool(ancs and ancs.authorized),
             **self.bearers.snapshot(),
+            # Legacy BlueZ has no LE Connected property. ANCS itself can
+            # prove LE usable without inventing a native bearer transition.
+            "le": self.bearers.le_connected or bool(ancs and ancs.connected),
             "contacts": self.contacts.count(),
             "events": history_count(storage=self.storage),
             "verified_iphone_setup": list(self.setup_verification.verified),

--- a/src/blueferry/onboarding.py
+++ b/src/blueferry/onboarding.py
@@ -9,6 +9,7 @@ from typing import Any, Protocol
 
 from blueferry.i18n import _
 from blueferry.models import BackendStatus
+from blueferry.pairing_policy import experimental_support_active
 from blueferry.setup_verification import remaining_iphone_setup_tasks
 
 ANCS_REPAIR_HINT = _(
@@ -157,7 +158,10 @@ def derive_stage(
         return OnboardingStage.CHECKING
     if compatibility.get("pairing_ready") is False:
         return OnboardingStage.INCOMPATIBLE
-    if compatibility.get("notifications_supported") and not compatibility.get("bearer_api_active"):
+    if (
+        compatibility.get("notifications_supported")
+        and not experimental_support_active(compatibility)
+    ):
         return OnboardingStage.ACTIVATE_BLUETOOTH
     if not configured:
         return OnboardingStage.SELECT_DEVICE

--- a/src/blueferry/pair_setup.py
+++ b/src/blueferry/pair_setup.py
@@ -22,7 +22,11 @@ from blueferry.bluetooth_devices import PairedDevice
 from blueferry.bus import get_session_bus, get_system_bus
 from blueferry.commands import run_command
 from blueferry.errors import CommandError, PairingError
-from blueferry.pairing_policy import PairingPolicy, resolve_pairing_policy
+from blueferry.pairing_policy import (
+    PairingPolicy,
+    experimental_support_active,
+    resolve_pairing_policy,
+)
 from blueferry.pairing_types import PairingAttempt, PairingOutcome, PairingTransports
 from blueferry.private_files import atomic_write_private_text, read_private_text
 from blueferry.setup_verification import clear_setup_verification
@@ -949,6 +953,7 @@ _COMPATIBILITY_REPORT_KEYS = (
     "notifications_supported",
     "bearer_api_supported",
     "bearer_api_active",
+    "experimental",
     "supported_settings",
     "current_settings",
     "manufacturer_id",
@@ -1072,7 +1077,7 @@ def _controller_snapshot(adapter: str, compatibility: dict) -> dict:
             controller.update(
                 capabilities.bluez_stack(
                     run_command=run_command,
-                    experimental=compatibility.get("bearer_api_active"),
+                    experimental=experimental_support_active(compatibility),
                     timeout=2,
                 )
             )
@@ -1201,7 +1206,7 @@ def _prepare_pairing(
         "enabled" if policy.solicitation_enabled else "unavailable",
         policy.reason,
     )
-    if policy.ancs_enabled and not compatibility["bearer_api_active"]:
+    if policy.ancs_enabled and not experimental_support_active(compatibility):
         raise PairingError(
             "Activate Bluetooth support before pairing or re-pairing the iPhone"
         )

--- a/src/blueferry/pairing_cli.py
+++ b/src/blueferry/pairing_cli.py
@@ -167,7 +167,7 @@ def run_wizard(
     if (
         not effective_compatibility_mode
         and compatibility.notifications_supported
-        and not compatibility.bearer_api_active
+        and not compatibility.experimental
     ):
         if not typer.confirm(
             "Activate Bluetooth support? This briefly disconnects Bluetooth devices.",

--- a/src/blueferry/pairing_policy.py
+++ b/src/blueferry/pairing_policy.py
@@ -8,6 +8,11 @@ from enum import Enum
 from typing import Any
 
 
+def experimental_support_active(compatibility: Mapping[str, Any]) -> bool:
+    """Read bluetoothd's -E state, accepting replies from older backends."""
+    return bool(compatibility.get("experimental", compatibility.get("bearer_api_active", False)))
+
+
 class PairingMode(str, Enum):
     """End-to-end behavior selected for one iPhone bond."""
 

--- a/src/blueferry/qt/controller.py
+++ b/src/blueferry/qt/controller.py
@@ -154,6 +154,7 @@ class BridgeController(QObject):
             "messages_supported": False,
             "notifications_supported": False,
             "bearer_api_active": False,
+            "experimental": False,
             "pairing_ready": True,
             "issue": message,
             "adapters": [],
@@ -359,7 +360,7 @@ class BridgeController(QObject):
             self._compatibility = compatibility.to_dict()
             self._configuration = configuration
             self._setup_loaded = True
-            self._bluetooth_active = compatibility.bearer_api_active
+            self._bluetooth_active = compatibility.experimental
             self.compatibilityChanged.emit()
             self.configuredChanged.emit()
             self.setupLoadedChanged.emit()
@@ -392,7 +393,7 @@ class BridgeController(QObject):
         def completed(value: object) -> None:
             compatibility = value
             self._compatibility = compatibility.to_dict()
-            self._bluetooth_active = bool(getattr(compatibility, "bearer_api_active", False))
+            self._bluetooth_active = compatibility.experimental
             self.compatibilityChanged.emit()
             self.bluetoothChanged.emit()
             self._update_onboarding_stage()

--- a/src/blueferry/setup_client.py
+++ b/src/blueferry/setup_client.py
@@ -16,6 +16,7 @@ from typing import IO, Any
 from blueferry import pair_setup, quirks_report
 from blueferry.bluetooth_devices import PairedDevice
 from blueferry.errors import PairingError
+from blueferry.pairing_policy import experimental_support_active
 from blueferry.pairing_types import PairingOutcome
 
 DISCOVERY_SECONDS = pair_setup.DISCOVERY_SECONDS
@@ -205,6 +206,7 @@ class BluetoothCompatibility:
     controller_vendor: str = ""
     ancs_limited_controller: bool = False
     explicit_pairing_default: bool = False
+    experimental: bool = False
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> BluetoothCompatibility:
@@ -221,6 +223,7 @@ class BluetoothCompatibility:
             messages_supported=bool(value.get("messages_supported", False)),
             notifications_supported=bool(value.get("notifications_supported", False)),
             bearer_api_active=bool(value.get("bearer_api_active", False)),
+            experimental=experimental_support_active(value),
             pairing_ready=bool(value.get("pairing_ready", False)),
             issue=str(value.get("issue", "")),
             supported_settings=tuple(

--- a/src/blueferry/ui/status.py
+++ b/src/blueferry/ui/status.py
@@ -470,7 +470,7 @@ class IPhonePage(Gtk.Box):
             )
 
     def _apply_bluetooth_support_status(self, compatibility) -> None:
-        active = compatibility.bearer_api_active
+        active = compatibility.experimental
         compatibility_mode = self._compatibility_switch.get_active()
         if compatibility_mode:
             self._bluez_row.set_subtitle(

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -677,7 +677,9 @@ def test_previously_authorized_subscription_waits_for_a_settled_bearer(
     ]
 
 
-def test_partial_start_notify_failure_reuses_live_subscription(monkeypatch) -> None:
+@pytest.mark.parametrize("error_name", ["org.bluez.Error.Failed", "org.bluez.Error.InProgress"])
+@pytest.mark.parametrize("legacy", [False, True])
+def test_partial_start_notify_failure_reuses_live_subscription(monkeypatch, error_name, legacy) -> None:
     scheduled = []
 
     class _Characteristic:
@@ -697,7 +699,7 @@ def test_partial_start_notify_failure_reuses_live_subscription(monkeypatch) -> N
                 self.fail_once = False
                 raise client_module.dbus.exceptions.DBusException(
                     "not ready",
-                    name="org.bluez.Error.Failed",
+                    name=error_name,
                 )
             self.notifying = True
 
@@ -727,7 +729,8 @@ def test_partial_start_notify_failure_reuses_live_subscription(monkeypatch) -> N
         schedule=lambda delay, callback: scheduled.append((delay, callback)) or 7,
     )
     client._started = True
-    client._bearer_connected = True
+    client._bearer_connected = None if legacy else True
+    client._legacy_connected = legacy
     client._bearer_ready = True
     client._ns_path = "/device/ns"
     client._ds_path = "/device/ds"
@@ -736,14 +739,14 @@ def test_partial_start_notify_failure_reuses_live_subscription(monkeypatch) -> N
     client._try_subscribe()
 
     assert ns.start_calls == 1
-    assert ns.stop_calls == 0
+    assert ns.stop_calls == ds.stop_calls == 0
     assert ds.start_calls == 1
     assert client.subscribed is False
 
     scheduled[0][1]()
 
     assert ns.start_calls == 1
-    assert ns.stop_calls == 0
+    assert ns.stop_calls == ds.stop_calls == 0
     assert ds.start_calls == 2
     assert client.subscribed is True
 
@@ -1367,3 +1370,206 @@ def test_control_point_failure_keeps_ancs_unready_and_retries(
     _complete_authorization_probe(client)
     assert client.authorized is True
     assert client.connected is True
+
+
+@pytest.fixture
+def legacy_ancs(monkeypatch):
+    """A cached ANCS service with controllable ATT and deterministic timers."""
+    from types import SimpleNamespace
+
+    pending = {}
+    serial = 0
+
+    def schedule(delay, callback):
+        nonlocal serial
+        serial += 1
+        pending[serial] = (delay, callback)
+        return serial
+
+    def cancel(timer):
+        pending.pop(timer, None)
+
+    def fire(timer):
+        delay, callback = pending.pop(timer)
+        assert callback() is False
+        return delay
+
+    radio = SimpleNamespace(att=True, writes=0, stops=0, resets=0)
+
+    class Characteristic:
+        notifying = False
+
+        def Get(self, _iface, _name, **_kwargs):
+            return self.notifying
+
+        def StartNotify(self, **_kwargs):
+            # BlueZ may accept StartNotify for a disconnected cached object.
+            self.notifying = True
+
+        def StopNotify(self, **_kwargs):
+            radio.stops += 1
+
+        def WriteValue(self, *_args, **_kwargs):
+            radio.writes += 1
+            if not radio.att:
+                raise client_module.dbus.exceptions.DBusException(
+                    "No ATT transport", name="org.bluez.Error.Failed",
+                )
+
+    uuids = [NOTIFICATION_SOURCE_CHAR, DATA_SOURCE_CHAR, CONTROL_POINT_CHAR]
+    paths = [f"/device/service/{name}" for name in ("ns", "ds", "cp")]
+    manager = _ObjectManager({
+        path: {"org.bluez.GattCharacteristic1": {"UUID": uuid}}
+        for path, uuid in zip(paths, uuids, strict=True)
+    })
+    objects = {path: Characteristic() for path in paths}
+    bus = _CharacteristicBus({"/": manager, **objects})
+    monkeypatch.setattr(client_module, "get_system_bus", lambda: bus)
+    monkeypatch.setattr(client_module.dbus, "Interface", lambda value, _iface: value)
+    monkeypatch.setattr(client_module.GLib, "timeout_add_seconds", schedule)
+    monkeypatch.setattr(client_module.GLib, "source_remove", cancel)
+
+    def reset():
+        radio.resets += 1
+
+    client = AncsClient(
+        "/device", lambda _event: None, on_transport_failure=reset,
+        schedule=schedule, cancel=cancel,
+    )
+    return SimpleNamespace(
+        client=client, radio=radio, pending=pending, fire=fire, objects=objects,
+    )
+
+
+def _start_legacy_ancs(harness):
+    client = harness.client
+    client.observe_bearer_state(None, legacy_connected=True)
+    client.start()
+    harness.fire(client._bearer_settle_id)
+
+
+def test_legacy_cached_characteristics_do_not_prove_le_connected(legacy_ancs):
+    h = legacy_ancs
+    h.radio.att = False
+    _start_legacy_ancs(h)
+
+    assert h.radio.writes == 1
+    assert h.client.connected is False
+    assert h.client.authorized is False
+    assert h.client._subscribe_retry_id is not None
+    assert h.radio.resets == h.radio.stops == 0
+
+
+def test_unknown_bearer_does_not_enable_legacy_fallback(legacy_ancs):
+    h = legacy_ancs
+    h.client.observe_bearer_state(None)
+    h.client.start()
+    assert h.radio.writes == 0
+    assert h.pending == {}
+    assert h.client.connected is False
+
+
+@pytest.mark.parametrize("connected_before_start", [False, True])
+def test_legacy_startup_waits_for_authorization(legacy_ancs, connected_before_start):
+    h = legacy_ancs
+    if not connected_before_start:
+        h.client.start()
+    h.client.observe_bearer_state(None, legacy_connected=True)
+    h.client.start()
+    h.fire(h.client._bearer_settle_id)
+
+    assert h.client.subscribed is True
+    assert h.client.connected is False
+    _complete_authorization_probe(h.client)
+    assert h.client.connected is True
+    assert h.client._bearer_connected is None
+    assert h.client._legacy_health_id is not None
+
+
+def test_legacy_retry_backs_off_and_recovers_without_a_bearer_transition(legacy_ancs):
+    h = legacy_ancs
+    h.radio.att = False
+    _start_legacy_ancs(h)
+    delays = [h.fire(h.client._subscribe_retry_id) for _ in range(8)]
+    assert delays == [2, 4, 8, 16, 32, 60, 60, 60]
+    assert h.radio.resets == h.radio.stops == 0
+    h.radio.att = True
+    h.fire(h.client._subscribe_retry_id)
+    _complete_authorization_probe(h.client)
+    assert h.client.connected is True
+    assert h.client._legacy_retry_delay == client_module.SUBSCRIBE_RETRY_SECONDS
+
+
+def test_legacy_health_expires_when_only_classic_remains_connected(legacy_ancs):
+    h = legacy_ancs
+    _start_legacy_ancs(h)
+    _complete_authorization_probe(h.client)
+    h.radio.att = False
+    h.fire(h.client._legacy_health_id)
+
+    assert h.client.connected is False
+    assert h.client._subscribe_retry_id is not None
+    assert h.client._legacy_health_id is None
+    assert h.radio.resets == h.radio.stops == 0
+
+
+def test_legacy_silent_health_probe_retries_without_stop_notify(legacy_ancs):
+    h = legacy_ancs
+    _start_legacy_ancs(h)
+    _complete_authorization_probe(h.client)
+    h.fire(h.client._legacy_health_id)
+    h.fire(h.client._request_timeout_id)
+
+    assert h.client.connected is False
+    assert h.client._subscribe_retry_id is not None
+    assert h.radio.resets == h.radio.stops == 0
+    h.fire(h.client._subscribe_retry_id)
+    _complete_authorization_probe(h.client)
+    assert h.client.connected is True
+
+
+@pytest.mark.parametrize("handler", ["_on_ns_changed", "_on_ds_changed"])
+def test_legacy_dropped_notification_registration_invalidates_health(legacy_ancs, handler):
+    h = legacy_ancs
+    _start_legacy_ancs(h)
+    _complete_authorization_probe(h.client)
+    getattr(h.client, handler)("org.bluez.GattCharacteristic1", {"Notifying": False}, [])
+    assert h.client.connected is False
+    assert h.client._subscribe_retry_id is not None
+    assert h.radio.stops == 0
+
+
+@pytest.mark.parametrize("event", ["disconnect", "read-error", "bluez-exit", "stop"])
+def test_legacy_lifecycle_cancels_health_and_retries(legacy_ancs, event):
+    h = legacy_ancs
+    _start_legacy_ancs(h)
+    _complete_authorization_probe(h.client)
+    if event == "disconnect":
+        h.client.observe_bearer_state(False)
+    elif event == "read-error":
+        h.client.observe_bearer_state(None)
+    elif event == "bluez-exit":
+        h.client._on_bluez_owner_changed("org.bluez", ":1.1", "")
+    else:
+        h.client.stop()
+    assert h.client.connected is False
+    assert h.pending == {}
+    assert h.radio.stops == 0
+
+
+def test_legacy_disconnect_during_start_notify_cannot_publish_stale_subscription(legacy_ancs):
+    h = legacy_ancs
+    ns_path = "/device/service/ns"
+    ns = h.objects[ns_path]
+
+    def start_notify(**_kwargs):
+        ns.notifying = True
+        h.client._on_ns_changed("org.bluez.GattCharacteristic1", {"Notifying": False}, [])
+
+    ns.StartNotify = start_notify
+    _start_legacy_ancs(h)
+    assert h.client.subscribed is False
+    assert h.client.connected is False
+    assert h.radio.writes == h.radio.stops == 0
+    assert ns_path in h.client._owned_notify_paths
+    assert h.client._subscribe_retry_id is not None

--- a/tests/test_ancs_client.py
+++ b/tests/test_ancs_client.py
@@ -1573,3 +1573,49 @@ def test_legacy_disconnect_during_start_notify_cannot_publish_stale_subscription
     assert h.radio.writes == h.radio.stops == 0
     assert ns_path in h.client._owned_notify_paths
     assert h.client._subscribe_retry_id is not None
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+@pytest.mark.parametrize("removed", [("ns",), ("ds",), ("cp",), ("ns", "ds", "cp")])
+def test_rediscovery_after_transport_failure_resumes_only_legacy_probes(legacy_ancs, legacy, removed):
+    h = legacy_ancs
+    h.radio.att = False
+    h.client.observe_bearer_state(None if legacy else True, legacy_connected=legacy)
+    h.client.start()
+    h.fire(h.client._bearer_settle_id)
+    assert h.client._transport_blocked is True
+
+    uuids = {"ns": NOTIFICATION_SOURCE_CHAR, "ds": DATA_SOURCE_CHAR, "cp": CONTROL_POINT_CHAR}
+    for name in removed:
+        h.client._on_iface_removed(f"/device/service/{name}", ["org.bluez.GattCharacteristic1"])
+    assert h.client._subscribe_retry_id is None
+    h.radio.att = True
+    for index, name in enumerate(reversed(removed)):
+        h.client._on_iface_added(f"/device/service/{name}", {
+            "org.bluez.GattCharacteristic1": {"UUID": uuids[name]},
+        })
+        if index < len(removed) - 1:
+            assert h.client._subscribe_retry_id is None
+    assert h.client.subscribed is False
+
+    if legacy:
+        retry_id = h.client._subscribe_retry_id
+        assert retry_id is not None
+        # Duplicate discovery must neither bypass the delay nor add retries.
+        h.client._on_iface_added("/device/service/ns", {
+            "org.bluez.GattCharacteristic1": {"UUID": NOTIFICATION_SOURCE_CHAR},
+        })
+        assert h.client._subscribe_retry_id == retry_id
+        assert h.fire(retry_id) == 4
+        _complete_authorization_probe(h.client)
+        assert h.client.connected is True
+        assert h.client._bearer_connected is None
+        assert h.radio.resets == 0
+    else:
+        # Native recovery must still wait for an actual LE reset, even though
+        # the cached characteristics reappeared while Connected stayed true.
+        assert h.client._subscribe_retry_id is None
+        assert h.client._transport_blocked is True
+        h.fire(h.client._transport_reset_id)
+        assert h.radio.resets == 1
+    assert h.radio.stops == 0

--- a/tests/test_bearer_supervisor.py
+++ b/tests/test_bearer_supervisor.py
@@ -1826,3 +1826,105 @@ def test_stable_le_clears_classic_backoff_once() -> None:
     now = quiet_until
     scheduled[0][1]()
     assert attempts == [("bredr", 0.0), ("bredr", retry_at), ("bredr", quiet_until)]
+
+
+def test_legacy_device_connection_is_not_reported_as_le(monkeypatch):
+    import dbus
+
+    state = {"connected": True, "native": False, "read_error": False}
+    observed = []
+    connections = []
+    disconnects = []
+
+    class Properties:
+        def Get(self, interface, _name, **_kwargs):
+            if state["read_error"]:
+                raise dbus.exceptions.DBusException(
+                    "Timeout", name="org.freedesktop.DBus.Error.NoReply",
+                )
+            if interface.startswith("org.bluez.Bearer.") and not state["native"]:
+                raise dbus.exceptions.DBusException(
+                    "No such interface", name="org.freedesktop.DBus.Error.InvalidArgs",
+                )
+            return state["connected"]
+
+    class Bus:
+        def get_object(self, _name, _path):
+            return Properties()
+
+    monkeypatch.setattr(bearer_supervisor, "get_system_bus", Bus)
+    monkeypatch.setattr(dbus, "Interface", lambda value, _iface: value)
+    supervisor = BearerSupervisor(
+        "/device", connect=lambda kind, *_args: connections.append(kind),
+        disconnect=lambda kind, *_args: disconnects.append(kind),
+        on_le_state=lambda value: observed.append((value, supervisor.legacy_connected)),
+        schedule=lambda *_args: 1, cancel=lambda _timer: None,
+    )
+    supervisor.start()
+    assert supervisor.bredr_connected is True
+    assert supervisor.le_state is None
+    assert supervisor.le_connected is False
+    assert supervisor.legacy_connected is True
+    assert observed == [(None, True)]
+    supervisor.recover_le_transport()
+    assert supervisor._le_reset_pending is False
+    assert connections == disconnects == []
+
+    state["read_error"] = True
+    supervisor.poke()
+    assert supervisor.legacy_connected is False
+    assert observed[-1] == (None, False)
+    state["read_error"] = False
+    supervisor.poke()
+    assert observed[-1] == (None, True)
+    state["connected"] = False
+    supervisor.poke()
+    assert observed[-1] == (False, False)
+    assert connections == ["bredr"]
+
+    # Device discovery can add the native interface without a daemon restart.
+    state.update(connected=True, native=True)
+    supervisor.poke()
+    assert supervisor.le_state is True
+    assert supervisor.legacy_connected is False
+    supervisor.reset_after_bluez_restart()
+    assert supervisor.le_state is True
+    assert supervisor.legacy_connected is False
+    assert observed[-1] == (True, False)
+
+
+def test_transient_le_probe_failure_is_not_cached_as_missing_api(monkeypatch):
+    import dbus
+
+    calls = []
+
+    class Properties:
+        def Get(self, interface, _name, **_kwargs):
+            calls.append(interface)
+            if len(calls) == 1:
+                raise dbus.exceptions.DBusException(
+                    "Timeout", name="org.freedesktop.DBus.Error.NoReply",
+                )
+            return True
+
+    class Bus:
+        def get_object(self, _name, _path):
+            return Properties()
+
+    monkeypatch.setattr(bearer_supervisor, "get_system_bus", Bus)
+    monkeypatch.setattr(dbus, "Interface", lambda value, _iface: value)
+    supervisor = BearerSupervisor("/device")
+    assert supervisor._read("le") is None
+    assert supervisor.legacy_connected is False
+    assert supervisor._read("le") is True
+    assert calls == ["org.bluez.Bearer.LE1"] * 2
+
+
+def test_invalid_arguments_do_not_alone_imply_missing_bearer_api():
+    import dbus
+
+    assert bearer_supervisor.bearer_connected_unavailable(
+        dbus.exceptions.DBusException(
+            "Invalid arguments", name="org.freedesktop.DBus.Error.InvalidArgs",
+        )
+    ) is False

--- a/tests/test_bluez_setup.py
+++ b/tests/test_bluez_setup.py
@@ -1,6 +1,8 @@
 """BLE advertisement shape and cleanup regressions."""
 from __future__ import annotations
 
+from uuid import UUID
+
 import dbus
 import pytest
 
@@ -18,13 +20,32 @@ class TestAncsAdvertisement:
         assert bool(props["Discoverable"])
         assert int(props["DiscoverableTimeout"]) == 180
         assert props["ManufacturerData"].signature == "qv"
-        assert props["ServiceData"].signature == "sv"
         assert bytes(props["ManufacturerData"][dbus.UInt16(0xFFFF)]) == (
             b"\x50\xb0\x13\xf0"
         )
-        assert bytes(props["ServiceData"][
-            "00009999-0000-1000-8000-00805f9b34fb"
-        ]) == b"\x9e\x85\x39\x96"
+
+    def test_pairing_payload_fits_legacy_advertising_budget(self):
+        props = bluez_setup._AncsAdvert.GetAll(None, "org.bluez.LEAdvertisement1")
+
+        def uuid_width(value):
+            # BlueZ compresses Bluetooth-base UUIDs to their 16-bit form.
+            value = str(UUID(str(value)))
+            if value.startswith("0000") and value[8:] == "-0000-1000-8000-00805f9b34fb":
+                return 2
+            return 16
+
+        # Every AD element has a length byte and a type byte. Manufacturer
+        # elements also include a 16-bit company ID. BlueZ puts LocalName in
+        # the separate scan response for our connectable legacy advertisement.
+        length = 2 + sum(uuid_width(value) for value in props["SolicitUUIDs"])
+        length += sum(4 + len(value) for value in props.get("ManufacturerData", {}).values())
+        length += sum(
+            2 + uuid_width(key) + len(value)
+            for key, value in props.get("ServiceData", {}).items()
+        )
+        length += 3 if props.get("Discoverable") else 0
+        length += 3 if "tx-power" in props.get("Includes", ()) else 0
+        assert length <= 31, f"advertisement needs {length} bytes; legacy limit is 31"
 
     def test_rejects_unknown_interface(self):
         with pytest.raises(dbus.exceptions.DBusException):

--- a/tests/test_daemon_lifecycle.py
+++ b/tests/test_daemon_lifecycle.py
@@ -186,13 +186,15 @@ def test_successful_empty_phonebook_verifies_contact_permission():
     assert verified == [daemon_mod.CONTACTS]
 
 
-def test_status_exposes_split_ancs_and_last_le_error(monkeypatch):
+@pytest.mark.parametrize("ancs_connected", [False, True])
+def test_status_exposes_split_ancs_and_last_le_error(monkeypatch, ancs_connected):
     instance = _bare_daemon()
     instance.contacts = SimpleNamespace(count=lambda: 0)
     instance.ancs = SimpleNamespace(
-        connected=False, subscribed=True, authorized=False,
+        connected=ancs_connected, subscribed=True, authorized=ancs_connected,
     )
     instance.bearers = SimpleNamespace(
+        le_connected=False,
         snapshot=lambda: {
             "bredr": True,
             "le": False,
@@ -201,16 +203,17 @@ def test_status_exposes_split_ancs_and_last_le_error(monkeypatch):
         }
     )
     instance.setup_verification = SimpleNamespace(verified=())
+    instance._mark_setup_task = lambda _task: False
     monkeypatch.setattr(daemon_mod, "history_count", lambda **_kwargs: 0)
 
     status = instance._status()
 
-    assert status["ancs"] is False
+    assert status["ancs"] is ancs_connected
     assert status["ancs_subscribed"] is True
-    assert status["ancs_authorized"] is False
+    assert status["ancs_authorized"] is ancs_connected
     assert status["contacts_only_notifications"] is False
     assert status["bredr"] is True
-    assert status["le"] is False
+    assert status["le"] is ancs_connected
     assert status["last_le_error"] == "org.bluez.Error.Failed"
     assert status["last_le_error_message"] == "le-connection-abort-by-local"
     assert status["_build_id"] == "0.6.0-6"

--- a/tests/test_daemon_pairing_policy.py
+++ b/tests/test_daemon_pairing_policy.py
@@ -1,10 +1,13 @@
 """The persisted pairing policy controls long-lived ANCS work."""
 
+import pytest
+
 from blueferry import daemon
 
 
 class _Bearer:
     le_state = False
+    legacy_connected = False
 
     def __init__(self, calls):
         self.calls = calls
@@ -127,13 +130,16 @@ def test_compatibility_daemon_solicits_but_never_starts_ancs(monkeypatch):
     assert value.ancs is None
 
 
-def test_full_daemon_starts_ancs_client(monkeypatch):
+@pytest.mark.parametrize("legacy", [False, True])
+def test_full_daemon_starts_ancs_client(monkeypatch, legacy):
     calls = []
 
     def app_filter(app_id):
         return app_id == "com.example.Allowed"
 
     value = _daemon(calls)
+    value.bearers.legacy_connected = legacy
+    value.bearers.le_state = None if legacy else False
     _ready_bluetooth(monkeypatch, calls)
     monkeypatch.setattr(daemon.config, "ANCS_ENABLED", True)
     monkeypatch.setattr(daemon.config, "include_ancs_app", app_filter)
@@ -144,8 +150,8 @@ def test_full_daemon_starts_ancs_client(monkeypatch):
             calls.append(("previously-authorized", kwargs["previously_authorized"]))
             calls.append(("app-filter", kwargs["include_app_notification"]))
 
-        def observe_bearer_state(self, connected):
-            calls.append(("ancs-bearer", connected))
+        def observe_bearer_state(self, connected, *, legacy_connected=False):
+            calls.append(("ancs-bearer", connected, legacy_connected))
 
         def start(self):
             calls.append("ancs-start")
@@ -160,7 +166,7 @@ def test_full_daemon_starts_ancs_client(monkeypatch):
     assert "ancs-client" in calls
     assert ("previously-authorized", False) in calls
     assert ("app-filter", app_filter) in calls
-    assert ("ancs-bearer", False) in calls
+    assert ("ancs-bearer", None if legacy else False, legacy) in calls
     assert "ancs-start" in calls
     assert value.ancs is not None
 
@@ -181,7 +187,7 @@ def test_full_daemon_preserves_known_ancs_reconnect_protection(monkeypatch):
             calls.append(("previously-authorized", kwargs["previously_authorized"]))
 
         @staticmethod
-        def observe_bearer_state(_connected):
+        def observe_bearer_state(_connected, *, legacy_connected=False):
             return None
 
         @staticmethod

--- a/tests/test_native_packaging.py
+++ b/tests/test_native_packaging.py
@@ -109,7 +109,7 @@ def test_notification_capable_packages_reload_and_restart_running_bluetooth() ->
     assert "if [ $1 -eq 0 ]" in rpm_spec
 
 
-def test_deb_is_map_pbap_only_and_does_not_manage_bluetooth_service() -> None:
+def test_deb_does_not_manage_bluetooth_service() -> None:
     control = (ROOT / "packaging/deb/control").read_text()
     rules = (ROOT / "packaging/deb/rules").read_text()
     install = (ROOT / "packaging/deb/blueferry-backend.install").read_text()
@@ -124,7 +124,6 @@ def test_deb_is_map_pbap_only_and_does_not_manage_bluetooth_service() -> None:
     assert not (ROOT / "packaging/deb/blueferry-backend.postrm").exists()
     assert "MAP messages and PBAP contacts" in readme
     assert "never enables `-E` or" in readme
-    assert "already has BlueZ 5.86 or newer" in readme
 
 
 def test_deb_and_rpm_install_secret_service_client_bindings() -> None:

--- a/tests/test_pair_setup.py
+++ b/tests/test_pair_setup.py
@@ -2896,3 +2896,40 @@ def test_pairing_without_bearer_api_continues_with_map_and_pbap(monkeypatch):
     assert result.ancs == "disabled"
     assert result.ancs_enabled is False
     assert result.ancs_ready is False
+
+
+@pytest.mark.parametrize("version", ["5.72", "5.85", "5.86", "5.87"])
+@pytest.mark.parametrize("active,packaged", [(False, False), (False, True), (True, False)])
+def test_ancs_support_does_not_require_native_bearer_controls(monkeypatch, version, active, packaged):
+    from blueferry.onboarding import OnboardingStage, derive_stage
+    from blueferry.setup_client import BluetoothCompatibility
+
+    class Manager:
+        def GetManagedObjects(self):
+            return {"/org/bluez/hci0": {"org.bluez.Adapter1": {}}}
+
+    def run(command, **_kwargs):
+        stdout = (
+            f"bluetoothctl: {version}\n" if command[0] == "bluetoothctl" else
+            "supported settings: powered ssp br/edr le advertising\n"
+            "current settings: powered ssp br/edr le advertising\n"
+        )
+        return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+
+    monkeypatch.setattr(pair_setup, "_object_manager", Manager)
+    monkeypatch.setattr(pair_setup, "run_command", run)
+    monkeypatch.setattr(pair_setup, "bluez_support_status", lambda: {
+        "active": active, "packaged_drop_in": packaged,
+    })
+    status = pair_setup.bluetooth_compatibility("hci0")
+    assert status["notifications_supported"] is (active or packaged)
+    assert status["bearer_api_supported"] is (version in {"5.86", "5.87"} and (active or packaged))
+    assert status["bearer_api_active"] is (version in {"5.86", "5.87"} and active)
+    compatibility = BluetoothCompatibility.from_dict(status)
+    assert compatibility.experimental is active
+    assert derive_stage(
+        setup_loaded=True, configured=False,
+        compatibility=compatibility.to_dict(), status={},
+    ) is (OnboardingStage.ACTIVATE_BLUETOOTH if packaged and not active else OnboardingStage.SELECT_DEVICE)
+    policy = pair_setup.resolve_pairing_policy(status)
+    assert policy.ancs_enabled is (active or packaged)

--- a/tests/test_pairing_cli.py
+++ b/tests/test_pairing_cli.py
@@ -265,6 +265,7 @@ def test_cli_wizard_supplies_its_own_pairing_agent_ui(
         issue=issue,
         notifications_supported=notifications_supported,
         bearer_api_active=True,
+        experimental=True,
         adapters=(),
     )
 
@@ -358,6 +359,7 @@ def test_cli_wizard_preserves_report_for_unexpected_pairing_failure(
                 issue="",
                 notifications_supported=True,
                 bearer_api_active=True,
+                experimental=True,
                 adapters=(),
             )
 
@@ -409,6 +411,7 @@ def test_cli_wizard_points_at_pairing_issue_when_ancs_stays_down(
         issue="",
         notifications_supported=True,
         bearer_api_active=True,
+        experimental=True,
         adapters=(),
     )
 

--- a/tests/test_qml_presenters.py
+++ b/tests/test_qml_presenters.py
@@ -1635,3 +1635,34 @@ Item {
     log = result.stdout + result.stderr
     assert result.returncode == 0 and "BLUEFERRY_GROUP_REPLY_OK" in log, log
     assert "WARN scene:" not in log and "ReferenceError" not in log and "TypeError" not in log, log
+
+
+@pytest.mark.parametrize("fields,active", [
+    ({"experimental": True, "bearer_api_active": False}, True),
+    ({"experimental": True, "bearer_api_active": True}, True),
+    ({"experimental": False, "bearer_api_active": True}, False),
+    ({"bearer_api_active": True}, True),
+    ({"bearer_api_active": False}, False),
+    ({}, False),
+])
+def test_quickshell_activation_uses_experimental_state(qml_engine, quickshell_setup, fields, active):
+    import json
+
+    compatibility = {"notifications_supported": True, "adapter": "hci0", **fields}
+    for _ in range(2):
+        _evaluate(qml_engine, '''
+            setup.loadCompatibility("hci0");
+            reply("compatibility", ''' + json.dumps(compatibility) + ''');
+        ''')
+        assert quickshell_setup.property("bluezActive") is active
+
+    component = _component(qml_engine, "data/quickshell/OnboardingState.qml")
+    presenter = component.createWithInitialProperties({
+        "notificationsSupported": quickshell_setup.property("notificationsSupported"),
+        "bluezActive": quickshell_setup.property("bluezActive"),
+        "configured": False,
+        "backendStatus": {},
+    })
+    assert presenter is not None
+    assert presenter.property("stage") == ("select-device" if active else "activate-bluetooth")
+    presenter.deleteLater()

--- a/tests/test_qt_controller.py
+++ b/tests/test_qt_controller.py
@@ -511,6 +511,7 @@ def test_saved_pairing_policy_does_not_overwrite_adapter_capability(monkeypatch)
                     "bearer_api_active": True,
                 },
                 bearer_api_active=True,
+                experimental=True,
             )
 
         @staticmethod
@@ -666,6 +667,7 @@ def test_select_adapter_reloads_compatibility_for_that_radio(monkeypatch) -> Non
                     ],
                 },
                 bearer_api_active=True,
+                experimental=True,
             )
 
     controller = BridgeController(
@@ -711,6 +713,7 @@ def test_activating_bluetooth_reloads_the_selected_adapter_before_scanning(
             return SimpleNamespace(
                 to_dict=lambda: {"adapter": adapter or "hci0", "bearer_api_active": True},
                 bearer_api_active=True,
+                experimental=True,
             )
 
         def configuration(self):


### PR DESCRIPTION
BlueFerry currently disables ANCS on BlueZ versions without the newer per-bearer controls. This enables ANCS on older BlueZ with experimental support active, verifies connectivity through an ANCS request/response, and preserves the existing protection against cancelling pending notification registrations.

Missing bearer interfaces are distinguished from transient read failures. Legacy connections use capped retry delays and periodic health probes, including recovery when BlueZ recreates GATT characteristics while Classic stays connected. Native bearer monitoring and targeted recovery remain available on newer BlueZ.

The solicitation advertisement now fits in 29 bytes, and all clients use experimental activation independently of native bearer availability. This includes Quickshell's setup flow and compatibility with older backend replies.

Implements the legacy support proposed by cliff-de-tech in #151.

Validation:

- 1,188 tests passed using isolated D-Bus, including partial-subscription safety, rediscovery recovery, advertisement size, and QML activation regressions.
- Ruff, mypy, Bandit, and qmllint passed.
- Pairing and reconnect validation on legacy BlueZ hardware is still needed. This PR retains the experimental-support requirement; operation without `-E` has not been validated on hardware.
